### PR TITLE
Normalize preserved redirect paths

### DIFF
--- a/internal/server/public_routing.go
+++ b/internal/server/public_routing.go
@@ -1358,7 +1358,7 @@ func redirectPathSuffix(r *http.Request, pathPrefix string) string {
 	}
 	pathPrefix = strings.TrimSpace(pathPrefix)
 	if pathPrefix == "" || pathPrefix == "/" {
-		return requestPath
+		return normalizeLocalRedirectPath(requestPath)
 	}
 	if !pathPrefixMatches(requestPath, pathPrefix) {
 		return ""
@@ -1367,29 +1367,48 @@ func redirectPathSuffix(r *http.Request, pathPrefix string) string {
 	if suffix == "" {
 		return ""
 	}
-	if !strings.HasPrefix(suffix, "/") {
-		return "/" + suffix
-	}
-	return suffix
+	return normalizeLocalRedirectPath(suffix)
 }
 
 func joinRedirectPath(basePath string, suffix string) string {
+	basePath = normalizeLocalRedirectPath(basePath)
 	if suffix == "" {
-		if basePath == "" {
-			return "/"
-		}
 		return basePath
 	}
-	if basePath == "" {
-		basePath = "/"
-	}
-	if !strings.HasPrefix(suffix, "/") {
-		suffix = "/" + suffix
-	}
+	suffix = normalizeLocalRedirectPath(suffix)
 	if basePath == "/" {
 		return suffix
 	}
 	return strings.TrimRight(basePath, "/") + "/" + strings.TrimLeft(suffix, "/")
+}
+
+func isSafeLocalRedirectTarget(path string) bool {
+	if !strings.HasPrefix(path, "/") {
+		return false
+	}
+	if len(path) > 1 && (path[1] == '/' || path[1] == '\\') {
+		return false
+	}
+	return true
+}
+
+func normalizeLocalRedirectPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "/"
+	}
+	if isSafeLocalRedirectTarget(path) {
+		return path
+	}
+	path = strings.TrimLeft(path, `/\`)
+	if path == "" || path[0] == '/' || path[0] == '\\' {
+		return "/"
+	}
+	normalized := "/" + path
+	if !isSafeLocalRedirectTarget(normalized) {
+		return "/"
+	}
+	return normalized
 }
 
 func pathPrefixMatches(requestPath string, pathPrefix string) bool {

--- a/internal/server/public_routing_test.go
+++ b/internal/server/public_routing_test.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRedirectPathSuffixNormalizesLocalTargets(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		target string
+		prefix string
+		want   string
+	}{
+		{name: "matched suffix", target: "http://example.com/api/users", prefix: "/api", want: "/users"},
+		{name: "segment boundary mismatch", target: "http://example.com/apiv2", prefix: "/api", want: ""},
+		{name: "scheme relative request path", target: "http://example.com//evil.example/path", prefix: "", want: "/evil.example/path"},
+		{name: "backslash request path", target: `http://example.com/\evil.example/path`, prefix: "", want: "/evil.example/path"},
+		{name: "scheme relative suffix", target: "http://example.com/app//evil.example/path", prefix: "/app", want: "/evil.example/path"},
+		{name: "backslash suffix", target: `http://example.com/app/\evil.example/path`, prefix: "/app", want: "/evil.example/path"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.target, nil)
+
+			if got := redirectPathSuffix(req, tc.prefix); got != tc.want {
+				t.Fatalf("redirectPathSuffix(%q, %q) = %q, want %q", tc.target, tc.prefix, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestJoinRedirectPathNormalizesUnsafeSuffixes(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		base   string
+		suffix string
+		want   string
+	}{
+		{name: "root with scheme relative suffix", base: "/", suffix: "//evil.example/path", want: "/evil.example/path"},
+		{name: "root with backslash suffix", base: "/", suffix: `/\evil.example/path`, want: "/evil.example/path"},
+		{name: "base with safe suffix", base: "/base", suffix: "/users", want: "/base/users"},
+		{name: "empty base with relative suffix", base: "", suffix: "users", want: "/users"},
+		{name: "unsafe base is normalized", base: "//configured.example", suffix: "users", want: "/configured.example/users"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := joinRedirectPath(tc.base, tc.suffix); got != tc.want {
+				t.Fatalf("joinRedirectPath(%q, %q) = %q, want %q", tc.base, tc.suffix, got, tc.want)
+			}
+			if got := joinRedirectPath("/", tc.suffix); got != "" && !isSafeLocalRedirectTarget(got) {
+				t.Fatalf("joinRedirectPath returned unsafe local redirect target %q", got)
+			}
+		})
+	}
+}
+
+func TestRedirectLocationPreservesSafePathSuffix(t *testing.T) {
+	route := publicRouteConfig{
+		PathPrefix:                 "/api",
+		RedirectTargetMode:         publicRouteRedirectTargetModeSameHostPath,
+		RedirectTarget:             "/target",
+		RedirectPreservePathSuffix: true,
+	}
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/api/users?debug=1", nil)
+
+	location, err := redirectLocationForRequest(req, route)
+	if err != nil {
+		t.Fatalf("redirectLocationForRequest returned error: %v", err)
+	}
+	if location != "/target/users" {
+		t.Fatalf("location = %q, want %q", location, "/target/users")
+	}
+}


### PR DESCRIPTION
## Summary
- normalize preserved redirect suffixes before building redirect locations
- reject scheme-relative and backslash-prefixed local redirect targets
- add route redirect regression tests for unsafe path shapes

## Tests
- go test ./internal/server
- go test ./...
- go vet ./...
- make test

Fixes CodeQL alerts #3 and #4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened local redirect handling with stricter validation and consistent normalization to prevent unsafe or malformed redirect targets.

* **Tests**
  * Added unit tests covering normalization, safety checks, and preservation of safe path suffixes during redirects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kirari04/p2pstream/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->