### PR TITLE
docs: simplify VitePress start page

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -3,55 +3,100 @@
   --vp-c-brand-2: #0f5f59;
   --vp-c-brand-3: #14b8a6;
   --vp-c-brand-soft: rgba(20, 184, 166, 0.13);
-  --vp-c-bg: #f7f9fb;
-  --vp-c-bg-alt: #edf2f6;
-  --vp-c-bg-soft: #f1f5f8;
-  --vp-c-border: #d8e1e8;
-  --vp-c-divider: #d8e1e8;
-  --vp-c-text-1: #11181f;
-  --vp-c-text-2: #40505d;
-  --vp-c-text-3: #697987;
+  --vp-c-bg: #f7fafb;
+  --vp-c-bg-alt: #edf3f6;
+  --vp-c-bg-soft: #f2f6f8;
+  --vp-c-border: #d6e0e7;
+  --vp-c-divider: #d6e0e7;
+  --vp-c-text-1: #101820;
+  --vp-c-text-2: #3e4f5c;
+  --vp-c-text-3: #6c7d89;
   --vp-font-family-base: "Aptos", "Segoe UI", ui-sans-serif, sans-serif;
   --vp-font-family-mono: "Cascadia Code", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
   --vp-layout-max-width: 1480px;
   --ops-accent-blue: #2563eb;
-  --ops-accent-amber: #c27803;
+  --ops-accent-amber: #b7791f;
   --ops-panel: #ffffff;
-  --ops-panel-strong: #eef5f8;
-  --ops-shadow: 0 20px 55px rgba(20, 42, 58, 0.08);
+  --ops-panel-muted: #f8fbfc;
+  --ops-panel-strong: #e8f1f4;
+  --ops-line-strong: #bdcbd5;
+  --ops-shadow: 0 22px 58px rgba(20, 42, 58, 0.1);
+  --ops-shadow-soft: 0 14px 34px rgba(20, 42, 58, 0.08);
+  --vp-home-hero-name-color: var(--vp-c-brand-1);
+  --vp-home-hero-name-background: none;
+  --vp-home-hero-image-background-image: none;
+  --vp-home-hero-image-filter: none;
+  --vp-button-brand-border: var(--vp-c-brand-2);
+  --vp-button-brand-text: #ffffff;
+  --vp-button-brand-bg: var(--vp-c-brand-1);
+  --vp-button-brand-hover-border: var(--vp-c-brand-1);
+  --vp-button-brand-hover-text: #ffffff;
+  --vp-button-brand-hover-bg: var(--vp-c-brand-2);
+  --vp-button-brand-active-border: var(--vp-c-brand-2);
+  --vp-button-brand-active-text: #ffffff;
+  --vp-button-brand-active-bg: var(--vp-c-brand-2);
+  --vp-button-alt-border: var(--vp-c-divider);
+  --vp-button-alt-text: var(--vp-c-text-1);
+  --vp-button-alt-bg: var(--ops-panel);
+  --vp-button-alt-hover-border: var(--ops-accent-blue);
+  --vp-button-alt-hover-text: var(--ops-accent-blue);
+  --vp-button-alt-hover-bg: color-mix(in srgb, var(--ops-accent-blue) 8%, var(--ops-panel));
+  --vp-button-alt-active-border: var(--ops-accent-blue);
+  --vp-button-alt-active-text: var(--ops-accent-blue);
+  --vp-button-alt-active-bg: color-mix(in srgb, var(--ops-accent-blue) 12%, var(--ops-panel));
 }
 
 .dark {
-  --vp-c-bg: #0a0f14;
-  --vp-c-bg-alt: #0f161d;
-  --vp-c-bg-soft: #141d25;
-  --vp-c-text-1: #edf6f7;
-  --vp-c-text-2: #b5c7d1;
-  --vp-c-text-3: #7f94a2;
-  --vp-c-border: #23313c;
-  --vp-c-divider: #23313c;
+  --vp-c-bg: #091014;
+  --vp-c-bg-alt: #0e171d;
+  --vp-c-bg-soft: #131e26;
+  --vp-c-text-1: #eef7f7;
+  --vp-c-text-2: #b8cad2;
+  --vp-c-text-3: #8196a3;
+  --vp-c-border: #22313b;
+  --vp-c-divider: #22313b;
   --vp-c-brand-1: #2dd4bf;
   --vp-c-brand-2: #5eead4;
   --vp-c-brand-3: #0f766e;
   --vp-c-brand-soft: rgba(45, 212, 191, 0.16);
   --ops-accent-blue: #60a5fa;
-  --ops-accent-amber: #fbbf24;
+  --ops-accent-amber: #f4c152;
   --ops-panel: #0f171e;
-  --ops-panel-strong: #15212a;
-  --ops-shadow: 0 20px 60px rgba(0, 0, 0, 0.28);
+  --ops-panel-muted: #0b1318;
+  --ops-panel-strong: #16232c;
+  --ops-line-strong: #344653;
+  --ops-shadow: 0 24px 64px rgba(0, 0, 0, 0.34);
+  --ops-shadow-soft: 0 16px 38px rgba(0, 0, 0, 0.24);
 }
 
 .VPNav {
   border-bottom: 1px solid var(--vp-c-divider);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--vp-c-bg) 94%, transparent), color-mix(in srgb, var(--vp-c-bg) 86%, transparent));
