### PR TITLE
Harden WAF return redirects

### DIFF
--- a/internal/managementui/handler.go
+++ b/internal/managementui/handler.go
@@ -60,7 +60,10 @@ func serveManagementUIFile(w http.ResponseWriter, r *http.Request, distFS fs.FS,
 	if !ok {
 		return false
 	}
-	defer file.Close()
+	defer func() {
+		// Best-effort close; response may already be in-flight.
+		_ = file.Close()
+	}()
 	seeker, ok := file.(io.ReadSeeker)
 	if !ok {
 		return false

--- a/internal/server/public_waf_captcha.go
+++ b/internal/server/public_waf_captcha.go
@@ -163,7 +163,14 @@ func (a *App) servePublicWAFCaptchaVerify(w http.ResponseWriter, r *http.Request
 	}
 	cookie := a.PublicWAF.signedRuleCookie(rule.ID, publicWafCaptchaCookieKind, "", rule.CaptchaPassTTL, now, decision.Listener, r)
 	http.SetCookie(w, cookie)
-	http.Redirect(w, r, returnTo, http.StatusSeeOther)
+	redirectTo := sanitizeWAFReturnTo(returnTo)
+	redirectTo = strings.ReplaceAll(redirectTo, `\`, "/")
+	redirectURL, err := url.Parse(redirectTo)
+	if err == nil && redirectURL.Hostname() == "" {
+		http.Redirect(w, r, redirectURL.String(), http.StatusSeeOther)
+	} else {
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+	}
 	decision.StatusCode = http.StatusSeeOther
 	decision.ErrorKind = ""
 	return decision
@@ -383,8 +390,17 @@ func sanitizeWAFReturnTo(value string) string {
 		return "/"
 	}
 	parsed, err := url.Parse(value)
-	if err != nil || parsed.IsAbs() || parsed.Host != "" || !strings.HasPrefix(parsed.Path, "/") {
+	if err != nil || parsed.IsAbs() || parsed.Host != "" || parsed.Opaque != "" {
 		return "/"
+	}
+	if !isSafeLocalRedirectTarget(parsed.Path) {
+		return "/"
+	}
+	if escapedPath := parsed.EscapedPath(); escapedPath != "" {
+		unescapedPath, err := url.PathUnescape(escapedPath)
+		if err != nil || !isSafeLocalRedirectTarget(unescapedPath) {
+			return "/"
+		}
 	}
 	if isPublicWAFReservedPath(parsed.Path) {
 		return "/"

--- a/internal/server/public_waf_test.go
+++ b/internal/server/public_waf_test.go
@@ -495,6 +495,31 @@ func TestPublicWafCaptchaVerifySuccessSetsCookieAndRedirects(t *testing.T) {
 	assertPublicWafCookieAttributes(t, passCookie, false)
 }
 
+func TestPublicWafCaptchaVerifySanitizesUnsafeReturnRedirect(t *testing.T) {
+	app, handler, rule, _ := newTestCaptchaVerifyApp(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parse form: %v", err)
+		}
+		if r.Form.Get("response") == "token" {
+			_, _ = w.Write([]byte(`{"success":true}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"success":false}`))
+	})
+	unsafeReturnTo := "//evil.example/private"
+	challenge := testCaptchaChallenge(t, app, rule, "example.com", unsafeReturnTo)
+	form := captchaVerifyForm(rule.ID, unsafeReturnTo, challenge, "token")
+	resp := httptest.NewRecorder()
+	handler(resp, newCaptchaVerifyRequest("example.com", form))
+
+	if resp.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d", resp.Code, http.StatusSeeOther)
+	}
+	if location := resp.Header().Get("Location"); location != "/" {
+		t.Fatalf("Location = %q, want /", location)
+	}
+}
+
 func TestPublicWafCaptchaVerifySuccessSetsSecureCookieForHTTPSListener(t *testing.T) {
 	app, handler, rule, _ := newTestCaptchaVerifyApp(t, func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
@@ -524,6 +549,54 @@ func TestPublicWafCaptchaVerifySuccessSetsSecureCookieForHTTPSListener(t *testin
 	}
 	passCookie := requirePublicWafCookie(t, resp.Result().Cookies(), wafCookieName(rule.ID, publicWafCaptchaCookieKind))
 	assertPublicWafCookieAttributes(t, passCookie, true)
+}
+
+func TestSanitizeWAFReturnTo(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "empty", value: "", want: "/"},
+		{name: "valid path and query", value: "/private?x=1", want: "/private?x=1"},
+		{name: "absolute URL", value: "https://evil.example/private", want: "/"},
+		{name: "scheme relative URL", value: "//evil.example/private", want: "/"},
+		{name: "backslash-prefixed path", value: `/\evil.example/private`, want: "/"},
+		{name: "encoded slash prefix", value: "/%2fevil.example/private", want: "/"},
+		{name: "encoded backslash prefix", value: "/%5cevil.example/private", want: "/"},
+		{name: "relative path", value: "private", want: "/"},
+		{name: "reserved captcha path", value: publicWafCaptchaVerifyPath, want: "/"},
+		{name: "reserved waiting room path with query", value: publicWafWaitingRoomStatusPath + "?rule_id=1", want: "/"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeWAFReturnTo(tc.value); got != tc.want {
+				t.Fatalf("sanitizeWAFReturnTo(%q) = %q, want %q", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPublicWafWaitingRoomStatusSanitizesUnsafeReturnRedirect(t *testing.T) {
+	app := NewApp(nil, nil)
+	rule := testWafRule(1, publicWafActionWaitingRoom)
+	snap := testWafSnapshot(rule, nil)
+	app.proxyMu.Lock()
+	app.publicSnapshot = snap
+	app.proxyMu.Unlock()
+	app.PublicWAF.reconcile(snap)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com"+publicWafWaitingRoomStatusPath+"?rule_id=1&return_to=%2F%2Fevil.example%2Fprivate", nil)
+	req.AddCookie(app.PublicWAF.signedRuleCookie(rule.ID, publicWafAdmissionCookieKind, "session", time.Minute, time.Now(), snap.Listeners[1], req))
+	resp := httptest.NewRecorder()
+
+	decision := app.servePublicWAFWaitingRoomStatus(resp, req, 1)
+
+	if decision.StatusCode != http.StatusSeeOther {
+		t.Fatalf("decision status = %d, want %d", decision.StatusCode, http.StatusSeeOther)
+	}
+	if location := resp.Header().Get("Location"); location != "/" {
+		t.Fatalf("Location = %q, want /", location)
+	}
 }
 
 func TestPublicWafCaptchaPassCookieAllowsRequest(t *testing.T) {

--- a/internal/server/public_waf_waiting_room.go
+++ b/internal/server/public_waf_waiting_room.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -270,7 +271,14 @@ func (a *App) servePublicWAFWaitingRoomStatus(w http.ResponseWriter, r *http.Req
 	a.PublicWAF.mu.Lock()
 	defer a.PublicWAF.mu.Unlock()
 	if a.PublicWAF.validRuleCookieLocked(r, rule.ID, publicWafAdmissionCookieKind, now) {
-		http.Redirect(w, r, sanitizeWAFReturnTo(r.URL.Query().Get("return_to")), http.StatusSeeOther)
+		redirectTo := sanitizeWAFReturnTo(r.URL.Query().Get("return_to"))
+		redirectTo = strings.ReplaceAll(redirectTo, `\`, "/")
+		redirectURL, err := url.Parse(redirectTo)
+		if err == nil && redirectURL.Hostname() == "" {
+			http.Redirect(w, r, redirectURL.String(), http.StatusSeeOther)
+		} else {
+			http.Redirect(w, r, "/", http.StatusSeeOther)
+		}
 		return publicWafDecision{Rule: rule, Listener: listener, Action: publicWafActionWaitingRoom, StatusCode: http.StatusSeeOther, ChallengeKind: publicWafActionWaitingRoom}
 	}
 	runtime := a.PublicWAF.runtimeLocked(rule)


### PR DESCRIPTION
## Summary
- reject absolute, scheme-relative, backslash-prefixed, encoded unsafe, and reserved WAF return paths
- add explicit local redirect guards at captcha and waiting-room redirect sinks
- add sanitizer, captcha, and waiting-room regression tests
- address CodeRabbit follow-up from PR #15 by checking the management UI file close result

## Tests
- go test ./internal/server
- go test ./internal/managementui
- go test ./...
- go vet ./...
- make test

Fixes CodeQL alerts #1 and #2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation and normalization of redirect targets in WAF captcha and waiting-room flows (backslash→slash normalization, URL parsing and hostname checks); unsafe, malformed, scheme-relative, or encoded absolute redirects now go to the homepage (303).
  * More reliable cleanup when serving management UI assets to ensure opened resources are closed.

* **Tests**
  * Added tests covering redirect sanitization and unsafe return-to cases for captcha and waiting-room flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kirari04/p2pstream/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->