### PR TITLE
Fix management UI static file path handling

### DIFF
--- a/internal/managementui/handler.go
+++ b/internal/managementui/handler.go
@@ -1,12 +1,13 @@
 package managementui
 
 import (
+	"io"
+	"io/fs"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 )
 
@@ -17,28 +18,71 @@ func NewHandler(devProxyURL, distDir string) http.Handler {
 		return newDevProxy(devProxyURL)
 	}
 
+	distFS := os.DirFS(distDir)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		indexPath := filepath.Join(distDir, "index.html")
-		if _, err := os.Stat(indexPath); err != nil {
+		if !managementUIFileExists(distFS, "index.html") {
 			http.Error(w, "management UI not built", http.StatusServiceUnavailable)
 			return
 		}
 
-		cleanPath := path.Clean("/" + r.URL.Path)
-		relPath := strings.TrimPrefix(cleanPath, "/")
-		if relPath == "" {
-			http.ServeFile(w, r, indexPath)
+		if relPath := managementUIAssetPath(r.URL.Path); relPath != "" {
+			if serveManagementUIFile(w, r, distFS, relPath) {
+				return
+			}
+		}
+		if serveManagementUIFile(w, r, distFS, "index.html") {
 			return
 		}
 
-		filePath := filepath.Join(distDir, filepath.FromSlash(relPath))
-		if stat, err := os.Stat(filePath); err == nil && !stat.IsDir() {
-			http.ServeFile(w, r, filePath)
-			return
-		}
-
-		http.ServeFile(w, r, indexPath)
+		http.Error(w, "management UI not built", http.StatusServiceUnavailable)
 	})
+}
+
+func managementUIFileExists(distFS fs.FS, name string) bool {
+	file, _, ok := openManagementUIFile(distFS, name)
+	if ok {
+		_ = file.Close()
+	}
+	return ok
+}
+
+func managementUIAssetPath(requestPath string) string {
+	cleanPath := path.Clean("/" + requestPath)
+	relPath := strings.TrimPrefix(cleanPath, "/")
+	if relPath == "" || !fs.ValidPath(relPath) || strings.Contains(relPath, `\`) {
+		return ""
+	}
+	return relPath
+}
+
+func serveManagementUIFile(w http.ResponseWriter, r *http.Request, distFS fs.FS, name string) bool {
+	file, info, ok := openManagementUIFile(distFS, name)
+	if !ok {
+		return false
+	}
+	defer file.Close()
+	seeker, ok := file.(io.ReadSeeker)
+	if !ok {
+		return false
+	}
+	http.ServeContent(w, r, info.Name(), info.ModTime(), seeker)
+	return true
+}
+
+func openManagementUIFile(distFS fs.FS, name string) (fs.File, fs.FileInfo, bool) {
+	if name == "" || !fs.ValidPath(name) || strings.Contains(name, `\`) {
+		return nil, nil, false
+	}
+	file, err := distFS.Open(name)
+	if err != nil {
+		return nil, nil, false
+	}
+	info, err := file.Stat()
+	if err != nil || info.IsDir() {
+		_ = file.Close()
+		return nil, nil, false
+	}
+	return file, info, true
 }
 
 func newDevProxy(rawURL string) http.Handler {

--- a/internal/managementui/handler_test.go
+++ b/internal/managementui/handler_test.go
@@ -61,6 +61,42 @@ func TestHandlerFallsBackToIndexForSPARoute(t *testing.T) {
 	}
 }
 
+func TestHandlerDoesNotServeTraversalOutsideDist(t *testing.T) {
+	rootDir := t.TempDir()
+	distDir := filepath.Join(rootDir, "dist")
+	if err := os.Mkdir(distDir, 0755); err != nil {
+		t.Fatalf("mkdir dist: %v", err)
+	}
+	writeFile(t, filepath.Join(rootDir, "secret.txt"), "outside-secret")
+	writeFile(t, filepath.Join(distDir, "index.html"), "<html>app shell</html>")
+	writeFile(t, filepath.Join(distDir, "asset.js"), "console.log('asset')")
+
+	for _, target := range []string{
+		"/../secret.txt",
+		"/%2e%2e/secret.txt",
+		"/assets/../../secret.txt",
+		"/assets/%2e%2e/%2e%2e/secret.txt",
+	} {
+		t.Run(target, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, target, nil)
+			rec := httptest.NewRecorder()
+
+			NewHandler("", distDir).ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected status 200, got %d", rec.Code)
+			}
+			body := rec.Body.String()
+			if strings.Contains(body, "outside-secret") {
+				t.Fatalf("served file outside dist for %q: %q", target, body)
+			}
+			if !strings.Contains(body, "app shell") {
+				t.Fatalf("expected index fallback for %q, got %q", target, body)
+			}
+		})
+	}
+}
+
 func TestHandlerReturnsUnavailableWhenDistMissing(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()


### PR DESCRIPTION
## Summary
- serve management UI assets from an os.DirFS with validated slash paths
- avoid constructing filesystem paths from request paths
- add traversal regression tests for decoded and encoded attempts

## Tests
- go test ./internal/managementui
- go test ./...
- go vet ./...
- make test

Fixes CodeQL alerts #5 and #6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced security in the management UI by implementing protection against path traversal attacks.
  * Improved reliability of asset serving with automatic fallback to the application shell for missing resources.
  * Enhanced error handling with proper HTTP status responses for unavailable assets.

* **Tests**
  * Added security validation tests to verify path traversal protection mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kirari04/p2pstream/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->