+  backdrop-filter: blur(12px);
 }
 
 .VPNavBarTitle .title {
+  color: var(--vp-c-text-1);
   letter-spacing: 0;
   font-weight: 760;
 }
 
 .VPNavBarTitle .logo {
   border-radius: 4px;
+}
+
+.VPNavBarMenuLink.active,
+.VPNavBarMenuLink:hover {
+  color: var(--vp-c-brand-1);
+}
+
+.VPNavBarMenuLink {
+  letter-spacing: 0;
+}
+
+.VPSidebar {
+  background: color-mix(in srgb, var(--vp-c-bg-alt) 82%, var(--vp-c-bg));
 }
 
 .VPSidebarItem .text {
@@ -62,16 +107,23 @@
 .VPDoc h1,
 .VPDoc h2,
 .VPDoc h3 {
+  color: var(--vp-c-text-1);
   letter-spacing: 0;
 }
 
 .VPDoc h1 {
   max-width: 920px;
+  font-weight: 780;
 }
 
 .VPDoc h2 {
   border-top: 1px solid var(--vp-c-divider);
-  padding-top: 28px;
+  padding-top: 30px;
+  font-weight: 740;
+}
+
+.VPDoc h3 {
+  font-weight: 720;
 }
 
 .VPDoc p,
@@ -80,8 +132,15 @@
 }
 
 .VPDoc a {
-  font-weight: 620;
+  font-weight: 640;
   text-underline-offset: 3px;
+}
+
+.VPDoc a:focus-visible,
+.home-reference-strip a:focus-visible {
+  outline: 2px solid var(--vp-c-brand-1);
+  outline-offset: 3px;
+  border-radius: 5px;
 }
 
 .VPDoc table {
@@ -93,11 +152,12 @@
   overflow: hidden;
   border: 1px solid var(--vp-c-divider);
   border-radius: 8px;
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--vp-c-bg) 80%, transparent);
 }
 
 .VPDoc th {
   background: var(--ops-panel-strong);
-  font-weight: 700;
+  font-weight: 720;
   color: var(--vp-c-text-1);
 }
 
@@ -107,7 +167,7 @@
 }
 
 .VPDoc tr:nth-child(even) td {
-  background: color-mix(in srgb, var(--vp-c-bg-soft) 58%, transparent);
+  background: color-mix(in srgb, var(--vp-c-bg-soft) 66%, transparent);
 }
 
 .VPDoc :not(pre) > code {
@@ -115,7 +175,7 @@
   border-radius: 5px;
   padding: 2px 5px;
   color: var(--vp-c-brand-1);
-  background: color-mix(in srgb, var(--vp-c-brand-soft) 42%, transparent);
+  background: color-mix(in srgb, var(--vp-c-brand-soft) 46%, transparent);
   overflow-wrap: anywhere;
 }
 
@@ -146,91 +206,164 @@
   border-color: rgba(190, 18, 60, 0.42);
 }
 
-.home-grid {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(235px, 1fr));
-  margin: 30px 0;
+.VPHome {
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--vp-c-brand-soft) 22%, transparent), transparent 320px),
+    var(--vp-c-bg);
 }
 
-.home-card {
+.VPHome .VPHero {
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.VPHome .VPHero .container,
+.VPHome .VPFeatures .container,
+.VPHome .vp-doc.container {
+  max-width: 1040px;
+}
+
+.VPHome .VPHero .main {
+  order: 1;
+}
+
+.VPHome .VPHero .image {
+  order: 2;
+  margin: 24px 0 0;
+}
+
+.VPHome .VPHero .heading {
+  gap: 8px;
+}
+
+.VPHome .VPHero .name,
+.VPHome .VPHero .text {
+  max-width: 680px;
+  letter-spacing: 0;
+  font-weight: 820;
+  white-space: normal;
+}
+
+.VPHome .VPHero .text {
+  color: var(--vp-c-text-1);
+}
+
+.VPHome .VPHero .tagline {
+  max-width: 660px;
+  color: var(--vp-c-text-2);
+  font-weight: 520;
+}
+
+.VPHome .VPHero .actions {
+  gap: 12px;
+  margin: 0;
+}
+
+.VPHome .VPHero .action {
+  padding: 0;
+}
+
+.VPHome .VPButton.medium {
+  border-radius: 6px;
+  padding: 0 18px;
+  line-height: 42px;
+  font-weight: 760;
+}
+
+.VPHome .VPHero .image-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 180px;
+  height: 180px;
+  transform: none;
+}
+
+.VPHome .VPHero .image-bg {
+  display: none;
+}
+
+.VPHome .VPHero .image-src {
+  position: relative;
+  top: auto;
+  left: auto;
+  width: 112px;
+  max-width: 112px;
+  max-height: 112px;
+  border: 1px solid color-mix(in srgb, var(--vp-c-divider) 70%, transparent);
+  border-radius: 16px;
+  box-shadow: var(--ops-shadow-soft);
+  transform: none;
+}
+
+.VPHome .VPFeatures {
+  padding-top: 34px;
+}
+
+.VPHome .VPFeature {
   border: 1px solid var(--vp-c-divider);
   border-radius: 8px;
   background:
-    linear-gradient(180deg, color-mix(in srgb, var(--ops-panel) 92%, var(--vp-c-brand-soft)), var(--ops-panel));
-  box-shadow: var(--ops-shadow);
-  padding: 18px;
-  min-height: 172px;
-  position: relative;
+    linear-gradient(180deg, color-mix(in srgb, var(--ops-panel) 96%, var(--vp-c-brand-soft)), var(--ops-panel));
+  box-shadow: var(--ops-shadow-soft);
 }
 
-.home-card::before {
-  content: "";
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: 3px;
-  border-radius: 8px 0 0 8px;
-  background: var(--vp-c-brand-1);
+.VPHome .VPFeature.link:hover {
+  border-color: color-mix(in srgb, var(--vp-c-brand-1) 68%, var(--vp-c-divider));
+  background: color-mix(in srgb, var(--vp-c-brand-soft) 22%, var(--ops-panel));
 }
 
-.home-card:nth-child(2n)::before {
-  background: var(--ops-accent-blue);
+.VPHome .VPFeature .box {
+  padding: 20px;
 }
 
-.home-card:nth-child(3n)::before {
-  background: var(--ops-accent-amber);
+.VPHome .VPFeature .title {
+  color: var(--vp-c-text-1);
+  letter-spacing: 0;
+  font-weight: 740;
 }
 
-.home-card h3 {
-  margin: 0 0 8px;
-  font-size: 16px;
-  line-height: 1.35;
+.VPHome .VPFeature .details {
+  color: var(--vp-c-text-2);
+  font-weight: 500;
 }
 
-.home-card p {
-  margin: 0 0 14px;
+.VPHome .VPFeature .link-text-value {
+  color: var(--vp-c-brand-1);
+  font-weight: 760;
+}
+
+.home-reference-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 36px auto 0;
+  max-width: 1040px;
+  border-top: 1px solid var(--vp-c-divider);
+  padding-top: 22px;
+}
+
+.home-reference-strip a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 36px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  padding: 0 13px;
   color: var(--vp-c-text-2);
   font-size: 14px;
-  line-height: 1.55;
-}
-
-.home-card a {
   font-weight: 700;
+  text-decoration: none;
+  background: color-mix(in srgb, var(--ops-panel) 88%, transparent);
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease,
+    color 160ms ease;
 }
 
-.home-kicker {
-  margin: 0 0 8px;
+.home-reference-strip a:hover {
+  border-color: color-mix(in srgb, var(--vp-c-brand-1) 58%, var(--vp-c-divider));
   color: var(--vp-c-brand-1);
-  font-family: var(--vp-font-family-mono);
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
-.home-strip {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 12px;
-  margin: 20px 0 30px;
-}
-
-.home-strip-item {
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 8px;
-  background: var(--vp-c-bg-soft);
-  padding: 12px 14px;
-}
-
-.home-strip-item strong {
-  display: block;
-  margin-bottom: 4px;
-  font-size: 13px;
-}
-
-.home-strip-item span {
-  color: var(--vp-c-text-2);
-  font-size: 13px;
+  background: color-mix(in srgb, var(--vp-c-brand-soft) 34%, var(--ops-panel));
 }
 
 .ops-kbd {
@@ -252,7 +385,7 @@
   background: var(--ops-panel);
   padding: 14px;
   margin: 24px 0;
-  box-shadow: var(--ops-shadow);
+  box-shadow: var(--ops-shadow-soft);
 }
 
 .architecture-frame img {
@@ -267,7 +400,7 @@
   background: var(--ops-panel);
   overflow: hidden;
   margin: 24px 0;
-  box-shadow: var(--ops-shadow);
+  box-shadow: var(--ops-shadow-soft);
 }
 
 .doc-screenshot img {
@@ -282,6 +415,7 @@
   color: var(--vp-c-text-2);
   font-size: 13px;
   line-height: 1.55;
+  background: color-mix(in srgb, var(--ops-panel) 88%, var(--vp-c-bg-soft));
 }
 
 .screenshot-gallery {
@@ -303,7 +437,7 @@
 
 .screenshot-tile figcaption {
   color: var(--vp-c-text-1);
-  font-weight: 700;
+  font-weight: 720;
 }
 
 .doc-screenshot img,
@@ -336,8 +470,7 @@
 
   .VPDoc p,
   .VPDoc li,
-  .home-card,
-  .home-strip-item {
+  .home-reference-strip a {
     overflow-wrap: anywhere;
   }
 
@@ -347,12 +480,22 @@
     white-space: normal;
   }
 
-  .home-grid {
-    grid-template-columns: 1fr;
+  .VPHome .VPHero .image-container {
+    width: 132px;
+    height: 132px;
   }
 
-  .home-card {
-    min-height: 0;
+  .VPHome .VPHero .image-src {
+    width: 88px;
+    max-width: 88px;
+    max-height: 88px;
+    border-radius: 14px;
+  }
+
+  .home-reference-strip {
+    gap: 8px;
+    margin-top: 28px;
+    padding-top: 18px;
   }
 
   .doc-screenshot figcaption {

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,87 +1,39 @@
-# p2pstream Self-Hosting Docs
+---
+layout: home
+title: p2pstream
+titleTemplate: Self-Hosting Docs
 
-Run p2pstream as a self-hosted public reverse proxy with a management console, optional remote agents, TLS automation, WAF controls, rate limits, traffic shaping, public asset caching, and live traffic tracing.
+hero:
+  name: p2pstream
+  text: Self-hosted public reverse proxy
+  tagline: Run public apps from direct backends or private networks with a management UI, TLS automation, traffic controls, and live tracing.
+  image:
+    src: /logo-mark.svg
+    alt: p2pstream logo mark
+  actions:
+    - theme: brand
+      text: Start with Docker Compose
+      link: /getting-started/quickstart
 
-<p class="home-kicker">Start by outcome</p>
+features:
+  - title: Install the server
+    details: Start the Compose deployment, persist state, and open management over HTTPS.
+    link: /getting-started/quickstart
+    linkText: Use the quickstart
+  - title: Publish an app
+    details: Create a backend, listener, route, and TLS mapping for a service the server can reach.
+    link: /guides/publish-a-service
+    linkText: Publish a direct backend
+  - title: Use a remote agent
+    details: Expose a private-network service through an outbound agent connection.
+    link: /guides/expose-a-home-lab-app
+    linkText: Expose a home lab app
+---
 
-<div class="home-grid">
-  <div class="home-card">
-    <h3>Install the server</h3>
-    <p>Start the Docker Compose deployment, persist runtime state in <code>p2pstream-data</code>, and open management over HTTPS.</p>
-    <a href="./getting-started/quickstart">Use the quickstart</a>
-  </div>
-  <div class="home-card">
-    <h3>Create the first admin</h3>
-    <p>Use the 5 minute setup window, learn the login rules, and recover with the local password reset command if needed.</p>
-    <a href="./getting-started/first-login">Complete first login</a>
-  </div>
-  <div class="home-card">
-    <h3>Expose an app from the server</h3>
-    <p>Create a backend, listener, route, and TLS mapping for a service reachable from the p2pstream host.</p>
-    <a href="./guides/publish-a-service">Publish a direct backend</a>
-  </div>
-  <div class="home-card">
-    <h3>Expose a home lab app</h3>
-    <p>Register an agent, install it on the remote host, and route public traffic through the outbound agent connection.</p>
-    <a href="./guides/expose-a-home-lab-app">Use an agent</a>
-  </div>
-  <div class="home-card">
-    <h3>Set up public TLS</h3>
-    <p>Use ACME HTTP-01, TLS-ALPN-01, or Cloudflare DNS-01 for trusted public certificates.</p>
-    <a href="./concepts/tls">Choose a TLS path</a>
-  </div>
-  <div class="home-card">
-    <h3>Harden and operate</h3>
-    <p>Restrict management access, back up <code>/data</code>, plan upgrades, and troubleshoot failed routes, TLS, agents, and cache rules.</p>
-    <a href="./operations/security-hardening">Review operations</a>
-  </div>
-</div>
-
-## What You Run
-
-<div class="home-strip">
-  <div class="home-strip-item">
-    <strong>Server</strong>
-    <span>Management UI/API on <code>8081</code> plus public listeners stored in SQLite.</span>
-  </div>
-  <div class="home-strip-item">
-    <strong>Data</strong>
-    <span>SQLite, generated management TLS, public TLS, ACME state, and cache files under <code>/data</code>.</span>
-  </div>
-  <div class="home-strip-item">
-    <strong>Agents</strong>
-    <span>Outbound HTTPS/WSS clients that forward selected public traffic from remote networks.</span>
-  </div>
-</div>
-
-## Management Console
-
-The management UI is where selfhosters inspect runtime health and manage agents, listeners, backends, routes, TLS, response templates, WAF rules, rate limits, cache rules, traffic shapers, and live traces.
-
-<figure class="doc-screenshot">
-  <img src="./assets/overview.png" alt="p2pstream proxy overview dashboard showing proxy status, request metrics, traffic trend, hotspots, and configuration snapshot">
-  <figcaption>Overview summarizes proxy health, recent traffic, active agents, and loaded public proxy configuration.</figcaption>
-</figure>
-
-## Reading Order
-
-1. [Docker Compose quickstart](./getting-started/quickstart)
-2. [First login](./getting-started/first-login)
-3. [Publish a service](./guides/publish-a-service)
-4. [Expose a home lab app through an agent](./guides/expose-a-home-lab-app)
-5. [TLS](./concepts/tls)
-6. [Security hardening](./operations/security-hardening)
-7. [Backup and restore](./operations/backup-restore)
-8. [Troubleshooting](./operations/troubleshooting)
-
-## Fast Reference
-
-| Need | Open |
-| --- | --- |
-| Environment variables | [Configuration reference](./reference/configuration) |
-| CLI commands | [CLI reference](./reference/cli) |
-| Docker image and ports | [Docker reference](./reference/docker) |
-| Route matching behavior | [Routing rules reference](./reference/routing-rules) |
-| Reusable response bodies and WAF pages | [Response templates reference](./reference/response-templates) |
-| WAF, rate limits, shapers, cache | [Traffic controls](./concepts/limits-and-shaping) |
-| Visual tour | [Screenshots](./reference/screenshots) |
+<nav class="home-reference-strip" aria-label="Fast reference">
+  <a href="./concepts/tls">TLS</a>
+  <a href="./concepts/limits-and-shaping">Traffic controls</a>
+  <a href="./operations/troubleshooting">Troubleshooting</a>
+  <a href="./reference/configuration">Configuration</a>
+  <a href="./reference/screenshots">Screenshots</a>
+</nav>

--- a/docs/public/logo-mark.svg
+++ b/docs/public/logo-mark.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="title desc">
+  <title id="title">p2pstream logo mark</title>
+  <desc id="desc">A square p2pstream logo mark with a rotated diamond in the center.</desc>
+  <rect width="96" height="96" rx="12" fill="#ffffff"/>
+  <rect x="34" y="34" width="28" height="28" rx="2" fill="#000000" transform="rotate(45 48 48)"/>
+</svg>


### PR DESCRIPTION
## Summary
- replace the docs homepage with a minimal native VitePress portal
- add the admin-style logo mark as the homepage hero image
- remove duplicated homepage screenshots and low-value start-page sections

## Verification
- bun run docs:build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Revised theme tokens (light/dark) for backgrounds, text, dividers, accents, panels and softer shadows
  * Updated nav to use a themed gradient and backdrop blur; refined button, hero, table, code and screenshot visuals
  * Strengthened typography, link focus outlines, hover states, and mobile spacing/overflow for reference links

* **Documentation**
  * Redesigned homepage with a new hero, feature list and compact reference strip for simpler navigation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kirari04/p2pstream/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->