### PR TITLE
Harden management setup, cache rules, and observability retention

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -68,7 +68,7 @@ var serverCmd = &cobra.Command{
 
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
-		app.StartObservabilityCleanup(ctx)
+		app.StartObservabilityMaintenance(ctx)
 
 		if app.PublicACME != nil {
 			app.PublicACME.Start(ctx)

--- a/internal/db/connection.go
+++ b/internal/db/connection.go
@@ -593,6 +593,9 @@ func (db *DB) migrate() error {
 			return err
 		}
 	}
+	if err := db.migrateObservabilityRollups(); err != nil {
+		return err
+	}
 	if _, err := db.Exec(`
 		CREATE TABLE IF NOT EXISTS public_tls_dns_credentials (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -626,6 +629,9 @@ func (db *DB) migrate() error {
 		return err
 	}
 	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_connections_agent_id ON connections (agent_id)`); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_connections_disconnected_at ON connections (disconnected_at)`); err != nil {
 		return err
 	}
 	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_public_tls_certificates_dns_credential_id ON public_tls_certificates (dns_credential_id)`); err != nil {
@@ -975,6 +981,95 @@ func (db *DB) migrate() error {
 		return err
 	}
 	return nil
+}
+
+func (db *DB) migrateObservabilityRollups() error {
+	_, err := db.Exec(`
+	CREATE TABLE IF NOT EXISTS proxy_request_rollup_minutes (
+		bucket_unix_millis INTEGER PRIMARY KEY,
+		requests INTEGER NOT NULL DEFAULT 0,
+		success INTEGER NOT NULL DEFAULT 0,
+		client_error INTEGER NOT NULL DEFAULT 0,
+		server_error INTEGER NOT NULL DEFAULT 0,
+		internal_error INTEGER NOT NULL DEFAULT 0,
+		duration_ms_sum INTEGER NOT NULL DEFAULT 0,
+		max_duration_ms INTEGER NOT NULL DEFAULT 0,
+		slow_requests INTEGER NOT NULL DEFAULT 0,
+		request_bytes INTEGER NOT NULL DEFAULT 0,
+		response_bytes INTEGER NOT NULL DEFAULT 0,
+		cache_hits INTEGER NOT NULL DEFAULT 0,
+		cache_misses INTEGER NOT NULL DEFAULT 0,
+		cache_bypasses INTEGER NOT NULL DEFAULT 0,
+		cache_stored INTEGER NOT NULL DEFAULT 0,
+		cache_store_failed INTEGER NOT NULL DEFAULT 0,
+		cache_hit_bytes INTEGER NOT NULL DEFAULT 0,
+		cache_stored_bytes INTEGER NOT NULL DEFAULT 0,
+		created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);
+
+	CREATE TABLE IF NOT EXISTS proxy_request_tuple_rollup_minutes (
+		bucket_unix_millis INTEGER NOT NULL,
+		listener_id INTEGER NOT NULL DEFAULT 0,
+		backend_id INTEGER NOT NULL DEFAULT 0,
+		route_id INTEGER NOT NULL DEFAULT 0,
+		agent_id INTEGER NOT NULL DEFAULT 0,
+		error_kind TEXT NOT NULL DEFAULT '',
+		status_class INTEGER NOT NULL DEFAULT 0,
+		requests INTEGER NOT NULL DEFAULT 0,
+		success INTEGER NOT NULL DEFAULT 0,
+		client_error INTEGER NOT NULL DEFAULT 0,
+		server_error INTEGER NOT NULL DEFAULT 0,
+		internal_error INTEGER NOT NULL DEFAULT 0,
+		duration_ms_sum INTEGER NOT NULL DEFAULT 0,
+		request_bytes INTEGER NOT NULL DEFAULT 0,
+		response_bytes INTEGER NOT NULL DEFAULT 0,
+		created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		PRIMARY KEY (bucket_unix_millis, listener_id, backend_id, route_id, agent_id, error_kind, status_class)
+	);
+
+	CREATE TABLE IF NOT EXISTS agent_stat_rollup_minutes (
+		bucket_unix_millis INTEGER PRIMARY KEY,
+		samples INTEGER NOT NULL DEFAULT 0,
+		req_success INTEGER NOT NULL DEFAULT 0,
+		req_client_error INTEGER NOT NULL DEFAULT 0,
+		req_server_error INTEGER NOT NULL DEFAULT 0,
+		req_internal_error INTEGER NOT NULL DEFAULT 0,
+		bytes_rx INTEGER NOT NULL DEFAULT 0,
+		bytes_tx INTEGER NOT NULL DEFAULT 0,
+		memory_mb_sum INTEGER NOT NULL DEFAULT 0,
+		max_memory_mb INTEGER NOT NULL DEFAULT 0,
+		goroutines_sum INTEGER NOT NULL DEFAULT 0,
+		max_goroutines INTEGER NOT NULL DEFAULT 0,
+		cpu_percent_sum REAL NOT NULL DEFAULT 0,
+		max_cpu_percent REAL NOT NULL DEFAULT 0,
+		created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);
+
+	CREATE TABLE IF NOT EXISTS observability_rollup_state (
+		id INTEGER PRIMARY KEY CHECK (id = 1),
+		proxy_backfill_upper_id INTEGER NOT NULL DEFAULT 0,
+		proxy_backfilled_through_id INTEGER NOT NULL DEFAULT 0,
+		agent_backfill_upper_id INTEGER NOT NULL DEFAULT 0,
+		agent_backfilled_through_id INTEGER NOT NULL DEFAULT 0,
+		created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);
+
+	INSERT INTO observability_rollup_state (
+		id, proxy_backfill_upper_id, proxy_backfilled_through_id, agent_backfill_upper_id, agent_backfilled_through_id
+	)
+	SELECT
+		1,
+		CAST(COALESCE((SELECT MAX(id) FROM proxy_request_events), 0) AS INTEGER),
+		0,
+		CAST(COALESCE((SELECT MAX(id) FROM agent_stats), 0) AS INTEGER),
+		0
+	WHERE NOT EXISTS (SELECT 1 FROM observability_rollup_state WHERE id = 1);
+	`)
+	return err
 }
 
 type legacyPolicyMatchJSON struct {

--- a/internal/db/connection_test.go
+++ b/internal/db/connection_test.go
@@ -83,7 +83,7 @@ func TestMigrationCreatesMultiAgentRoutingSchema(t *testing.T) {
 	}
 	defer func() { _ = database.Close() }()
 
-	for _, table := range []string{"agents", "public_backend_agents", "public_backend_upstream_headers", "public_waf_captcha_providers", "public_waf_rules", "public_waf_settings", "public_cache_settings", "public_cache_rules", "public_cache_entries"} {
+	for _, table := range []string{"agents", "public_backend_agents", "public_backend_upstream_headers", "public_waf_captcha_providers", "public_waf_rules", "public_waf_settings", "public_cache_settings", "public_cache_rules", "public_cache_entries", "proxy_request_rollup_minutes", "proxy_request_tuple_rollup_minutes", "agent_stat_rollup_minutes", "observability_rollup_state"} {
 		var name string
 		if err := database.QueryRowContext(context.Background(), `SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`, table).Scan(&name); err != nil {
 			t.Fatalf("expected table %s: %v", table, err)
@@ -112,6 +112,7 @@ func TestMigrationCreatesMultiAgentRoutingSchema(t *testing.T) {
 		"idx_public_cache_entries_rule_id",
 		"idx_public_cache_entries_expires_at",
 		"idx_public_cache_entries_last_accessed_at",
+		"idx_connections_disconnected_at",
 	} {
 		if !indexExists(t, database, index) {
 			t.Fatalf("expected %s on fresh schema", index)
@@ -372,6 +373,9 @@ func TestMigrationUpgradesLegacySchemaWithAgentColumns(t *testing.T) {
 	if !indexExists(t, database, "idx_connections_agent_id") {
 		t.Fatal("expected idx_connections_agent_id after migration")
 	}
+	if !indexExists(t, database, "idx_connections_disconnected_at") {
+		t.Fatal("expected idx_connections_disconnected_at after migration")
+	}
 	if !indexExists(t, database, "idx_public_backend_upstream_headers_backend_position") {
 		t.Fatal("expected idx_public_backend_upstream_headers_backend_position after migration")
 	}
@@ -392,7 +396,7 @@ func TestMigrationUpgradesLegacySchemaWithAgentColumns(t *testing.T) {
 			t.Fatalf("expected %s after migration", index)
 		}
 	}
-	for _, table := range []string{"public_cache_settings", "public_cache_rules", "public_cache_entries"} {
+	for _, table := range []string{"public_cache_settings", "public_cache_rules", "public_cache_entries", "proxy_request_rollup_minutes", "proxy_request_tuple_rollup_minutes", "agent_stat_rollup_minutes", "observability_rollup_state"} {
 		var name string
 		if err := database.QueryRowContext(context.Background(), `SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`, table).Scan(&name); err != nil {
 			t.Fatalf("expected migrated table %s: %v", table, err)

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -36,6 +36,25 @@ type AgentStat struct {
 	CpuPercent       float64       `json:"cpu_percent"`
 }
 
+type AgentStatRollupMinute struct {
+	BucketUnixMillis int64     `json:"bucket_unix_millis"`
+	Samples          int64     `json:"samples"`
+	ReqSuccess       int64     `json:"req_success"`
+	ReqClientError   int64     `json:"req_client_error"`
+	ReqServerError   int64     `json:"req_server_error"`
+	ReqInternalError int64     `json:"req_internal_error"`
+	BytesRx          int64     `json:"bytes_rx"`
+	BytesTx          int64     `json:"bytes_tx"`
+	MemoryMbSum      int64     `json:"memory_mb_sum"`
+	MaxMemoryMb      int64     `json:"max_memory_mb"`
+	GoroutinesSum    int64     `json:"goroutines_sum"`
+	MaxGoroutines    int64     `json:"max_goroutines"`
+	CpuPercentSum    float64   `json:"cpu_percent_sum"`
+	MaxCpuPercent    float64   `json:"max_cpu_percent"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+}
+
 type Connection struct {
 	ID             int64         `json:"id"`
 	AgentID        sql.NullInt64 `json:"agent_id"`
@@ -76,6 +95,16 @@ type ManagementAccessToken struct {
 	UpdatedAt  time.Time    `json:"updated_at"`
 }
 
+type ObservabilityRollupState struct {
+	ID                       int64     `json:"id"`
+	ProxyBackfillUpperID     int64     `json:"proxy_backfill_upper_id"`
+	ProxyBackfilledThroughID int64     `json:"proxy_backfilled_through_id"`
+	AgentBackfillUpperID     int64     `json:"agent_backfill_upper_id"`
+	AgentBackfilledThroughID int64     `json:"agent_backfilled_through_id"`
+	CreatedAt                time.Time `json:"created_at"`
+	UpdatedAt                time.Time `json:"updated_at"`
+}
+
 type ProxyRequestEvent struct {
 	ID            int64         `json:"id"`
 	OccurredAt    time.Time     `json:"occurred_at"`
@@ -93,6 +122,49 @@ type ProxyRequestEvent struct {
 	CacheRuleID   sql.NullInt64 `json:"cache_rule_id"`
 	CacheStatus   string        `json:"cache_status"`
 	CacheBytes    int64         `json:"cache_bytes"`
+}
+
+type ProxyRequestRollupMinute struct {
+	BucketUnixMillis int64     `json:"bucket_unix_millis"`
+	Requests         int64     `json:"requests"`
+	Success          int64     `json:"success"`
+	ClientError      int64     `json:"client_error"`
+	ServerError      int64     `json:"server_error"`
+	InternalError    int64     `json:"internal_error"`
+	DurationMsSum    int64     `json:"duration_ms_sum"`
+	MaxDurationMs    int64     `json:"max_duration_ms"`
+	SlowRequests     int64     `json:"slow_requests"`
+	RequestBytes     int64     `json:"request_bytes"`
+	ResponseBytes    int64     `json:"response_bytes"`
+	CacheHits        int64     `json:"cache_hits"`
+	CacheMisses      int64     `json:"cache_misses"`
+	CacheBypasses    int64     `json:"cache_bypasses"`
+	CacheStored      int64     `json:"cache_stored"`
+	CacheStoreFailed int64     `json:"cache_store_failed"`
+	CacheHitBytes    int64     `json:"cache_hit_bytes"`
+	CacheStoredBytes int64     `json:"cache_stored_bytes"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+}
+
+type ProxyRequestTupleRollupMinute struct {
+	BucketUnixMillis int64     `json:"bucket_unix_millis"`
+	ListenerID       int64     `json:"listener_id"`
+	BackendID        int64     `json:"backend_id"`
+	RouteID          int64     `json:"route_id"`
+	AgentID          int64     `json:"agent_id"`
+	ErrorKind        string    `json:"error_kind"`
+	StatusClass      int64     `json:"status_class"`
+	Requests         int64     `json:"requests"`
+	Success          int64     `json:"success"`
+	ClientError      int64     `json:"client_error"`
+	ServerError      int64     `json:"server_error"`
+	InternalError    int64     `json:"internal_error"`
+	DurationMsSum    int64     `json:"duration_ms_sum"`
+	RequestBytes     int64     `json:"request_bytes"`
+	ResponseBytes    int64     `json:"response_bytes"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
 }
 
 type PublicBackend struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -11,6 +11,9 @@ import (
 )
 
 type Querier interface {
+	BackfillAgentStatRollupMinutesRange(ctx context.Context, arg BackfillAgentStatRollupMinutesRangeParams) error
+	BackfillProxyRequestRollupMinutesRange(ctx context.Context, arg BackfillProxyRequestRollupMinutesRangeParams) error
+	BackfillProxyRequestTupleRollupMinutesRange(ctx context.Context, arg BackfillProxyRequestTupleRollupMinutesRangeParams) error
 	ClearEnvironmentTrust(ctx context.Context, id int64) (Environment, error)
 	CountEnabledAgentPoolBackendsWhereAgentIsLast(ctx context.Context, agentID int64) (int64, error)
 	CountPublicBackendEnabledReferences(ctx context.Context, backendID int64) (int64, error)
@@ -38,14 +41,17 @@ type Querier interface {
 	CreateSession(ctx context.Context, arg CreateSessionParams) (Session, error)
 	CreateUser(ctx context.Context, arg CreateUserParams) (CreateUserRow, error)
 	DeleteAgent(ctx context.Context, id int64) error
+	DeleteAgentStatRollupsBefore(ctx context.Context, bucketUnixMillis int64) error
 	DeleteAgentStatsBefore(ctx context.Context, reportedAt time.Time) error
 	DeleteDisconnectedConnectionsBefore(ctx context.Context, disconnectedAt sql.NullTime) error
 	DeleteEnvironment(ctx context.Context, id int64) error
 	DeleteExpiredPublicCacheEntries(ctx context.Context, expiresAt time.Time) ([]DeleteExpiredPublicCacheEntriesRow, error)
 	DeleteManagementAccessToken(ctx context.Context, id int64) error
-	DeleteOldestAgentStatsOverLimit(ctx context.Context, offset int64) error
-	DeleteOldestProxyRequestEventsOverLimit(ctx context.Context, offset int64) error
+	DeleteOldestAgentStatsOverLimit(ctx context.Context, arg DeleteOldestAgentStatsOverLimitParams) (int64, error)
+	DeleteOldestProxyRequestEventsOverLimit(ctx context.Context, arg DeleteOldestProxyRequestEventsOverLimitParams) (int64, error)
 	DeleteProxyRequestEventsBefore(ctx context.Context, occurredAt time.Time) error
+	DeleteProxyRequestRollupsBefore(ctx context.Context, bucketUnixMillis int64) error
+	DeleteProxyRequestTupleRollupsBefore(ctx context.Context, bucketUnixMillis int64) error
 	DeletePublicBackend(ctx context.Context, id int64) error
 	DeletePublicBackendAgents(ctx context.Context, backendID int64) error
 	DeletePublicBackendHeaders(ctx context.Context, backendID int64) error
@@ -67,11 +73,16 @@ type Querier interface {
 	GetActiveSessionByTokenHash(ctx context.Context, tokenHash string) (GetActiveSessionByTokenHashRow, error)
 	GetAgent(ctx context.Context, id int64) (Agent, error)
 	GetAgentByPublicID(ctx context.Context, publicID string) (Agent, error)
+	GetAgentStatsRollupSummarySince(ctx context.Context, bucketUnixMillis int64) (GetAgentStatsRollupSummarySinceRow, error)
 	GetAgentStatsSummarySince(ctx context.Context, reportedAt time.Time) (GetAgentStatsSummarySinceRow, error)
 	GetConnectionSummarySince(ctx context.Context, connectedAt time.Time) (GetConnectionSummarySinceRow, error)
 	GetEnvironment(ctx context.Context, id int64) (Environment, error)
 	GetLatestAgentStat(ctx context.Context) (AgentStat, error)
 	GetLatestAgentStatByAgent(ctx context.Context, agentID sql.NullInt64) (AgentStat, error)
+	GetNextAgentRollupBackfillThroughID(ctx context.Context, arg GetNextAgentRollupBackfillThroughIDParams) (int64, error)
+	GetNextProxyRollupBackfillThroughID(ctx context.Context, arg GetNextProxyRollupBackfillThroughIDParams) (int64, error)
+	GetObservabilityRollupState(ctx context.Context) (ObservabilityRollupState, error)
+	GetProxyRequestRollupSummarySince(ctx context.Context, bucketUnixMillis int64) (GetProxyRequestRollupSummarySinceRow, error)
 	GetProxyRequestSummarySince(ctx context.Context, occurredAt time.Time) (GetProxyRequestSummarySinceRow, error)
 	GetPublicBackend(ctx context.Context, id int64) (PublicBackend, error)
 	GetPublicCacheEntry(ctx context.Context, keyDigest string) (PublicCacheEntry, error)
@@ -91,12 +102,16 @@ type Querier interface {
 	GetUserByID(ctx context.Context, id int64) (User, error)
 	GetUserByUsername(ctx context.Context, username string) (User, error)
 	InsertAgentStat(ctx context.Context, arg InsertAgentStatParams) error
+	InsertAgentStatAt(ctx context.Context, arg InsertAgentStatAtParams) (int64, error)
 	InsertConnection(ctx context.Context, agentID sql.NullInt64) (int64, error)
 	InsertProxyRequestEvent(ctx context.Context, arg InsertProxyRequestEventParams) error
+	InsertProxyRequestEventAt(ctx context.Context, arg InsertProxyRequestEventAtParams) (int64, error)
 	ListAgents(ctx context.Context) ([]Agent, error)
 	ListEnvironments(ctx context.Context) ([]Environment, error)
 	ListManagementAccessTokens(ctx context.Context) ([]ManagementAccessToken, error)
+	ListProxyStatusClassesRollupsSince(ctx context.Context, bucketUnixMillis int64) ([]ListProxyStatusClassesRollupsSinceRow, error)
 	ListProxyStatusClassesSince(ctx context.Context, occurredAt time.Time) ([]ListProxyStatusClassesSinceRow, error)
+	ListProxyTrafficBucketRollupsSince(ctx context.Context, arg ListProxyTrafficBucketRollupsSinceParams) ([]ListProxyTrafficBucketRollupsSinceRow, error)
 	ListProxyTrafficBucketsSince(ctx context.Context, arg ListProxyTrafficBucketsSinceParams) ([]ListProxyTrafficBucketsSinceRow, error)
 	ListPublicBackendAgents(ctx context.Context) ([]PublicBackendAgent, error)
 	ListPublicBackendAgentsByBackend(ctx context.Context, backendID int64) ([]PublicBackendAgent, error)
@@ -119,13 +134,20 @@ type Querier interface {
 	ListPublicTrafficShaperRules(ctx context.Context) ([]PublicTrafficShaperRule, error)
 	ListPublicWafCaptchaProviders(ctx context.Context) ([]PublicWafCaptchaProvider, error)
 	ListPublicWafRules(ctx context.Context) ([]PublicWafRule, error)
+	ListTopProxyAgentsRollupsSince(ctx context.Context, bucketUnixMillis int64) ([]ListTopProxyAgentsRollupsSinceRow, error)
 	ListTopProxyAgentsSince(ctx context.Context, occurredAt time.Time) ([]ListTopProxyAgentsSinceRow, error)
+	ListTopProxyBackendsRollupsSince(ctx context.Context, bucketUnixMillis int64) ([]ListTopProxyBackendsRollupsSinceRow, error)
 	ListTopProxyBackendsSince(ctx context.Context, occurredAt time.Time) ([]ListTopProxyBackendsSinceRow, error)
+	ListTopProxyErrorKindsRollupsSince(ctx context.Context, bucketUnixMillis int64) ([]ListTopProxyErrorKindsRollupsSinceRow, error)
 	ListTopProxyErrorKindsSince(ctx context.Context, occurredAt time.Time) ([]ListTopProxyErrorKindsSinceRow, error)
+	ListTopProxyListenersRollupsSince(ctx context.Context, bucketUnixMillis int64) ([]ListTopProxyListenersRollupsSinceRow, error)
 	ListTopProxyListenersSince(ctx context.Context, occurredAt time.Time) ([]ListTopProxyListenersSinceRow, error)
+	ListTopProxyRoutesRollupsSince(ctx context.Context, bucketUnixMillis int64) ([]ListTopProxyRoutesRollupsSinceRow, error)
 	ListTopProxyRoutesSince(ctx context.Context, occurredAt time.Time) ([]ListTopProxyRoutesSinceRow, error)
 	MarkAgentConnected(ctx context.Context, id int64) error
 	MarkAgentDisconnected(ctx context.Context, id int64) error
+	MarkAgentRollupBackfilledThrough(ctx context.Context, agentBackfilledThroughID int64) error
+	MarkProxyRollupBackfilledThrough(ctx context.Context, proxyBackfilledThroughID int64) error
 	PurgeAllPublicCacheEntries(ctx context.Context) ([]PurgeAllPublicCacheEntriesRow, error)
 	PurgePublicCacheEntriesByHostPath(ctx context.Context, arg PurgePublicCacheEntriesByHostPathParams) ([]PurgePublicCacheEntriesByHostPathRow, error)
 	PurgePublicCacheEntriesByRule(ctx context.Context, ruleID int64) ([]PurgePublicCacheEntriesByRuleRow, error)
@@ -158,7 +180,10 @@ type Querier interface {
 	UpdatePublicWafCaptchaProvider(ctx context.Context, arg UpdatePublicWafCaptchaProviderParams) (PublicWafCaptchaProvider, error)
 	UpdatePublicWafRule(ctx context.Context, arg UpdatePublicWafRuleParams) (PublicWafRule, error)
 	UpdateUserPassword(ctx context.Context, arg UpdateUserPasswordParams) (User, error)
+	UpsertAgentStatRollupMinute(ctx context.Context, arg UpsertAgentStatRollupMinuteParams) error
 	UpsertBootstrapAgent(ctx context.Context, arg UpsertBootstrapAgentParams) (Agent, error)
+	UpsertProxyRequestRollupMinute(ctx context.Context, arg UpsertProxyRequestRollupMinuteParams) error
+	UpsertProxyRequestTupleRollupMinute(ctx context.Context, arg UpsertProxyRequestTupleRollupMinuteParams) error
 	UpsertPublicCacheEntry(ctx context.Context, arg UpsertPublicCacheEntryParams) (PublicCacheEntry, error)
 	UpsertPublicCacheSettingsDefaults(ctx context.Context) (PublicCacheSetting, error)
 	UpsertPublicWafSettings(ctx context.Context, cookieSigningSecret string) (PublicWafSetting, error)

--- a/internal/db/query.sql.go
+++ b/internal/db/query.sql.go
@@ -11,6 +11,167 @@ import (
 	"time"
 )
 
+const backfillAgentStatRollupMinutesRange = `-- name: BackfillAgentStatRollupMinutesRange :exec
+INSERT INTO agent_stat_rollup_minutes (
+    bucket_unix_millis, samples, req_success, req_client_error, req_server_error, req_internal_error,
+    bytes_rx, bytes_tx, memory_mb_sum, max_memory_mb, goroutines_sum, max_goroutines,
+    cpu_percent_sum, max_cpu_percent
+)
+SELECT
+    CAST((unixepoch(reported_at) / 60) * 60 * 1000 AS INTEGER) AS bucket_unix_millis,
+    COUNT(*) AS samples,
+    CAST(COALESCE(SUM(req_success), 0) AS INTEGER) AS req_success,
+    CAST(COALESCE(SUM(req_client_error), 0) AS INTEGER) AS req_client_error,
+    CAST(COALESCE(SUM(req_server_error), 0) AS INTEGER) AS req_server_error,
+    CAST(COALESCE(SUM(req_internal_error), 0) AS INTEGER) AS req_internal_error,
+    CAST(COALESCE(SUM(bytes_rx), 0) AS INTEGER) AS bytes_rx,
+    CAST(COALESCE(SUM(bytes_tx), 0) AS INTEGER) AS bytes_tx,
+    CAST(COALESCE(SUM(memory_mb), 0) AS INTEGER) AS memory_mb_sum,
+    CAST(COALESCE(MAX(memory_mb), 0) AS INTEGER) AS max_memory_mb,
+    CAST(COALESCE(SUM(goroutines), 0) AS INTEGER) AS goroutines_sum,
+    CAST(COALESCE(MAX(goroutines), 0) AS INTEGER) AS max_goroutines,
+    CAST(COALESCE(SUM(cpu_percent), 0) AS REAL) AS cpu_percent_sum,
+    CAST(COALESCE(MAX(cpu_percent), 0) AS REAL) AS max_cpu_percent
+FROM agent_stats
+WHERE id > ?1
+  AND id <= ?2
+GROUP BY bucket_unix_millis
+ON CONFLICT(bucket_unix_millis) DO UPDATE SET
+    samples = agent_stat_rollup_minutes.samples + excluded.samples,
+    req_success = agent_stat_rollup_minutes.req_success + excluded.req_success,
+    req_client_error = agent_stat_rollup_minutes.req_client_error + excluded.req_client_error,
+    req_server_error = agent_stat_rollup_minutes.req_server_error + excluded.req_server_error,
+    req_internal_error = agent_stat_rollup_minutes.req_internal_error + excluded.req_internal_error,
+    bytes_rx = agent_stat_rollup_minutes.bytes_rx + excluded.bytes_rx,
+    bytes_tx = agent_stat_rollup_minutes.bytes_tx + excluded.bytes_tx,
+    memory_mb_sum = agent_stat_rollup_minutes.memory_mb_sum + excluded.memory_mb_sum,
+    max_memory_mb = MAX(agent_stat_rollup_minutes.max_memory_mb, excluded.max_memory_mb),
+    goroutines_sum = agent_stat_rollup_minutes.goroutines_sum + excluded.goroutines_sum,
+    max_goroutines = MAX(agent_stat_rollup_minutes.max_goroutines, excluded.max_goroutines),
+    cpu_percent_sum = agent_stat_rollup_minutes.cpu_percent_sum + excluded.cpu_percent_sum,
+    max_cpu_percent = MAX(agent_stat_rollup_minutes.max_cpu_percent, excluded.max_cpu_percent),
+    updated_at = CURRENT_TIMESTAMP
+`
+
+type BackfillAgentStatRollupMinutesRangeParams struct {
+	FromID    int64 `json:"from_id"`
+	ThroughID int64 `json:"through_id"`
+}
+
+func (q *Queries) BackfillAgentStatRollupMinutesRange(ctx context.Context, arg BackfillAgentStatRollupMinutesRangeParams) error {
+	_, err := q.db.ExecContext(ctx, backfillAgentStatRollupMinutesRange, arg.FromID, arg.ThroughID)
+	return err
+}
+
+const backfillProxyRequestRollupMinutesRange = `-- name: BackfillProxyRequestRollupMinutesRange :exec
+INSERT INTO proxy_request_rollup_minutes (
+    bucket_unix_millis, requests, success, client_error, server_error, internal_error,
+    duration_ms_sum, max_duration_ms, slow_requests, request_bytes, response_bytes,
+    cache_hits, cache_misses, cache_bypasses, cache_stored, cache_store_failed,
+    cache_hit_bytes, cache_stored_bytes
+)
+SELECT
+    CAST((unixepoch(occurred_at) / 60) * 60 * 1000 AS INTEGER) AS bucket_unix_millis,
+    COUNT(*) AS requests,
+    CAST(COALESCE(SUM(CASE WHEN status_code >= 200 AND status_code < 400 THEN 1 ELSE 0 END), 0) AS INTEGER) AS success,
+    CAST(COALESCE(SUM(CASE WHEN status_code >= 400 AND status_code < 500 THEN 1 ELSE 0 END), 0) AS INTEGER) AS client_error,
+    CAST(COALESCE(SUM(CASE WHEN status_code >= 500 THEN 1 ELSE 0 END), 0) AS INTEGER) AS server_error,
+    CAST(COALESCE(SUM(CASE WHEN error_kind != '' THEN 1 ELSE 0 END), 0) AS INTEGER) AS internal_error,
+    CAST(COALESCE(SUM(duration_ms), 0) AS INTEGER) AS duration_ms_sum,
+    CAST(COALESCE(MAX(duration_ms), 0) AS INTEGER) AS max_duration_ms,
+    CAST(COALESCE(SUM(CASE WHEN duration_ms >= 1000 THEN 1 ELSE 0 END), 0) AS INTEGER) AS slow_requests,
+    CAST(COALESCE(SUM(request_bytes), 0) AS INTEGER) AS request_bytes,
+    CAST(COALESCE(SUM(response_bytes), 0) AS INTEGER) AS response_bytes,
+    CAST(COALESCE(SUM(CASE WHEN cache_status = 'hit' THEN 1 ELSE 0 END), 0) AS INTEGER) AS cache_hits,
+    CAST(COALESCE(SUM(CASE WHEN cache_status IN ('miss', 'stored', 'store_failed') THEN 1 ELSE 0 END), 0) AS INTEGER) AS cache_misses,
+    CAST(COALESCE(SUM(CASE WHEN cache_status = 'bypass' THEN 1 ELSE 0 END), 0) AS INTEGER) AS cache_bypasses,
+    CAST(COALESCE(SUM(CASE WHEN cache_status = 'stored' THEN 1 ELSE 0 END), 0) AS INTEGER) AS cache_stored,
+    CAST(COALESCE(SUM(CASE WHEN cache_status = 'store_failed' THEN 1 ELSE 0 END), 0) AS INTEGER) AS cache_store_failed,
+    CAST(COALESCE(SUM(CASE WHEN cache_status = 'hit' THEN cache_bytes ELSE 0 END), 0) AS INTEGER) AS cache_hit_bytes,
+    CAST(COALESCE(SUM(CASE WHEN cache_status = 'stored' THEN cache_bytes ELSE 0 END), 0) AS INTEGER) AS cache_stored_bytes
+FROM proxy_request_events
+WHERE id > ?1
+  AND id <= ?2
+GROUP BY bucket_unix_millis
+ON CONFLICT(bucket_unix_millis) DO UPDATE SET
+    requests = proxy_request_rollup_minutes.requests + excluded.requests,
+    success = proxy_request_rollup_minutes.success + excluded.success,
+    client_error = proxy_request_rollup_minutes.client_error + excluded.client_error,
+    server_error = proxy_request_rollup_minutes.server_error + excluded.server_error,
+    internal_error = proxy_request_rollup_minutes.internal_error + excluded.internal_error,
+    duration_ms_sum = proxy_request_rollup_minutes.duration_ms_sum + excluded.duration_ms_sum,
+    max_duration_ms = MAX(proxy_request_rollup_minutes.max_duration_ms, excluded.max_duration_ms),
+    slow_requests = proxy_request_rollup_minutes.slow_requests + excluded.slow_requests,
+    request_bytes = proxy_request_rollup_minutes.request_bytes + excluded.request_bytes,
+    response_bytes = proxy_request_rollup_minutes.response_bytes + excluded.response_bytes,
+    cache_hits = proxy_request_rollup_minutes.cache_hits + excluded.cache_hits,
+    cache_misses = proxy_request_rollup_minutes.cache_misses + excluded.cache_misses,
+    cache_bypasses = proxy_request_rollup_minutes.cache_bypasses + excluded.cache_bypasses,
+    cache_stored = proxy_request_rollup_minutes.cache_stored + excluded.cache_stored,
+    cache_store_failed = proxy_request_rollup_minutes.cache_store_failed + excluded.cache_store_failed,
+    cache_hit_bytes = proxy_request_rollup_minutes.cache_hit_bytes + excluded.cache_hit_bytes,
+    cache_stored_bytes = proxy_request_rollup_minutes.cache_stored_bytes + excluded.cache_stored_bytes,
+    updated_at = CURRENT_TIMESTAMP
+`
+
+type BackfillProxyRequestRollupMinutesRangeParams struct {
+	FromID    int64 `json:"from_id"`
+	ThroughID int64 `json:"through_id"`
+}
+
+func (q *Queries) BackfillProxyRequestRollupMinutesRange(ctx context.Context, arg BackfillProxyRequestRollupMinutesRangeParams) error {
+	_, err := q.db.ExecContext(ctx, backfillProxyRequestRollupMinutesRange, arg.FromID, arg.ThroughID)
+	return err
+}
+
+const backfillProxyRequestTupleRollupMinutesRange = `-- name: BackfillProxyRequestTupleRollupMinutesRange :exec
+INSERT INTO proxy_request_tuple_rollup_minutes (
+    bucket_unix_millis, listener_id, backend_id, route_id, agent_id, error_kind, status_class,
+    requests, success, client_error, server_error, internal_error, duration_ms_sum,
+    request_bytes, response_bytes
+)
+SELECT
+    CAST((unixepoch(occurred_at) / 60) * 60 * 1000 AS INTEGER) AS bucket_unix_millis,
+    CAST(COALESCE(listener_id, 0) AS INTEGER) AS listener_id,
+    CAST(COALESCE(backend_id, 0) AS INTEGER) AS backend_id,
+    CAST(COALESCE(route_id, 0) AS INTEGER) AS route_id,
+    CAST(COALESCE(agent_id, 0) AS INTEGER) AS agent_id,
+    error_kind,
+    CAST(CASE WHEN status_code >= 200 AND status_code < 600 THEN status_code / 100 ELSE 0 END AS INTEGER) AS status_class,
+    COUNT(*) AS requests,
+    CAST(COALESCE(SUM(CASE WHEN status_code >= 200 AND status_code < 400 THEN 1 ELSE 0 END), 0) AS INTEGER) AS success,
+    CAST(COALESCE(SUM(CASE WHEN status_code >= 400 AND status_code < 500 THEN 1 ELSE 0 END), 0) AS INTEGER) AS client_error,
+    CAST(COALESCE(SUM(CASE WHEN status_code >= 500 THEN 1 ELSE 0 END), 0) AS INTEGER) AS server_error,
+    CAST(COALESCE(SUM(CASE WHEN error_kind != '' THEN 1 ELSE 0 END), 0) AS INTEGER) AS internal_error,
+    CAST(COALESCE(SUM(duration_ms), 0) AS INTEGER) AS duration_ms_sum,
+    CAST(COALESCE(SUM(request_bytes), 0) AS INTEGER) AS request_bytes,
+    CAST(COALESCE(SUM(response_bytes), 0) AS INTEGER) AS response_bytes
+FROM proxy_request_events
+WHERE id > ?1
+  AND id <= ?2
+GROUP BY bucket_unix_millis, listener_id, backend_id, route_id, agent_id, error_kind, status_class
+ON CONFLICT(bucket_unix_millis, listener_id, backend_id, route_id, agent_id, error_kind, status_class) DO UPDATE SET
+    requests = proxy_request_tuple_rollup_minutes.requests + excluded.requests,
+    success = proxy_request_tuple_rollup_minutes.success + excluded.success,
+    client_error = proxy_request_tuple_rollup_minutes.client_error + excluded.client_error,
+    server_error = proxy_request_tuple_rollup_minutes.server_error + excluded.server_error,
+    internal_error = proxy_request_tuple_rollup_minutes.internal_error + excluded.internal_error,
+    duration_ms_sum = proxy_request_tuple_rollup_minutes.duration_ms_sum + excluded.duration_ms_sum,
+    request_bytes = proxy_request_tuple_rollup_minutes.request_bytes + excluded.request_bytes,
+    response_bytes = proxy_request_tuple_rollup_minutes.response_bytes + excluded.response_bytes,
+    updated_at = CURRENT_TIMESTAMP
+`
+
+type BackfillProxyRequestTupleRollupMinutesRangeParams struct {
+	FromID    int64 `json:"from_id"`
+	ThroughID int64 `json:"through_id"`
+}
+
+func (q *Queries) BackfillProxyRequestTupleRollupMinutesRange(ctx context.Context, arg BackfillProxyRequestTupleRollupMinutesRangeParams) error {
+	_, err := q.db.ExecContext(ctx, backfillProxyRequestTupleRollupMinutesRange, arg.FromID, arg.ThroughID)
+	return err
+}
+
 const clearEnvironmentTrust = `-- name: ClearEnvironmentTrust :one
 UPDATE environments
 SET trusted_certificate_pem = '',
@@ -1318,6 +1479,16 @@ func (q *Queries) DeleteAgent(ctx context.Context, id int64) error {
 	return err
 }
 
+const deleteAgentStatRollupsBefore = `-- name: DeleteAgentStatRollupsBefore :exec
+DELETE FROM agent_stat_rollup_minutes
+WHERE bucket_unix_millis < ?
+`
+
+func (q *Queries) DeleteAgentStatRollupsBefore(ctx context.Context, bucketUnixMillis int64) error {
+	_, err := q.db.ExecContext(ctx, deleteAgentStatRollupsBefore, bucketUnixMillis)
+	return err
+}
+
 const deleteAgentStatsBefore = `-- name: DeleteAgentStatsBefore :exec
 DELETE FROM agent_stats
 WHERE reported_at < ?
@@ -1394,34 +1565,60 @@ func (q *Queries) DeleteManagementAccessToken(ctx context.Context, id int64) err
 	return err
 }
 
-const deleteOldestAgentStatsOverLimit = `-- name: DeleteOldestAgentStatsOverLimit :exec
+const deleteOldestAgentStatsOverLimit = `-- name: DeleteOldestAgentStatsOverLimit :execrows
 DELETE FROM agent_stats
 WHERE id IN (
     SELECT id
-    FROM agent_stats
-    ORDER BY reported_at DESC, id DESC
-    LIMIT -1 OFFSET ?
+    FROM (
+        SELECT id
+        FROM agent_stats
+        ORDER BY reported_at DESC, id DESC
+        LIMIT -1 OFFSET ?1
+    )
+    ORDER BY id ASC
+    LIMIT ?2
 )
 `
 
-func (q *Queries) DeleteOldestAgentStatsOverLimit(ctx context.Context, offset int64) error {
-	_, err := q.db.ExecContext(ctx, deleteOldestAgentStatsOverLimit, offset)
-	return err
+type DeleteOldestAgentStatsOverLimitParams struct {
+	Offset      int64 `json:"offset"`
+	DeleteLimit int64 `json:"delete_limit"`
 }
 
-const deleteOldestProxyRequestEventsOverLimit = `-- name: DeleteOldestProxyRequestEventsOverLimit :exec
+func (q *Queries) DeleteOldestAgentStatsOverLimit(ctx context.Context, arg DeleteOldestAgentStatsOverLimitParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteOldestAgentStatsOverLimit, arg.Offset, arg.DeleteLimit)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const deleteOldestProxyRequestEventsOverLimit = `-- name: DeleteOldestProxyRequestEventsOverLimit :execrows
 DELETE FROM proxy_request_events
 WHERE id IN (
     SELECT id
-    FROM proxy_request_events
-    ORDER BY occurred_at DESC, id DESC
-    LIMIT -1 OFFSET ?
+    FROM (
+        SELECT id
+        FROM proxy_request_events
+        ORDER BY occurred_at DESC, id DESC
+        LIMIT -1 OFFSET ?1
+    )
+    ORDER BY id ASC
+    LIMIT ?2
 )
 `
 
-func (q *Queries) DeleteOldestProxyRequestEventsOverLimit(ctx context.Context, offset int64) error {
-	_, err := q.db.ExecContext(ctx, deleteOldestProxyRequestEventsOverLimit, offset)
-	return err
+type DeleteOldestProxyRequestEventsOverLimitParams struct {
+	Offset      int64 `json:"offset"`
+	DeleteLimit int64 `json:"delete_limit"`
+}
+
+func (q *Queries) DeleteOldestProxyRequestEventsOverLimit(ctx context.Context, arg DeleteOldestProxyRequestEventsOverLimitParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteOldestProxyRequestEventsOverLimit, arg.Offset, arg.DeleteLimit)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const deleteProxyRequestEventsBefore = `-- name: DeleteProxyRequestEventsBefore :exec
@@ -1431,6 +1628,26 @@ WHERE occurred_at < ?
 
 func (q *Queries) DeleteProxyRequestEventsBefore(ctx context.Context, occurredAt time.Time) error {
 	_, err := q.db.ExecContext(ctx, deleteProxyRequestEventsBefore, occurredAt)
+	return err
+}
+
+const deleteProxyRequestRollupsBefore = `-- name: DeleteProxyRequestRollupsBefore :exec
+DELETE FROM proxy_request_rollup_minutes
+WHERE bucket_unix_millis < ?
+`
+
+func (q *Queries) DeleteProxyRequestRollupsBefore(ctx context.Context, bucketUnixMillis int64) error {
+	_, err := q.db.ExecContext(ctx, deleteProxyRequestRollupsBefore, bucketUnixMillis)
+	return err
+}
+
+const deleteProxyRequestTupleRollupsBefore = `-- name: DeleteProxyRequestTupleRollupsBefore :exec
+DELETE FROM proxy_request_tuple_rollup_minutes
+WHERE bucket_unix_millis < ?
+`
+
+func (q *Queries) DeleteProxyRequestTupleRollupsBefore(ctx context.Context, bucketUnixMillis int64) error {
+	_, err := q.db.ExecContext(ctx, deleteProxyRequestTupleRollupsBefore, bucketUnixMillis)
 	return err
 }
 
@@ -1728,6 +1945,62 @@ func (q *Queries) GetAgentByPublicID(ctx context.Context, publicID string) (Agen
 	return i, err
 }
 
+const getAgentStatsRollupSummarySince = `-- name: GetAgentStatsRollupSummarySince :one
+SELECT
+    CAST(COALESCE(SUM(samples), 0) AS INTEGER) AS samples,
+    CAST(COALESCE(SUM(req_success), 0) AS INTEGER) AS req_success,
+    CAST(COALESCE(SUM(req_client_error), 0) AS INTEGER) AS req_client_error,
+    CAST(COALESCE(SUM(req_server_error), 0) AS INTEGER) AS req_server_error,
+    CAST(COALESCE(SUM(req_internal_error), 0) AS INTEGER) AS req_internal_error,
+    CAST(COALESCE(SUM(bytes_rx), 0) AS INTEGER) AS bytes_rx,
+    CAST(COALESCE(SUM(bytes_tx), 0) AS INTEGER) AS bytes_tx,
+    CAST(CASE WHEN COALESCE(SUM(samples), 0) > 0 THEN COALESCE(SUM(memory_mb_sum), 0) / SUM(samples) ELSE 0 END AS INTEGER) AS avg_memory_mb,
+    CAST(COALESCE(MAX(max_memory_mb), 0) AS INTEGER) AS max_memory_mb,
+    CAST(CASE WHEN COALESCE(SUM(samples), 0) > 0 THEN COALESCE(SUM(goroutines_sum), 0) / SUM(samples) ELSE 0 END AS INTEGER) AS avg_goroutines,
+    CAST(COALESCE(MAX(max_goroutines), 0) AS INTEGER) AS max_goroutines,
+    CAST(CASE WHEN COALESCE(SUM(samples), 0) > 0 THEN COALESCE(SUM(cpu_percent_sum), 0) / SUM(samples) ELSE 0 END AS REAL) AS avg_cpu_percent,
+    CAST(COALESCE(MAX(max_cpu_percent), 0) AS REAL) AS max_cpu_percent
+FROM agent_stat_rollup_minutes
+WHERE bucket_unix_millis >= ?
+`
+
+type GetAgentStatsRollupSummarySinceRow struct {
+	Samples          int64   `json:"samples"`
+	ReqSuccess       int64   `json:"req_success"`
+	ReqClientError   int64   `json:"req_client_error"`
+	ReqServerError   int64   `json:"req_server_error"`
+	ReqInternalError int64   `json:"req_internal_error"`
+	BytesRx          int64   `json:"bytes_rx"`
+	BytesTx          int64   `json:"bytes_tx"`
+	AvgMemoryMb      int64   `json:"avg_memory_mb"`
+	MaxMemoryMb      int64   `json:"max_memory_mb"`
+	AvgGoroutines    int64   `json:"avg_goroutines"`
+	MaxGoroutines    int64   `json:"max_goroutines"`
+	AvgCpuPercent    float64 `json:"avg_cpu_percent"`
+	MaxCpuPercent    float64 `json:"max_cpu_percent"`
+}
+
+func (q *Queries) GetAgentStatsRollupSummarySince(ctx context.Context, bucketUnixMillis int64) (GetAgentStatsRollupSummarySinceRow, error) {
+	row := q.db.QueryRowContext(ctx, getAgentStatsRollupSummarySince, bucketUnixMillis)
+	var i GetAgentStatsRollupSummarySinceRow
+	err := row.Scan(
+		&i.Samples,
+		&i.ReqSuccess,
+		&i.ReqClientError,
+		&i.ReqServerError,
+		&i.ReqInternalError,
+		&i.BytesRx,
+		&i.BytesTx,
+		&i.AvgMemoryMb,
+		&i.MaxMemoryMb,
+		&i.AvgGoroutines,
+		&i.MaxGoroutines,
+		&i.AvgCpuPercent,
+		&i.MaxCpuPercent,
+	)
+	return i, err
+}
+
 const getAgentStatsSummarySince = `-- name: GetAgentStatsSummarySince :one
 SELECT
     COUNT(*) AS samples,
@@ -1891,6 +2164,154 @@ func (q *Queries) GetLatestAgentStatByAgent(ctx context.Context, agentID sql.Nul
 		&i.BytesRx,
 		&i.BytesTx,
 		&i.CpuPercent,
+	)
+	return i, err
+}
+
+const getNextAgentRollupBackfillThroughID = `-- name: GetNextAgentRollupBackfillThroughID :one
+SELECT CAST(COALESCE(MAX(id), ?1) AS INTEGER) AS through_id
+FROM (
+    SELECT id
+    FROM agent_stats
+    WHERE id > ?1
+      AND id <= ?2
+    ORDER BY id ASC
+    LIMIT ?3
+)
+`
+
+type GetNextAgentRollupBackfillThroughIDParams struct {
+	CurrentID int64 `json:"current_id"`
+	UpperID   int64 `json:"upper_id"`
+	BatchSize int64 `json:"batch_size"`
+}
+
+func (q *Queries) GetNextAgentRollupBackfillThroughID(ctx context.Context, arg GetNextAgentRollupBackfillThroughIDParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, getNextAgentRollupBackfillThroughID, arg.CurrentID, arg.UpperID, arg.BatchSize)
+	var through_id int64
+	err := row.Scan(&through_id)
+	return through_id, err
+}
+
+const getNextProxyRollupBackfillThroughID = `-- name: GetNextProxyRollupBackfillThroughID :one
+SELECT CAST(COALESCE(MAX(id), ?1) AS INTEGER) AS through_id
+FROM (
+    SELECT id
+    FROM proxy_request_events
+    WHERE id > ?1
+      AND id <= ?2
+    ORDER BY id ASC
+    LIMIT ?3
+)
+`
+
+type GetNextProxyRollupBackfillThroughIDParams struct {
+	CurrentID int64 `json:"current_id"`
+	UpperID   int64 `json:"upper_id"`
+	BatchSize int64 `json:"batch_size"`
+}
+
+func (q *Queries) GetNextProxyRollupBackfillThroughID(ctx context.Context, arg GetNextProxyRollupBackfillThroughIDParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, getNextProxyRollupBackfillThroughID, arg.CurrentID, arg.UpperID, arg.BatchSize)
+	var through_id int64
+	err := row.Scan(&through_id)
+	return through_id, err
+}
+
+const getObservabilityRollupState = `-- name: GetObservabilityRollupState :one
+SELECT id, proxy_backfill_upper_id, proxy_backfilled_through_id, agent_backfill_upper_id, agent_backfilled_through_id, created_at, updated_at
+FROM observability_rollup_state
+WHERE id = 1
+`
+
+func (q *Queries) GetObservabilityRollupState(ctx context.Context) (ObservabilityRollupState, error) {
+	row := q.db.QueryRowContext(ctx, getObservabilityRollupState)
+	var i ObservabilityRollupState
+	err := row.Scan(
+		&i.ID,
+		&i.ProxyBackfillUpperID,
+		&i.ProxyBackfilledThroughID,
+		&i.AgentBackfillUpperID,
+		&i.AgentBackfilledThroughID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getProxyRequestRollupSummarySince = `-- name: GetProxyRequestRollupSummarySince :one
+SELECT
+    CAST(COALESCE(SUM(requests), 0) AS INTEGER) AS total_requests,
+    CAST(COALESCE(SUM(success), 0) AS INTEGER) AS success,
+    CAST(COALESCE(SUM(client_error), 0) AS INTEGER) AS client_error,
+    CAST(COALESCE(SUM(server_error), 0) AS INTEGER) AS server_error,
+    CAST(COALESCE(SUM(internal_error), 0) AS INTEGER) AS internal_error,
+    CAST(CASE WHEN COALESCE(SUM(requests), 0) > 0 THEN COALESCE(SUM(duration_ms_sum), 0) / SUM(requests) ELSE 0 END AS INTEGER) AS avg_duration_ms,
+    CAST(COALESCE(SUM(request_bytes), 0) AS INTEGER) AS request_bytes,
+    CAST(COALESCE(SUM(response_bytes), 0) AS INTEGER) AS response_bytes,
+    CAST(COALESCE(SUM(request_bytes + response_bytes), 0) AS INTEGER) AS total_bytes,
+    CAST(CASE WHEN COALESCE(SUM(requests), 0) > 0 THEN COALESCE(SUM(request_bytes), 0) / SUM(requests) ELSE 0 END AS INTEGER) AS avg_request_bytes,
+    CAST(CASE WHEN COALESCE(SUM(requests), 0) > 0 THEN COALESCE(SUM(response_bytes), 0) / SUM(requests) ELSE 0 END AS INTEGER) AS avg_response_bytes,
+    CAST(COALESCE(MAX(max_duration_ms), 0) AS INTEGER) AS max_duration_ms,
+    CAST(COALESCE(SUM(slow_requests), 0) AS INTEGER) AS slow_requests,
+    CAST(COALESCE(SUM(cache_hits), 0) AS INTEGER) AS cache_hits,
+    CAST(COALESCE(SUM(cache_misses), 0) AS INTEGER) AS cache_misses,
+    CAST(COALESCE(SUM(cache_bypasses), 0) AS INTEGER) AS cache_bypasses,
+    CAST(COALESCE(SUM(cache_stored), 0) AS INTEGER) AS cache_stored,
+    CAST(COALESCE(SUM(cache_store_failed), 0) AS INTEGER) AS cache_store_failed,
+    CAST(COALESCE(SUM(cache_hit_bytes), 0) AS INTEGER) AS cache_hit_bytes,
+    CAST(COALESCE(SUM(cache_stored_bytes), 0) AS INTEGER) AS cache_stored_bytes
+FROM proxy_request_rollup_minutes
+WHERE bucket_unix_millis >= ?
+`
+
+type GetProxyRequestRollupSummarySinceRow struct {
+	TotalRequests    int64 `json:"total_requests"`
+	Success          int64 `json:"success"`
+	ClientError      int64 `json:"client_error"`
+	ServerError      int64 `json:"server_error"`
+	InternalError    int64 `json:"internal_error"`
+	AvgDurationMs    int64 `json:"avg_duration_ms"`
+	RequestBytes     int64 `json:"request_bytes"`
+	ResponseBytes    int64 `json:"response_bytes"`
+	TotalBytes       int64 `json:"total_bytes"`
+	AvgRequestBytes  int64 `json:"avg_request_bytes"`
+	AvgResponseBytes int64 `json:"avg_response_bytes"`
+	MaxDurationMs    int64 `json:"max_duration_ms"`
+	SlowRequests     int64 `json:"slow_requests"`
+	CacheHits        int64 `json:"cache_hits"`
+	CacheMisses      int64 `json:"cache_misses"`
+	CacheBypasses    int64 `json:"cache_bypasses"`
+	CacheStored      int64 `json:"cache_stored"`
+	CacheStoreFailed int64 `json:"cache_store_failed"`
+	CacheHitBytes    int64 `json:"cache_hit_bytes"`
+	CacheStoredBytes int64 `json:"cache_stored_bytes"`
+}
+
+func (q *Queries) GetProxyRequestRollupSummarySince(ctx context.Context, bucketUnixMillis int64) (GetProxyRequestRollupSummarySinceRow, error) {
+	row := q.db.QueryRowContext(ctx, getProxyRequestRollupSummarySince, bucketUnixMillis)
+	var i GetProxyRequestRollupSummarySinceRow
+	err := row.Scan(
+		&i.TotalRequests,
+		&i.Success,
+		&i.ClientError,
+		&i.ServerError,
+		&i.InternalError,
+		&i.AvgDurationMs,
+		&i.RequestBytes,
+		&i.ResponseBytes,
+		&i.TotalBytes,
+		&i.AvgRequestBytes,
+		&i.AvgResponseBytes,
+		&i.MaxDurationMs,
+		&i.SlowRequests,
+		&i.CacheHits,
+		&i.CacheMisses,
+		&i.CacheBypasses,
+		&i.CacheStored,
+		&i.CacheStoreFailed,
+		&i.CacheHitBytes,
+		&i.CacheStoredBytes,
 	)
 	return i, err
 }
@@ -2496,6 +2917,48 @@ func (q *Queries) InsertAgentStat(ctx context.Context, arg InsertAgentStatParams
 	return err
 }
 
+const insertAgentStatAt = `-- name: InsertAgentStatAt :one
+INSERT INTO agent_stats (
+    reported_at, agent_id, memory_mb, goroutines, req_success, req_client_error, req_server_error, req_internal_error, bytes_rx, bytes_tx, cpu_percent
+) VALUES (
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+)
+RETURNING id
+`
+
+type InsertAgentStatAtParams struct {
+	ReportedAt       time.Time     `json:"reported_at"`
+	AgentID          sql.NullInt64 `json:"agent_id"`
+	MemoryMb         int64         `json:"memory_mb"`
+	Goroutines       int64         `json:"goroutines"`
+	ReqSuccess       int64         `json:"req_success"`
+	ReqClientError   int64         `json:"req_client_error"`
+	ReqServerError   int64         `json:"req_server_error"`
+	ReqInternalError int64         `json:"req_internal_error"`
+	BytesRx          int64         `json:"bytes_rx"`
+	BytesTx          int64         `json:"bytes_tx"`
+	CpuPercent       float64       `json:"cpu_percent"`
+}
+
+func (q *Queries) InsertAgentStatAt(ctx context.Context, arg InsertAgentStatAtParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, insertAgentStatAt,
+		arg.ReportedAt,
+		arg.AgentID,
+		arg.MemoryMb,
+		arg.Goroutines,
+		arg.ReqSuccess,
+		arg.ReqClientError,
+		arg.ReqServerError,
+		arg.ReqInternalError,
+		arg.BytesRx,
+		arg.BytesTx,
+		arg.CpuPercent,
+	)
+	var id int64
+	err := row.Scan(&id)
+	return id, err
+}
+
 const insertConnection = `-- name: InsertConnection :one
 INSERT INTO connections (agent_id, connected_at)
 VALUES (?, CURRENT_TIMESTAMP)
@@ -2552,6 +3015,56 @@ func (q *Queries) InsertProxyRequestEvent(ctx context.Context, arg InsertProxyRe
 		arg.CacheBytes,
 	)
 	return err
+}
+
+const insertProxyRequestEventAt = `-- name: InsertProxyRequestEventAt :one
+INSERT INTO proxy_request_events (
+    occurred_at, status_code, duration_ms, error_kind, listener_id, backend_id, route_id, waf_rule_id, waf_action, agent_id, request_bytes, response_bytes, cache_rule_id, cache_status, cache_bytes
+) VALUES (
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+)
+RETURNING id
+`
+
+type InsertProxyRequestEventAtParams struct {
+	OccurredAt    time.Time     `json:"occurred_at"`
+	StatusCode    int64         `json:"status_code"`
+	DurationMs    int64         `json:"duration_ms"`
+	ErrorKind     string        `json:"error_kind"`
+	ListenerID    sql.NullInt64 `json:"listener_id"`
+	BackendID     sql.NullInt64 `json:"backend_id"`
+	RouteID       sql.NullInt64 `json:"route_id"`
+	WafRuleID     sql.NullInt64 `json:"waf_rule_id"`
+	WafAction     string        `json:"waf_action"`
+	AgentID       sql.NullInt64 `json:"agent_id"`
+	RequestBytes  int64         `json:"request_bytes"`
+	ResponseBytes int64         `json:"response_bytes"`
+	CacheRuleID   sql.NullInt64 `json:"cache_rule_id"`
+	CacheStatus   string        `json:"cache_status"`
+	CacheBytes    int64         `json:"cache_bytes"`
+}
+
+func (q *Queries) InsertProxyRequestEventAt(ctx context.Context, arg InsertProxyRequestEventAtParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, insertProxyRequestEventAt,
+		arg.OccurredAt,
+		arg.StatusCode,
+		arg.DurationMs,
+		arg.ErrorKind,
+		arg.ListenerID,
+		arg.BackendID,
+		arg.RouteID,
+		arg.WafRuleID,
+		arg.WafAction,
+		arg.AgentID,
+		arg.RequestBytes,
+		arg.ResponseBytes,
+		arg.CacheRuleID,
+		arg.CacheStatus,
+		arg.CacheBytes,
+	)
+	var id int64
+	err := row.Scan(&id)
+	return id, err
 }
 
 const listAgents = `-- name: ListAgents :many
@@ -2683,6 +3196,73 @@ func (q *Queries) ListManagementAccessTokens(ctx context.Context) ([]ManagementA
 	return items, nil
 }
 
+const listProxyStatusClassesRollupsSince = `-- name: ListProxyStatusClassesRollupsSince :many
+SELECT
+    r.status_class AS id,
+    CAST(r.status_class AS TEXT) || 'xx' AS label,
+    CAST(COALESCE(SUM(r.requests), 0) AS INTEGER) AS requests,
+    CAST(COALESCE(SUM(r.success), 0) AS INTEGER) AS success,
+    CAST(COALESCE(SUM(r.client_error), 0) AS INTEGER) AS client_error,
+    CAST(COALESCE(SUM(r.server_error), 0) AS INTEGER) AS server_error,
+    CAST(COALESCE(SUM(r.internal_error), 0) AS INTEGER) AS internal_error,
+    CAST(CASE WHEN COALESCE(SUM(r.requests), 0) > 0 THEN COALESCE(SUM(r.duration_ms_sum), 0) / SUM(r.requests) ELSE 0 END AS INTEGER) AS avg_duration_ms,
+    CAST(COALESCE(SUM(r.request_bytes), 0) AS INTEGER) AS request_bytes,
+    CAST(COALESCE(SUM(r.response_bytes), 0) AS INTEGER) AS response_bytes
+FROM proxy_request_tuple_rollup_minutes r
+WHERE r.bucket_unix_millis >= ?
+  AND r.status_class >= 2
+  AND r.status_class < 6
+GROUP BY r.status_class
+ORDER BY id ASC
+`
+
+type ListProxyStatusClassesRollupsSinceRow struct {
+	ID            int64       `json:"id"`
+	Label         interface{} `json:"label"`
+	Requests      int64       `json:"requests"`
+	Success       int64       `json:"success"`
+	ClientError   int64       `json:"client_error"`
+	ServerError   int64       `json:"server_error"`
+	InternalError int64       `json:"internal_error"`
+	AvgDurationMs int64       `json:"avg_duration_ms"`
+	RequestBytes  int64       `json:"request_bytes"`
+	ResponseBytes int64       `json:"response_bytes"`
+}
+
+func (q *Queries) ListProxyStatusClassesRollupsSince(ctx context.Context, bucketUnixMillis int64) ([]ListProxyStatusClassesRollupsSinceRow, error) {
+	rows, err := q.db.QueryContext(ctx, listProxyStatusClassesRollupsSince, bucketUnixMillis)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListProxyStatusClassesRollupsSinceRow
+	for rows.Next() {
+		var i ListProxyStatusClassesRollupsSinceRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Label,
+			&i.Requests,
+			&i.Success,
+			&i.ClientError,
+			&i.ServerError,
+			&i.InternalError,
+			&i.AvgDurationMs,
+			&i.RequestBytes,
+			&i.ResponseBytes,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listProxyStatusClassesSince = `-- name: ListProxyStatusClassesSince :many
 SELECT
     CAST(status_code / 100 AS INTEGER) AS id,
@@ -2695,7 +3275,7 @@ SELECT
     CAST(COALESCE(AVG(duration_ms), 0) AS INTEGER) AS avg_duration_ms,
     CAST(COALESCE(SUM(request_bytes), 0) AS INTEGER) AS request_bytes,
     CAST(COALESCE(SUM(response_bytes), 0) AS INTEGER) AS response_bytes
-FROM proxy_request_events
+FROM proxy_request_events INDEXED BY idx_proxy_request_events_occurred_at
 WHERE occurred_at >= ?
   AND status_code >= 200
   AND status_code < 600
@@ -2750,6 +3330,73 @@ func (q *Queries) ListProxyStatusClassesSince(ctx context.Context, occurredAt ti
 	return items, nil
 }
 
+const listProxyTrafficBucketRollupsSince = `-- name: ListProxyTrafficBucketRollupsSince :many
+SELECT
+    CAST((bucket_unix_millis / (CAST(?1 AS INTEGER) * 1000)) * (CAST(?1 AS INTEGER) * 1000) AS INTEGER) AS bucket_unix_millis,
+    CAST(COALESCE(SUM(requests), 0) AS INTEGER) AS requests,
+    CAST(COALESCE(SUM(success), 0) AS INTEGER) AS success,
+    CAST(COALESCE(SUM(client_error), 0) AS INTEGER) AS client_error,
+    CAST(COALESCE(SUM(server_error), 0) AS INTEGER) AS server_error,
+    CAST(COALESCE(SUM(internal_error), 0) AS INTEGER) AS internal_error,
+    CAST(COALESCE(SUM(request_bytes), 0) AS INTEGER) AS request_bytes,
+    CAST(COALESCE(SUM(response_bytes), 0) AS INTEGER) AS response_bytes,
+    CAST(CASE WHEN COALESCE(SUM(requests), 0) > 0 THEN COALESCE(SUM(duration_ms_sum), 0) / SUM(requests) ELSE 0 END AS INTEGER) AS avg_duration_ms
+FROM proxy_request_rollup_minutes
+WHERE bucket_unix_millis >= ?2
+GROUP BY 1
+ORDER BY bucket_unix_millis ASC
+`
+
+type ListProxyTrafficBucketRollupsSinceParams struct {
+	BucketSeconds   int64 `json:"bucket_seconds"`
+	SinceUnixMillis int64 `json:"since_unix_millis"`
+}
+
+type ListProxyTrafficBucketRollupsSinceRow struct {
+	BucketUnixMillis int64 `json:"bucket_unix_millis"`
+	Requests         int64 `json:"requests"`
+	Success          int64 `json:"success"`
+	ClientError      int64 `json:"client_error"`
+	ServerError      int64 `json:"server_error"`
+	InternalError    int64 `json:"internal_error"`
+	RequestBytes     int64 `json:"request_bytes"`
+	ResponseBytes    int64 `json:"response_bytes"`
+	AvgDurationMs    int64 `json:"avg_duration_ms"`
+}
+
+func (q *Queries) ListProxyTrafficBucketRollupsSince(ctx context.Context, arg ListProxyTrafficBucketRollupsSinceParams) ([]ListProxyTrafficBucketRollupsSinceRow, error) {
+	rows, err := q.db.QueryContext(ctx, listProxyTrafficBucketRollupsSince, arg.BucketSeconds, arg.SinceUnixMillis)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListProxyTrafficBucketRollupsSinceRow
+	for rows.Next() {
+		var i ListProxyTrafficBucketRollupsSinceRow
+		if err := rows.Scan(
+			&i.BucketUnixMillis,
+			&i.Requests,
+			&i.Success,
+			&i.ClientError,
+			&i.ServerError,
+			&i.InternalError,
+			&i.RequestBytes,
+			&i.ResponseBytes,
+			&i.AvgDurationMs,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listProxyTrafficBucketsSince = `-- name: ListProxyTrafficBucketsSince :many
 SELECT
     CAST((unixepoch(occurred_at) / CAST(?1 AS INTEGER)) * CAST(?1 AS INTEGER) * 1000 AS INTEGER) AS bucket_unix_millis,
@@ -2761,7 +3408,7 @@ SELECT
     CAST(COALESCE(SUM(request_bytes), 0) AS INTEGER) AS request_bytes,
     CAST(COALESCE(SUM(response_bytes), 0) AS INTEGER) AS response_bytes,
     CAST(COALESCE(AVG(duration_ms), 0) AS INTEGER) AS avg_duration_ms
-FROM proxy_request_events
+FROM proxy_request_events INDEXED BY idx_proxy_request_events_occurred_at
 WHERE occurred_at >= ?2
 GROUP BY bucket_unix_millis
 ORDER BY bucket_unix_millis ASC
@@ -3758,6 +4405,74 @@ func (q *Queries) ListPublicWafRules(ctx context.Context) ([]PublicWafRule, erro
 	return items, nil
 }
 
+const listTopProxyAgentsRollupsSince = `-- name: ListTopProxyAgentsRollupsSince :many
+SELECT
+    r.agent_id AS id,
+    COALESCE(a.name, 'agent #' || r.agent_id) AS label,
+    CAST(COALESCE(SUM(r.requests), 0) AS INTEGER) AS requests,
+    CAST(COALESCE(SUM(r.success), 0) AS INTEGER) AS success,
+    CAST(COALESCE(SUM(r.client_error), 0) AS INTEGER) AS client_error,
+    CAST(COALESCE(SUM(r.server_error), 0) AS INTEGER) AS server_error,
+    CAST(COALESCE(SUM(r.internal_error), 0) AS INTEGER) AS internal_error,
+    CAST(CASE WHEN COALESCE(SUM(r.requests), 0) > 0 THEN COALESCE(SUM(r.duration_ms_sum), 0) / SUM(r.requests) ELSE 0 END AS INTEGER) AS avg_duration_ms,
+    CAST(COALESCE(SUM(r.request_bytes), 0) AS INTEGER) AS request_bytes,
+    CAST(COALESCE(SUM(r.response_bytes), 0) AS INTEGER) AS response_bytes
+FROM proxy_request_tuple_rollup_minutes r
+LEFT JOIN agents a ON a.id = r.agent_id
+WHERE r.bucket_unix_millis >= ?
+  AND r.agent_id != 0
+GROUP BY r.agent_id, a.name
+ORDER BY requests DESC, id ASC
+LIMIT 5
+`
+
+type ListTopProxyAgentsRollupsSinceRow struct {
+	ID            int64  `json:"id"`
+	Label         string `json:"label"`
+	Requests      int64  `json:"requests"`
+	Success       int64  `json:"success"`
+	ClientError   int64  `json:"client_error"`
+	ServerError   int64  `json:"server_error"`
+	InternalError int64  `json:"internal_error"`
+	AvgDurationMs int64  `json:"avg_duration_ms"`
+	RequestBytes  int64  `json:"request_bytes"`
+	ResponseBytes int64  `json:"response_bytes"`
+}
+
+func (q *Queries) ListTopProxyAgentsRollupsSince(ctx context.Context, bucketUnixMillis int64) ([]ListTopProxyAgentsRollupsSinceRow, error) {
+	rows, err := q.db.QueryContext(ctx, listTopProxyAgentsRollupsSince, bucketUnixMillis)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListTopProxyAgentsRollupsSinceRow
+	for rows.Next() {
+		var i ListTopProxyAgentsRollupsSinceRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Label,
+			&i.Requests,
+			&i.Success,
+			&i.ClientError,
+			&i.ServerError,
+			&i.InternalError,
+			&i.AvgDurationMs,
+			&i.RequestBytes,
+			&i.ResponseBytes,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listTopProxyAgentsSince = `-- name: ListTopProxyAgentsSince :many
 SELECT
     CAST(pre.agent_id AS INTEGER) AS id,
@@ -3770,7 +4485,7 @@ SELECT
     CAST(COALESCE(AVG(pre.duration_ms), 0) AS INTEGER) AS avg_duration_ms,
     CAST(COALESCE(SUM(pre.request_bytes), 0) AS INTEGER) AS request_bytes,
     CAST(COALESCE(SUM(pre.response_bytes), 0) AS INTEGER) AS response_bytes
-FROM proxy_request_events pre
+FROM proxy_request_events AS pre INDEXED BY idx_proxy_request_events_occurred_at
 LEFT JOIN agents a ON a.id = pre.agent_id
 WHERE pre.occurred_at >= ?
   AND pre.agent_id IS NOT NULL
@@ -3826,6 +4541,73 @@ func (q *Queries) ListTopProxyAgentsSince(ctx context.Context, occurredAt time.T
 	return items, nil
 }
 
+const listTopProxyBackendsRollupsSince = `-- name: ListTopProxyBackendsRollupsSince :many
+SELECT
+    r.backend_id AS id,
+    COALESCE(pb.name, CASE WHEN r.backend_id = 0 THEN 'unknown backend' ELSE 'backend #' || r.backend_id END) AS label,
+    CAST(COALESCE(SUM(r.requests), 0) AS INTEGER) AS requests,
+    CAST(COALESCE(SUM(r.success), 0) AS INTEGER) AS success,
+    CAST(COALESCE(SUM(r.client_error), 0) AS INTEGER) AS client_error,
+    CAST(COALESCE(SUM(r.server_error), 0) AS INTEGER) AS server_error,
+    CAST(COALESCE(SUM(r.internal_error), 0) AS INTEGER) AS internal_error,
+    CAST(CASE WHEN COALESCE(SUM(r.requests), 0) > 0 THEN COALESCE(SUM(r.duration_ms_sum), 0) / SUM(r.requests) ELSE 0 END AS INTEGER) AS avg_duration_ms,
+    CAST(COALESCE(SUM(r.request_bytes), 0) AS INTEGER) AS request_bytes,
+    CAST(COALESCE(SUM(r.response_bytes), 0) AS INTEGER) AS response_bytes
+FROM proxy_request_tuple_rollup_minutes r
+LEFT JOIN public_backends pb ON pb.id = r.backend_id
+WHERE r.bucket_unix_millis >= ?
+GROUP BY r.backend_id, pb.name
+ORDER BY requests DESC, id ASC
+LIMIT 5
+`
+
+type ListTopProxyBackendsRollupsSinceRow struct {
+	ID            int64  `json:"id"`
+	Label         string `json:"label"`
+	Requests      int64  `json:"requests"`
+	Success       int64  `json:"success"`
+	ClientError   int64  `json:"client_error"`
+	ServerError   int64  `json:"server_error"`
+	InternalError int64  `json:"internal_error"`
+	AvgDurationMs int64  `json:"avg_duration_ms"`
+	RequestBytes  int64  `json:"request_bytes"`
+	ResponseBytes int64  `json:"response_bytes"`
+}
+
+func (q *Queries) ListTopProxyBackendsRollupsSince(ctx context.Context, bucketUnixMillis int64) ([]ListTopProxyBackendsRollupsSinceRow, error) {
+	rows, err := q.db.QueryContext(ctx, listTopProxyBackendsRollupsSince, bucketUnixMillis)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListTopProxyBackendsRollupsSinceRow
+	for rows.Next() {
+		var i ListTopProxyBackendsRollupsSinceRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Label,
+			&i.Requests,
+			&i.Success,
+			&i.ClientError,
+			&i.ServerError,
+			&i.InternalError,
+			&i.AvgDurationMs,
+			&i.RequestBytes,
+			&i.ResponseBytes,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listTopProxyBackendsSince = `-- name: ListTopProxyBackendsSince :many
 SELECT
     CAST(COALESCE(pre.backend_id, 0) AS INTEGER) AS id,
@@ -3838,7 +4620,7 @@ SELECT
     CAST(COALESCE(AVG(pre.duration_ms), 0) AS INTEGER) AS avg_duration_ms,
     CAST(COALESCE(SUM(pre.request_bytes), 0) AS INTEGER) AS request_bytes,
     CAST(COALESCE(SUM(pre.response_bytes), 0) AS INTEGER) AS response_bytes
-FROM proxy_request_events pre
+FROM proxy_request_events AS pre INDEXED BY idx_proxy_request_events_occurred_at
 LEFT JOIN public_backends pb ON pb.id = pre.backend_id
 WHERE pre.occurred_at >= ?
 GROUP BY pre.backend_id, pb.name
@@ -3893,6 +4675,73 @@ func (q *Queries) ListTopProxyBackendsSince(ctx context.Context, occurredAt time
 	return items, nil
 }
 
+const listTopProxyErrorKindsRollupsSince = `-- name: ListTopProxyErrorKindsRollupsSince :many
+SELECT
+    CAST(0 AS INTEGER) AS id,
+    r.error_kind AS label,
+    CAST(COALESCE(SUM(r.requests), 0) AS INTEGER) AS requests,
+    CAST(COALESCE(SUM(r.success), 0) AS INTEGER) AS success,
+    CAST(COALESCE(SUM(r.client_error), 0) AS INTEGER) AS client_error,
+    CAST(COALESCE(SUM(r.server_error), 0) AS INTEGER) AS server_error,
+    CAST(COALESCE(SUM(r.internal_error), 0) AS INTEGER) AS internal_error,
+    CAST(CASE WHEN COALESCE(SUM(r.requests), 0) > 0 THEN COALESCE(SUM(r.duration_ms_sum), 0) / SUM(r.requests) ELSE 0 END AS INTEGER) AS avg_duration_ms,
+    CAST(COALESCE(SUM(r.request_bytes), 0) AS INTEGER) AS request_bytes,
+    CAST(COALESCE(SUM(r.response_bytes), 0) AS INTEGER) AS response_bytes
+FROM proxy_request_tuple_rollup_minutes r
+WHERE r.bucket_unix_millis >= ?
+  AND r.error_kind != ''
+GROUP BY r.error_kind
+ORDER BY requests DESC, label ASC
+LIMIT 5
+`
+
+type ListTopProxyErrorKindsRollupsSinceRow struct {
+	ID            int64  `json:"id"`
+	Label         string `json:"label"`
+	Requests      int64  `json:"requests"`
+	Success       int64  `json:"success"`
+	ClientError   int64  `json:"client_error"`
+	ServerError   int64  `json:"server_error"`
+	InternalError int64  `json:"internal_error"`
+	AvgDurationMs int64  `json:"avg_duration_ms"`
+	RequestBytes  int64  `json:"request_bytes"`
+	ResponseBytes int64  `json:"response_bytes"`
+}
+
+func (q *Queries) ListTopProxyErrorKindsRollupsSince(ctx context.Context, bucketUnixMillis int64) ([]ListTopProxyErrorKindsRollupsSinceRow, error) {
+	rows, err := q.db.QueryContext(ctx, listTopProxyErrorKindsRollupsSince, bucketUnixMillis)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListTopProxyErrorKindsRollupsSinceRow
+	for rows.Next() {
+		var i ListTopProxyErrorKindsRollupsSinceRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Label,
+			&i.Requests,
+			&i.Success,
+			&i.ClientError,
+			&i.ServerError,
+			&i.InternalError,
+			&i.AvgDurationMs,
+			&i.RequestBytes,
+			&i.ResponseBytes,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listTopProxyErrorKindsSince = `-- name: ListTopProxyErrorKindsSince :many
 SELECT
     CAST(0 AS INTEGER) AS id,
@@ -3905,7 +4754,7 @@ SELECT
     CAST(COALESCE(AVG(duration_ms), 0) AS INTEGER) AS avg_duration_ms,
     CAST(COALESCE(SUM(request_bytes), 0) AS INTEGER) AS request_bytes,
     CAST(COALESCE(SUM(response_bytes), 0) AS INTEGER) AS response_bytes
-FROM proxy_request_events
+FROM proxy_request_events INDEXED BY idx_proxy_request_events_occurred_at
 WHERE occurred_at >= ?
   AND error_kind != ''
 GROUP BY error_kind
@@ -3960,6 +4809,73 @@ func (q *Queries) ListTopProxyErrorKindsSince(ctx context.Context, occurredAt ti
 	return items, nil
 }
 
+const listTopProxyListenersRollupsSince = `-- name: ListTopProxyListenersRollupsSince :many
+SELECT
+    r.listener_id AS id,
+    COALESCE(pl.name, CASE WHEN r.listener_id = 0 THEN 'unknown listener' ELSE 'listener #' || r.listener_id END) AS label,
+    CAST(COALESCE(SUM(r.requests), 0) AS INTEGER) AS requests,
+    CAST(COALESCE(SUM(r.success), 0) AS INTEGER) AS success,
+    CAST(COALESCE(SUM(r.client_error), 0) AS INTEGER) AS client_error,
+    CAST(COALESCE(SUM(r.server_error), 0) AS INTEGER) AS server_error,
+    CAST(COALESCE(SUM(r.internal_error), 0) AS INTEGER) AS internal_error,
+    CAST(CASE WHEN COALESCE(SUM(r.requests), 0) > 0 THEN COALESCE(SUM(r.duration_ms_sum), 0) / SUM(r.requests) ELSE 0 END AS INTEGER) AS avg_duration_ms,
+    CAST(COALESCE(SUM(r.request_bytes), 0) AS INTEGER) AS request_bytes,
+    CAST(COALESCE(SUM(r.response_bytes), 0) AS INTEGER) AS response_bytes
+FROM proxy_request_tuple_rollup_minutes r
+LEFT JOIN public_listeners pl ON pl.id = r.listener_id
+WHERE r.bucket_unix_millis >= ?
+GROUP BY r.listener_id, pl.name
+ORDER BY requests DESC, id ASC
+LIMIT 5
+`
+
+type ListTopProxyListenersRollupsSinceRow struct {
+	ID            int64  `json:"id"`
+	Label         string `json:"label"`
+	Requests      int64  `json:"requests"`
+	Success       int64  `json:"success"`
+	ClientError   int64  `json:"client_error"`
+	ServerError   int64  `json:"server_error"`
+	InternalError int64  `json:"internal_error"`
+	AvgDurationMs int64  `json:"avg_duration_ms"`
+	RequestBytes  int64  `json:"request_bytes"`
+	ResponseBytes int64  `json:"response_bytes"`
+}
+
+func (q *Queries) ListTopProxyListenersRollupsSince(ctx context.Context, bucketUnixMillis int64) ([]ListTopProxyListenersRollupsSinceRow, error) {
+	rows, err := q.db.QueryContext(ctx, listTopProxyListenersRollupsSince, bucketUnixMillis)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListTopProxyListenersRollupsSinceRow
+	for rows.Next() {
+		var i ListTopProxyListenersRollupsSinceRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Label,
+			&i.Requests,
+			&i.Success,
+			&i.ClientError,
+			&i.ServerError,
+			&i.InternalError,
+			&i.AvgDurationMs,
+			&i.RequestBytes,
+			&i.ResponseBytes,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listTopProxyListenersSince = `-- name: ListTopProxyListenersSince :many
 SELECT
     CAST(COALESCE(pre.listener_id, 0) AS INTEGER) AS id,
@@ -3972,7 +4888,7 @@ SELECT
     CAST(COALESCE(AVG(pre.duration_ms), 0) AS INTEGER) AS avg_duration_ms,
     CAST(COALESCE(SUM(pre.request_bytes), 0) AS INTEGER) AS request_bytes,
     CAST(COALESCE(SUM(pre.response_bytes), 0) AS INTEGER) AS response_bytes
-FROM proxy_request_events pre
+FROM proxy_request_events AS pre INDEXED BY idx_proxy_request_events_occurred_at
 LEFT JOIN public_listeners pl ON pl.id = pre.listener_id
 WHERE pre.occurred_at >= ?
 GROUP BY pre.listener_id, pl.name
@@ -4027,6 +4943,80 @@ func (q *Queries) ListTopProxyListenersSince(ctx context.Context, occurredAt tim
 	return items, nil
 }
 
+const listTopProxyRoutesRollupsSince = `-- name: ListTopProxyRoutesRollupsSince :many
+SELECT
+    r.route_id AS id,
+    CASE
+        WHEN r.route_id = 0 THEN 'Default route'
+        WHEN pr.id IS NULL THEN 'route #' || r.route_id
+        WHEN pr.host_pattern != '' AND pr.path_prefix != '' THEN pr.host_pattern || ' ' || pr.path_prefix
+        WHEN pr.host_pattern != '' THEN pr.host_pattern
+        WHEN pr.path_prefix != '' THEN pr.path_prefix
+        ELSE 'route #' || pr.id
+    END AS label,
+    CAST(COALESCE(SUM(r.requests), 0) AS INTEGER) AS requests,
+    CAST(COALESCE(SUM(r.success), 0) AS INTEGER) AS success,
+    CAST(COALESCE(SUM(r.client_error), 0) AS INTEGER) AS client_error,
+    CAST(COALESCE(SUM(r.server_error), 0) AS INTEGER) AS server_error,
+    CAST(COALESCE(SUM(r.internal_error), 0) AS INTEGER) AS internal_error,
+    CAST(CASE WHEN COALESCE(SUM(r.requests), 0) > 0 THEN COALESCE(SUM(r.duration_ms_sum), 0) / SUM(r.requests) ELSE 0 END AS INTEGER) AS avg_duration_ms,
+    CAST(COALESCE(SUM(r.request_bytes), 0) AS INTEGER) AS request_bytes,
+    CAST(COALESCE(SUM(r.response_bytes), 0) AS INTEGER) AS response_bytes
+FROM proxy_request_tuple_rollup_minutes r
+LEFT JOIN public_routes pr ON pr.id = r.route_id
+WHERE r.bucket_unix_millis >= ?
+GROUP BY r.route_id, pr.id, pr.host_pattern, pr.path_prefix
+ORDER BY requests DESC, id ASC
+LIMIT 5
+`
+
+type ListTopProxyRoutesRollupsSinceRow struct {
+	ID            int64       `json:"id"`
+	Label         interface{} `json:"label"`
+	Requests      int64       `json:"requests"`
+	Success       int64       `json:"success"`
+	ClientError   int64       `json:"client_error"`
+	ServerError   int64       `json:"server_error"`
+	InternalError int64       `json:"internal_error"`
+	AvgDurationMs int64       `json:"avg_duration_ms"`
+	RequestBytes  int64       `json:"request_bytes"`
+	ResponseBytes int64       `json:"response_bytes"`
+}
+
+func (q *Queries) ListTopProxyRoutesRollupsSince(ctx context.Context, bucketUnixMillis int64) ([]ListTopProxyRoutesRollupsSinceRow, error) {
+	rows, err := q.db.QueryContext(ctx, listTopProxyRoutesRollupsSince, bucketUnixMillis)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListTopProxyRoutesRollupsSinceRow
+	for rows.Next() {
+		var i ListTopProxyRoutesRollupsSinceRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Label,
+			&i.Requests,
+			&i.Success,
+			&i.ClientError,
+			&i.ServerError,
+			&i.InternalError,
+			&i.AvgDurationMs,
+			&i.RequestBytes,
+			&i.ResponseBytes,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listTopProxyRoutesSince = `-- name: ListTopProxyRoutesSince :many
 SELECT
     CAST(COALESCE(pre.route_id, 0) AS INTEGER) AS id,
@@ -4046,7 +5036,7 @@ SELECT
     CAST(COALESCE(AVG(pre.duration_ms), 0) AS INTEGER) AS avg_duration_ms,
     CAST(COALESCE(SUM(pre.request_bytes), 0) AS INTEGER) AS request_bytes,
     CAST(COALESCE(SUM(pre.response_bytes), 0) AS INTEGER) AS response_bytes
-FROM proxy_request_events pre
+FROM proxy_request_events AS pre INDEXED BY idx_proxy_request_events_occurred_at
 LEFT JOIN public_routes pr ON pr.id = pre.route_id
 WHERE pre.occurred_at >= ?
 GROUP BY pre.route_id, pr.id, pr.host_pattern, pr.path_prefix
@@ -4122,6 +5112,30 @@ WHERE id = ?
 
 func (q *Queries) MarkAgentDisconnected(ctx context.Context, id int64) error {
 	_, err := q.db.ExecContext(ctx, markAgentDisconnected, id)
+	return err
+}
+
+const markAgentRollupBackfilledThrough = `-- name: MarkAgentRollupBackfilledThrough :exec
+UPDATE observability_rollup_state
+SET agent_backfilled_through_id = ?,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = 1
+`
+
+func (q *Queries) MarkAgentRollupBackfilledThrough(ctx context.Context, agentBackfilledThroughID int64) error {
+	_, err := q.db.ExecContext(ctx, markAgentRollupBackfilledThrough, agentBackfilledThroughID)
+	return err
+}
+
+const markProxyRollupBackfilledThrough = `-- name: MarkProxyRollupBackfilledThrough :exec
+UPDATE observability_rollup_state
+SET proxy_backfilled_through_id = ?,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = 1
+`
+
+func (q *Queries) MarkProxyRollupBackfilledThrough(ctx context.Context, proxyBackfilledThroughID int64) error {
+	_, err := q.db.ExecContext(ctx, markProxyRollupBackfilledThrough, proxyBackfilledThroughID)
 	return err
 }
 
@@ -5684,6 +6698,68 @@ func (q *Queries) UpdateUserPassword(ctx context.Context, arg UpdateUserPassword
 	return i, err
 }
 
+const upsertAgentStatRollupMinute = `-- name: UpsertAgentStatRollupMinute :exec
+INSERT INTO agent_stat_rollup_minutes (
+    bucket_unix_millis, samples, req_success, req_client_error, req_server_error, req_internal_error,
+    bytes_rx, bytes_tx, memory_mb_sum, max_memory_mb, goroutines_sum, max_goroutines,
+    cpu_percent_sum, max_cpu_percent
+) VALUES (
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+)
+ON CONFLICT(bucket_unix_millis) DO UPDATE SET
+    samples = agent_stat_rollup_minutes.samples + excluded.samples,
+    req_success = agent_stat_rollup_minutes.req_success + excluded.req_success,
+    req_client_error = agent_stat_rollup_minutes.req_client_error + excluded.req_client_error,
+    req_server_error = agent_stat_rollup_minutes.req_server_error + excluded.req_server_error,
+    req_internal_error = agent_stat_rollup_minutes.req_internal_error + excluded.req_internal_error,
+    bytes_rx = agent_stat_rollup_minutes.bytes_rx + excluded.bytes_rx,
+    bytes_tx = agent_stat_rollup_minutes.bytes_tx + excluded.bytes_tx,
+    memory_mb_sum = agent_stat_rollup_minutes.memory_mb_sum + excluded.memory_mb_sum,
+    max_memory_mb = MAX(agent_stat_rollup_minutes.max_memory_mb, excluded.max_memory_mb),
+    goroutines_sum = agent_stat_rollup_minutes.goroutines_sum + excluded.goroutines_sum,
+    max_goroutines = MAX(agent_stat_rollup_minutes.max_goroutines, excluded.max_goroutines),
+    cpu_percent_sum = agent_stat_rollup_minutes.cpu_percent_sum + excluded.cpu_percent_sum,
+    max_cpu_percent = MAX(agent_stat_rollup_minutes.max_cpu_percent, excluded.max_cpu_percent),
+    updated_at = CURRENT_TIMESTAMP
+`
+
+type UpsertAgentStatRollupMinuteParams struct {
+	BucketUnixMillis int64   `json:"bucket_unix_millis"`
+	Samples          int64   `json:"samples"`
+	ReqSuccess       int64   `json:"req_success"`
+	ReqClientError   int64   `json:"req_client_error"`
+	ReqServerError   int64   `json:"req_server_error"`
+	ReqInternalError int64   `json:"req_internal_error"`
+	BytesRx          int64   `json:"bytes_rx"`
+	BytesTx          int64   `json:"bytes_tx"`
+	MemoryMbSum      int64   `json:"memory_mb_sum"`
+	MaxMemoryMb      int64   `json:"max_memory_mb"`
+	GoroutinesSum    int64   `json:"goroutines_sum"`
+	MaxGoroutines    int64   `json:"max_goroutines"`
+	CpuPercentSum    float64 `json:"cpu_percent_sum"`
+	MaxCpuPercent    float64 `json:"max_cpu_percent"`
+}
+
+func (q *Queries) UpsertAgentStatRollupMinute(ctx context.Context, arg UpsertAgentStatRollupMinuteParams) error {
+	_, err := q.db.ExecContext(ctx, upsertAgentStatRollupMinute,
+		arg.BucketUnixMillis,
+		arg.Samples,
+		arg.ReqSuccess,
+		arg.ReqClientError,
+		arg.ReqServerError,
+		arg.ReqInternalError,
+		arg.BytesRx,
+		arg.BytesTx,
+		arg.MemoryMbSum,
+		arg.MaxMemoryMb,
+		arg.GoroutinesSum,
+		arg.MaxGoroutines,
+		arg.CpuPercentSum,
+		arg.MaxCpuPercent,
+	)
+	return err
+}
+
 const upsertBootstrapAgent = `-- name: UpsertBootstrapAgent :one
 INSERT INTO agents (public_id, name, token_hash, enabled)
 VALUES (?, ?, ?, 1)
@@ -5716,6 +6792,140 @@ func (q *Queries) UpsertBootstrapAgent(ctx context.Context, arg UpsertBootstrapA
 		&i.UpdatedAt,
 	)
 	return i, err
+}
+
+const upsertProxyRequestRollupMinute = `-- name: UpsertProxyRequestRollupMinute :exec
+INSERT INTO proxy_request_rollup_minutes (
+    bucket_unix_millis, requests, success, client_error, server_error, internal_error,
+    duration_ms_sum, max_duration_ms, slow_requests, request_bytes, response_bytes,
+    cache_hits, cache_misses, cache_bypasses, cache_stored, cache_store_failed,
+    cache_hit_bytes, cache_stored_bytes
+) VALUES (
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+)
+ON CONFLICT(bucket_unix_millis) DO UPDATE SET
+    requests = proxy_request_rollup_minutes.requests + excluded.requests,
+    success = proxy_request_rollup_minutes.success + excluded.success,
+    client_error = proxy_request_rollup_minutes.client_error + excluded.client_error,
+    server_error = proxy_request_rollup_minutes.server_error + excluded.server_error,
+    internal_error = proxy_request_rollup_minutes.internal_error + excluded.internal_error,
+    duration_ms_sum = proxy_request_rollup_minutes.duration_ms_sum + excluded.duration_ms_sum,
+    max_duration_ms = MAX(proxy_request_rollup_minutes.max_duration_ms, excluded.max_duration_ms),
+    slow_requests = proxy_request_rollup_minutes.slow_requests + excluded.slow_requests,
+    request_bytes = proxy_request_rollup_minutes.request_bytes + excluded.request_bytes,
+    response_bytes = proxy_request_rollup_minutes.response_bytes + excluded.response_bytes,
+    cache_hits = proxy_request_rollup_minutes.cache_hits + excluded.cache_hits,
+    cache_misses = proxy_request_rollup_minutes.cache_misses + excluded.cache_misses,
+    cache_bypasses = proxy_request_rollup_minutes.cache_bypasses + excluded.cache_bypasses,
+    cache_stored = proxy_request_rollup_minutes.cache_stored + excluded.cache_stored,
+    cache_store_failed = proxy_request_rollup_minutes.cache_store_failed + excluded.cache_store_failed,
+    cache_hit_bytes = proxy_request_rollup_minutes.cache_hit_bytes + excluded.cache_hit_bytes,
+    cache_stored_bytes = proxy_request_rollup_minutes.cache_stored_bytes + excluded.cache_stored_bytes,
+    updated_at = CURRENT_TIMESTAMP
+`
+
+type UpsertProxyRequestRollupMinuteParams struct {
+	BucketUnixMillis int64 `json:"bucket_unix_millis"`
+	Requests         int64 `json:"requests"`
+	Success          int64 `json:"success"`
+	ClientError      int64 `json:"client_error"`
+	ServerError      int64 `json:"server_error"`
+	InternalError    int64 `json:"internal_error"`
+	DurationMsSum    int64 `json:"duration_ms_sum"`
+	MaxDurationMs    int64 `json:"max_duration_ms"`
+	SlowRequests     int64 `json:"slow_requests"`
+	RequestBytes     int64 `json:"request_bytes"`
+	ResponseBytes    int64 `json:"response_bytes"`
+	CacheHits        int64 `json:"cache_hits"`
+	CacheMisses      int64 `json:"cache_misses"`
+	CacheBypasses    int64 `json:"cache_bypasses"`
+	CacheStored      int64 `json:"cache_stored"`
+	CacheStoreFailed int64 `json:"cache_store_failed"`
+	CacheHitBytes    int64 `json:"cache_hit_bytes"`
+	CacheStoredBytes int64 `json:"cache_stored_bytes"`
+}
+
+func (q *Queries) UpsertProxyRequestRollupMinute(ctx context.Context, arg UpsertProxyRequestRollupMinuteParams) error {
+	_, err := q.db.ExecContext(ctx, upsertProxyRequestRollupMinute,
+		arg.BucketUnixMillis,
+		arg.Requests,
+		arg.Success,
+		arg.ClientError,
+		arg.ServerError,
+		arg.InternalError,
+		arg.DurationMsSum,
+		arg.MaxDurationMs,
+		arg.SlowRequests,
+		arg.RequestBytes,
+		arg.ResponseBytes,
+		arg.CacheHits,
+		arg.CacheMisses,
+		arg.CacheBypasses,
+		arg.CacheStored,
+		arg.CacheStoreFailed,
+		arg.CacheHitBytes,
+		arg.CacheStoredBytes,
+	)
+	return err
+}
+
+const upsertProxyRequestTupleRollupMinute = `-- name: UpsertProxyRequestTupleRollupMinute :exec
+INSERT INTO proxy_request_tuple_rollup_minutes (
+    bucket_unix_millis, listener_id, backend_id, route_id, agent_id, error_kind, status_class,
+    requests, success, client_error, server_error, internal_error, duration_ms_sum,
+    request_bytes, response_bytes
+) VALUES (
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+)
+ON CONFLICT(bucket_unix_millis, listener_id, backend_id, route_id, agent_id, error_kind, status_class) DO UPDATE SET
+    requests = proxy_request_tuple_rollup_minutes.requests + excluded.requests,
+    success = proxy_request_tuple_rollup_minutes.success + excluded.success,
+    client_error = proxy_request_tuple_rollup_minutes.client_error + excluded.client_error,
+    server_error = proxy_request_tuple_rollup_minutes.server_error + excluded.server_error,
+    internal_error = proxy_request_tuple_rollup_minutes.internal_error + excluded.internal_error,
+    duration_ms_sum = proxy_request_tuple_rollup_minutes.duration_ms_sum + excluded.duration_ms_sum,
+    request_bytes = proxy_request_tuple_rollup_minutes.request_bytes + excluded.request_bytes,
+    response_bytes = proxy_request_tuple_rollup_minutes.response_bytes + excluded.response_bytes,
+    updated_at = CURRENT_TIMESTAMP
+`
+
+type UpsertProxyRequestTupleRollupMinuteParams struct {
+	BucketUnixMillis int64  `json:"bucket_unix_millis"`
+	ListenerID       int64  `json:"listener_id"`
+	BackendID        int64  `json:"backend_id"`
+	RouteID          int64  `json:"route_id"`
+	AgentID          int64  `json:"agent_id"`
+	ErrorKind        string `json:"error_kind"`
+	StatusClass      int64  `json:"status_class"`
+	Requests         int64  `json:"requests"`
+	Success          int64  `json:"success"`
+	ClientError      int64  `json:"client_error"`
+	ServerError      int64  `json:"server_error"`
+	InternalError    int64  `json:"internal_error"`
+	DurationMsSum    int64  `json:"duration_ms_sum"`
+	RequestBytes     int64  `json:"request_bytes"`
+	ResponseBytes    int64  `json:"response_bytes"`
+}
+
+func (q *Queries) UpsertProxyRequestTupleRollupMinute(ctx context.Context, arg UpsertProxyRequestTupleRollupMinuteParams) error {
+	_, err := q.db.ExecContext(ctx, upsertProxyRequestTupleRollupMinute,
+		arg.BucketUnixMillis,
+		arg.ListenerID,
+		arg.BackendID,
+		arg.RouteID,
+		arg.AgentID,
+		arg.ErrorKind,
+		arg.StatusClass,
+		arg.Requests,
+		arg.Success,
+		arg.ClientError,
+		arg.ServerError,
+		arg.InternalError,
+		arg.DurationMsSum,
+		arg.RequestBytes,
+		arg.ResponseBytes,
+	)
+	return err
 }
 
 const upsertPublicCacheEntry = `-- name: UpsertPublicCacheEntry :one

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -45,11 +45,32 @@ func (a *App) GetDashboard(
 	}
 
 	now := time.Now().UTC()
-	a.cleanupObservability(ctx, now)
+	useRollups, err := a.observabilityRollupsReady(ctx)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
 
 	windows := make([]*p2pstreamv1.DashboardWindowSummary, 0, len(dashboardWindows))
 	for _, window := range dashboardWindows {
 		since := now.Add(-window.Since)
+		if useRollups {
+			sinceUnixMillis := rollupBucketUnixMillis(since)
+			proxySummary, err := a.DB.GetProxyRequestRollupSummarySince(ctx, sinceUnixMillis)
+			if err != nil {
+				return nil, connect.NewError(connect.CodeInternal, err)
+			}
+			agentSummary, err := a.DB.GetAgentStatsRollupSummarySince(ctx, sinceUnixMillis)
+			if err != nil {
+				return nil, connect.NewError(connect.CodeInternal, err)
+			}
+			windows = append(windows, dashboardWindowSummary(
+				window.Label,
+				sinceUnixMillis,
+				dashboardProxyWindowFromRollup(proxySummary),
+				dashboardAgentWindowFromRollup(agentSummary),
+			))
+			continue
+		}
 
 		proxySummary, err := a.DB.GetProxyRequestSummarySince(ctx, since)
 		if err != nil {
@@ -59,44 +80,12 @@ func (a *App) GetDashboard(
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, err)
 		}
-
-		windows = append(windows, &p2pstreamv1.DashboardWindowSummary{
-			Label:                 window.Label,
-			SinceUnixMillis:       since.UnixMilli(),
-			ProxyRequests:         proxySummary.TotalRequests,
-			ProxySuccess:          proxySummary.Success,
-			ProxyClientError:      proxySummary.ClientError,
-			ProxyServerError:      proxySummary.ServerError,
-			ProxyInternalError:    proxySummary.InternalError,
-			ProxyAvgDurationMs:    proxySummary.AvgDurationMs,
-			ProxyRequestBytes:     uint64FromInt64(proxySummary.RequestBytes),
-			ProxyResponseBytes:    uint64FromInt64(proxySummary.ResponseBytes),
-			ProxyTotalBytes:       uint64FromInt64(proxySummary.TotalBytes),
-			ProxyAvgRequestBytes:  uint64FromInt64(proxySummary.AvgRequestBytes),
-			ProxyAvgResponseBytes: uint64FromInt64(proxySummary.AvgResponseBytes),
-			ProxyMaxDurationMs:    proxySummary.MaxDurationMs,
-			ProxySlowRequests:     proxySummary.SlowRequests,
-			ProxyCacheHits:        proxySummary.CacheHits,
-			ProxyCacheMisses:      proxySummary.CacheMisses,
-			ProxyCacheBypasses:    proxySummary.CacheBypasses,
-			ProxyCacheStored:      proxySummary.CacheStored,
-			ProxyCacheStoreFailed: proxySummary.CacheStoreFailed,
-			ProxyCacheHitBytes:    uint64FromInt64(proxySummary.CacheHitBytes),
-			ProxyCacheStoredBytes: uint64FromInt64(proxySummary.CacheStoredBytes),
-			AgentSamples:          agentSummary.Samples,
-			AgentReqSuccess:       agentSummary.ReqSuccess,
-			AgentReqClientError:   agentSummary.ReqClientError,
-			AgentReqServerError:   agentSummary.ReqServerError,
-			AgentReqInternalError: agentSummary.ReqInternalError,
-			AgentBytesReceived:    uint64FromInt64(agentSummary.BytesRx),
-			AgentBytesSent:        uint64FromInt64(agentSummary.BytesTx),
-			AgentAvgMemoryMb:      agentSummary.AvgMemoryMb,
-			AgentMaxMemoryMb:      agentSummary.MaxMemoryMb,
-			AgentAvgGoroutines:    agentSummary.AvgGoroutines,
-			AgentMaxGoroutines:    agentSummary.MaxGoroutines,
-			AgentAvgCpuPercent:    agentSummary.AvgCpuPercent,
-			AgentMaxCpuPercent:    agentSummary.MaxCpuPercent,
-		})
+		windows = append(windows, dashboardWindowSummary(
+			window.Label,
+			since.UnixMilli(),
+			dashboardProxyWindowFromRaw(proxySummary),
+			dashboardAgentWindowFromRaw(agentSummary),
+		))
 	}
 
 	agentConnections, err := a.agentConnectionSummary(ctx, now)
@@ -105,36 +94,96 @@ func (a *App) GetDashboard(
 	}
 
 	topSince := now.Add(-dashboardTopWindow)
-	topListenerRows, err := a.DB.ListTopProxyListenersSince(ctx, topSince)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
-	}
-	topBackendRows, err := a.DB.ListTopProxyBackendsSince(ctx, topSince)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
-	}
-	topRouteRows, err := a.DB.ListTopProxyRoutesSince(ctx, topSince)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
-	}
-	topAgentRows, err := a.DB.ListTopProxyAgentsSince(ctx, topSince)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
-	}
-	topErrorRows, err := a.DB.ListTopProxyErrorKindsSince(ctx, topSince)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
-	}
-	statusClassRows, err := a.DB.ListProxyStatusClassesSince(ctx, topSince)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
-	}
-	trafficBucketRows, err := a.DB.ListProxyTrafficBucketsSince(ctx, db.ListProxyTrafficBucketsSinceParams{
-		BucketSeconds: dashboardTrafficBucketSeconds,
-		Since:         now.Add(-dashboardTrafficBucketWindow),
-	})
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+	trafficSince := now.Add(-dashboardTrafficBucketWindow)
+
+	var topListeners []*p2pstreamv1.DashboardProxyDimensionSummary
+	var topBackends []*p2pstreamv1.DashboardProxyDimensionSummary
+	var topRoutes []*p2pstreamv1.DashboardProxyDimensionSummary
+	var topAgents []*p2pstreamv1.DashboardProxyDimensionSummary
+	var topErrorKinds []*p2pstreamv1.DashboardProxyDimensionSummary
+	var statusClasses []*p2pstreamv1.DashboardProxyDimensionSummary
+	var trafficBuckets []*p2pstreamv1.DashboardTrafficBucket
+
+	if useRollups {
+		topSinceUnixMillis := rollupBucketUnixMillis(topSince)
+		trafficSinceUnixMillis := rollupBucketUnixMillis(trafficSince)
+		topListenerRows, err := a.DB.ListTopProxyListenersRollupsSince(ctx, topSinceUnixMillis)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		topBackendRows, err := a.DB.ListTopProxyBackendsRollupsSince(ctx, topSinceUnixMillis)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		topRouteRows, err := a.DB.ListTopProxyRoutesRollupsSince(ctx, topSinceUnixMillis)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		topAgentRows, err := a.DB.ListTopProxyAgentsRollupsSince(ctx, topSinceUnixMillis)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		topErrorRows, err := a.DB.ListTopProxyErrorKindsRollupsSince(ctx, topSinceUnixMillis)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		statusClassRows, err := a.DB.ListProxyStatusClassesRollupsSince(ctx, topSinceUnixMillis)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		trafficBucketRows, err := a.DB.ListProxyTrafficBucketRollupsSince(ctx, db.ListProxyTrafficBucketRollupsSinceParams{
+			BucketSeconds:   dashboardTrafficBucketSeconds,
+			SinceUnixMillis: trafficSinceUnixMillis,
+		})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		topListeners = dashboardRollupListenerSummaries(topListenerRows)
+		topBackends = dashboardRollupBackendSummaries(topBackendRows)
+		topRoutes = dashboardRollupRouteSummaries(topRouteRows)
+		topAgents = dashboardRollupAgentSummaries(topAgentRows)
+		topErrorKinds = dashboardRollupErrorKindSummaries(topErrorRows)
+		statusClasses = dashboardRollupStatusClassSummaries(statusClassRows)
+		trafficBuckets = dashboardRollupTrafficBuckets(trafficBucketRows)
+	} else {
+		topListenerRows, err := a.DB.ListTopProxyListenersSince(ctx, topSince)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		topBackendRows, err := a.DB.ListTopProxyBackendsSince(ctx, topSince)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		topRouteRows, err := a.DB.ListTopProxyRoutesSince(ctx, topSince)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		topAgentRows, err := a.DB.ListTopProxyAgentsSince(ctx, topSince)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		topErrorRows, err := a.DB.ListTopProxyErrorKindsSince(ctx, topSince)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		statusClassRows, err := a.DB.ListProxyStatusClassesSince(ctx, topSince)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		trafficBucketRows, err := a.DB.ListProxyTrafficBucketsSince(ctx, db.ListProxyTrafficBucketsSinceParams{
+			BucketSeconds: dashboardTrafficBucketSeconds,
+			Since:         trafficSince,
+		})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		topListeners = dashboardListenerSummaries(topListenerRows)
+		topBackends = dashboardBackendSummaries(topBackendRows)
+		topRoutes = dashboardRouteSummaries(topRouteRows)
+		topAgents = dashboardAgentSummaries(topAgentRows)
+		topErrorKinds = dashboardErrorKindSummaries(topErrorRows)
+		statusClasses = dashboardStatusClassSummaries(statusClassRows)
+		trafficBuckets = dashboardTrafficBuckets(trafficBucketRows)
 	}
 
 	resp := &p2pstreamv1.GetDashboardResponse{
@@ -143,13 +192,13 @@ func (a *App) GetDashboard(
 		AgentConnections:      agentConnections,
 		RetentionDays:         int64(a.observabilityRetentionDays()),
 		GeneratedAtUnixMillis: now.UnixMilli(),
-		TopListeners:          dashboardListenerSummaries(topListenerRows),
-		TopBackends:           dashboardBackendSummaries(topBackendRows),
-		TopRoutes:             dashboardRouteSummaries(topRouteRows),
-		TopAgents:             dashboardAgentSummaries(topAgentRows),
-		TopErrorKinds:         dashboardErrorKindSummaries(topErrorRows),
-		StatusClasses:         dashboardStatusClassSummaries(statusClassRows),
-		TrafficBuckets:        dashboardTrafficBuckets(trafficBucketRows),
+		TopListeners:          topListeners,
+		TopBackends:           topBackends,
+		TopRoutes:             topRoutes,
+		TopAgents:             topAgents,
+		TopErrorKinds:         topErrorKinds,
+		StatusClasses:         statusClasses,
+		TrafficBuckets:        trafficBuckets,
 		ManagementSecurity:    a.managementSecurity(),
 	}
 	return connect.NewResponse(resp), nil
@@ -170,6 +219,176 @@ func (a *App) managementSecurity() *p2pstreamv1.ManagementSecurity {
 		ManagementCaPem:                cfg.ManagementCAPEM,
 		ManagementCaSha256:             cfg.ManagementCASHA256,
 		DetectedAdvertiseHost:          cfg.ManagementDetectedAdvertiseHost,
+	}
+}
+
+type dashboardProxyWindowMetrics struct {
+	TotalRequests    int64
+	Success          int64
+	ClientError      int64
+	ServerError      int64
+	InternalError    int64
+	AvgDurationMs    int64
+	RequestBytes     int64
+	ResponseBytes    int64
+	TotalBytes       int64
+	AvgRequestBytes  int64
+	AvgResponseBytes int64
+	MaxDurationMs    int64
+	SlowRequests     int64
+	CacheHits        int64
+	CacheMisses      int64
+	CacheBypasses    int64
+	CacheStored      int64
+	CacheStoreFailed int64
+	CacheHitBytes    int64
+	CacheStoredBytes int64
+}
+
+type dashboardAgentWindowMetrics struct {
+	Samples          int64
+	ReqSuccess       int64
+	ReqClientError   int64
+	ReqServerError   int64
+	ReqInternalError int64
+	BytesRx          int64
+	BytesTx          int64
+	AvgMemoryMb      int64
+	MaxMemoryMb      int64
+	AvgGoroutines    int64
+	MaxGoroutines    int64
+	AvgCpuPercent    float64
+	MaxCpuPercent    float64
+}
+
+func dashboardWindowSummary(
+	label string,
+	sinceUnixMillis int64,
+	proxy dashboardProxyWindowMetrics,
+	agent dashboardAgentWindowMetrics,
+) *p2pstreamv1.DashboardWindowSummary {
+	return &p2pstreamv1.DashboardWindowSummary{
+		Label:                 label,
+		SinceUnixMillis:       sinceUnixMillis,
+		ProxyRequests:         proxy.TotalRequests,
+		ProxySuccess:          proxy.Success,
+		ProxyClientError:      proxy.ClientError,
+		ProxyServerError:      proxy.ServerError,
+		ProxyInternalError:    proxy.InternalError,
+		ProxyAvgDurationMs:    proxy.AvgDurationMs,
+		ProxyRequestBytes:     uint64FromInt64(proxy.RequestBytes),
+		ProxyResponseBytes:    uint64FromInt64(proxy.ResponseBytes),
+		ProxyTotalBytes:       uint64FromInt64(proxy.TotalBytes),
+		ProxyAvgRequestBytes:  uint64FromInt64(proxy.AvgRequestBytes),
+		ProxyAvgResponseBytes: uint64FromInt64(proxy.AvgResponseBytes),
+		ProxyMaxDurationMs:    proxy.MaxDurationMs,
+		ProxySlowRequests:     proxy.SlowRequests,
+		ProxyCacheHits:        proxy.CacheHits,
+		ProxyCacheMisses:      proxy.CacheMisses,
+		ProxyCacheBypasses:    proxy.CacheBypasses,
+		ProxyCacheStored:      proxy.CacheStored,
+		ProxyCacheStoreFailed: proxy.CacheStoreFailed,
+		ProxyCacheHitBytes:    uint64FromInt64(proxy.CacheHitBytes),
+		ProxyCacheStoredBytes: uint64FromInt64(proxy.CacheStoredBytes),
+		AgentSamples:          agent.Samples,
+		AgentReqSuccess:       agent.ReqSuccess,
+		AgentReqClientError:   agent.ReqClientError,
+		AgentReqServerError:   agent.ReqServerError,
+		AgentReqInternalError: agent.ReqInternalError,
+		AgentBytesReceived:    uint64FromInt64(agent.BytesRx),
+		AgentBytesSent:        uint64FromInt64(agent.BytesTx),
+		AgentAvgMemoryMb:      agent.AvgMemoryMb,
+		AgentMaxMemoryMb:      agent.MaxMemoryMb,
+		AgentAvgGoroutines:    agent.AvgGoroutines,
+		AgentMaxGoroutines:    agent.MaxGoroutines,
+		AgentAvgCpuPercent:    agent.AvgCpuPercent,
+		AgentMaxCpuPercent:    agent.MaxCpuPercent,
+	}
+}
+
+func dashboardProxyWindowFromRaw(row db.GetProxyRequestSummarySinceRow) dashboardProxyWindowMetrics {
+	return dashboardProxyWindowMetrics{
+		TotalRequests:    row.TotalRequests,
+		Success:          row.Success,
+		ClientError:      row.ClientError,
+		ServerError:      row.ServerError,
+		InternalError:    row.InternalError,
+		AvgDurationMs:    row.AvgDurationMs,
+		RequestBytes:     row.RequestBytes,
+		ResponseBytes:    row.ResponseBytes,
+		TotalBytes:       row.TotalBytes,
+		AvgRequestBytes:  row.AvgRequestBytes,
+		AvgResponseBytes: row.AvgResponseBytes,
+		MaxDurationMs:    row.MaxDurationMs,
+		SlowRequests:     row.SlowRequests,
+		CacheHits:        row.CacheHits,
+		CacheMisses:      row.CacheMisses,
+		CacheBypasses:    row.CacheBypasses,
+		CacheStored:      row.CacheStored,
+		CacheStoreFailed: row.CacheStoreFailed,
+		CacheHitBytes:    row.CacheHitBytes,
+		CacheStoredBytes: row.CacheStoredBytes,
+	}
+}
+
+func dashboardProxyWindowFromRollup(row db.GetProxyRequestRollupSummarySinceRow) dashboardProxyWindowMetrics {
+	return dashboardProxyWindowMetrics{
+		TotalRequests:    row.TotalRequests,
+		Success:          row.Success,
+		ClientError:      row.ClientError,
+		ServerError:      row.ServerError,
+		InternalError:    row.InternalError,
+		AvgDurationMs:    row.AvgDurationMs,
+		RequestBytes:     row.RequestBytes,
+		ResponseBytes:    row.ResponseBytes,
+		TotalBytes:       row.TotalBytes,
+		AvgRequestBytes:  row.AvgRequestBytes,
+		AvgResponseBytes: row.AvgResponseBytes,
+		MaxDurationMs:    row.MaxDurationMs,
+		SlowRequests:     row.SlowRequests,
+		CacheHits:        row.CacheHits,
+		CacheMisses:      row.CacheMisses,
+		CacheBypasses:    row.CacheBypasses,
+		CacheStored:      row.CacheStored,
+		CacheStoreFailed: row.CacheStoreFailed,
+		CacheHitBytes:    row.CacheHitBytes,
+		CacheStoredBytes: row.CacheStoredBytes,
+	}
+}
+
+func dashboardAgentWindowFromRaw(row db.GetAgentStatsSummarySinceRow) dashboardAgentWindowMetrics {
+	return dashboardAgentWindowMetrics{
+		Samples:          row.Samples,
+		ReqSuccess:       row.ReqSuccess,
+		ReqClientError:   row.ReqClientError,
+		ReqServerError:   row.ReqServerError,
+		ReqInternalError: row.ReqInternalError,
+		BytesRx:          row.BytesRx,
+		BytesTx:          row.BytesTx,
+		AvgMemoryMb:      row.AvgMemoryMb,
+		MaxMemoryMb:      row.MaxMemoryMb,
+		AvgGoroutines:    row.AvgGoroutines,
+		MaxGoroutines:    row.MaxGoroutines,
+		AvgCpuPercent:    row.AvgCpuPercent,
+		MaxCpuPercent:    row.MaxCpuPercent,
+	}
+}
+
+func dashboardAgentWindowFromRollup(row db.GetAgentStatsRollupSummarySinceRow) dashboardAgentWindowMetrics {
+	return dashboardAgentWindowMetrics{
+		Samples:          row.Samples,
+		ReqSuccess:       row.ReqSuccess,
+		ReqClientError:   row.ReqClientError,
+		ReqServerError:   row.ReqServerError,
+		ReqInternalError: row.ReqInternalError,
+		BytesRx:          row.BytesRx,
+		BytesTx:          row.BytesTx,
+		AvgMemoryMb:      row.AvgMemoryMb,
+		MaxMemoryMb:      row.MaxMemoryMb,
+		AvgGoroutines:    row.AvgGoroutines,
+		MaxGoroutines:    row.MaxGoroutines,
+		AvgCpuPercent:    row.AvgCpuPercent,
+		MaxCpuPercent:    row.MaxCpuPercent,
 	}
 }
 
@@ -236,7 +455,9 @@ func (a *App) recordProxyRequestEventWithCache(
 		statusCode = http.StatusInternalServerError
 	}
 
-	if err := a.DB.InsertProxyRequestEvent(ctx, db.InsertProxyRequestEventParams{
+	occurredAt := time.Now().UTC()
+	if err := a.insertProxyRequestEventWithRollups(ctx, db.InsertProxyRequestEventAtParams{
+		OccurredAt:    occurredAt,
 		StatusCode:    int64(statusCode),
 		DurationMs:    duration.Milliseconds(),
 		ErrorKind:     errorKind,
@@ -376,6 +597,126 @@ func dashboardStatusClassSummaries(rows []db.ListProxyStatusClassesSinceRow) []*
 	return items
 }
 
+func dashboardRollupListenerSummaries(rows []db.ListTopProxyListenersRollupsSinceRow) []*p2pstreamv1.DashboardProxyDimensionSummary {
+	items := make([]*p2pstreamv1.DashboardProxyDimensionSummary, 0, len(rows))
+	for _, row := range rows {
+		items = append(items, dashboardDimensionSummary(
+			p2pstreamv1.DashboardProxyDimension_DASHBOARD_PROXY_DIMENSION_LISTENER,
+			row.ID,
+			row.Label,
+			row.Requests,
+			row.Success,
+			row.ClientError,
+			row.ServerError,
+			row.InternalError,
+			row.AvgDurationMs,
+			row.RequestBytes,
+			row.ResponseBytes,
+		))
+	}
+	return items
+}
+
+func dashboardRollupBackendSummaries(rows []db.ListTopProxyBackendsRollupsSinceRow) []*p2pstreamv1.DashboardProxyDimensionSummary {
+	items := make([]*p2pstreamv1.DashboardProxyDimensionSummary, 0, len(rows))
+	for _, row := range rows {
+		items = append(items, dashboardDimensionSummary(
+			p2pstreamv1.DashboardProxyDimension_DASHBOARD_PROXY_DIMENSION_BACKEND,
+			row.ID,
+			row.Label,
+			row.Requests,
+			row.Success,
+			row.ClientError,
+			row.ServerError,
+			row.InternalError,
+			row.AvgDurationMs,
+			row.RequestBytes,
+			row.ResponseBytes,
+		))
+	}
+	return items
+}
+
+func dashboardRollupRouteSummaries(rows []db.ListTopProxyRoutesRollupsSinceRow) []*p2pstreamv1.DashboardProxyDimensionSummary {
+	items := make([]*p2pstreamv1.DashboardProxyDimensionSummary, 0, len(rows))
+	for _, row := range rows {
+		items = append(items, dashboardDimensionSummary(
+			p2pstreamv1.DashboardProxyDimension_DASHBOARD_PROXY_DIMENSION_ROUTE,
+			row.ID,
+			row.Label,
+			row.Requests,
+			row.Success,
+			row.ClientError,
+			row.ServerError,
+			row.InternalError,
+			row.AvgDurationMs,
+			row.RequestBytes,
+			row.ResponseBytes,
+		))
+	}
+	return items
+}
+
+func dashboardRollupAgentSummaries(rows []db.ListTopProxyAgentsRollupsSinceRow) []*p2pstreamv1.DashboardProxyDimensionSummary {
+	items := make([]*p2pstreamv1.DashboardProxyDimensionSummary, 0, len(rows))
+	for _, row := range rows {
+		items = append(items, dashboardDimensionSummary(
+			p2pstreamv1.DashboardProxyDimension_DASHBOARD_PROXY_DIMENSION_AGENT,
+			row.ID,
+			row.Label,
+			row.Requests,
+			row.Success,
+			row.ClientError,
+			row.ServerError,
+			row.InternalError,
+			row.AvgDurationMs,
+			row.RequestBytes,
+			row.ResponseBytes,
+		))
+	}
+	return items
+}
+
+func dashboardRollupErrorKindSummaries(rows []db.ListTopProxyErrorKindsRollupsSinceRow) []*p2pstreamv1.DashboardProxyDimensionSummary {
+	items := make([]*p2pstreamv1.DashboardProxyDimensionSummary, 0, len(rows))
+	for _, row := range rows {
+		items = append(items, dashboardDimensionSummary(
+			p2pstreamv1.DashboardProxyDimension_DASHBOARD_PROXY_DIMENSION_ERROR_KIND,
+			row.ID,
+			row.Label,
+			row.Requests,
+			row.Success,
+			row.ClientError,
+			row.ServerError,
+			row.InternalError,
+			row.AvgDurationMs,
+			row.RequestBytes,
+			row.ResponseBytes,
+		))
+	}
+	return items
+}
+
+func dashboardRollupStatusClassSummaries(rows []db.ListProxyStatusClassesRollupsSinceRow) []*p2pstreamv1.DashboardProxyDimensionSummary {
+	items := make([]*p2pstreamv1.DashboardProxyDimensionSummary, 0, len(rows))
+	for _, row := range rows {
+		items = append(items, dashboardDimensionSummary(
+			p2pstreamv1.DashboardProxyDimension_DASHBOARD_PROXY_DIMENSION_STATUS_CLASS,
+			row.ID,
+			row.Label,
+			row.Requests,
+			row.Success,
+			row.ClientError,
+			row.ServerError,
+			row.InternalError,
+			row.AvgDurationMs,
+			row.RequestBytes,
+			row.ResponseBytes,
+		))
+	}
+	return items
+}
+
 func dashboardDimensionSummary(
 	dimension p2pstreamv1.DashboardProxyDimension,
 	id int64,
@@ -405,6 +746,24 @@ func dashboardDimensionSummary(
 }
 
 func dashboardTrafficBuckets(rows []db.ListProxyTrafficBucketsSinceRow) []*p2pstreamv1.DashboardTrafficBucket {
+	items := make([]*p2pstreamv1.DashboardTrafficBucket, 0, len(rows))
+	for _, row := range rows {
+		items = append(items, &p2pstreamv1.DashboardTrafficBucket{
+			BucketUnixMillis: row.BucketUnixMillis,
+			Requests:         row.Requests,
+			Success:          row.Success,
+			ClientError:      row.ClientError,
+			ServerError:      row.ServerError,
+			InternalError:    row.InternalError,
+			RequestBytes:     uint64FromInt64(row.RequestBytes),
+			ResponseBytes:    uint64FromInt64(row.ResponseBytes),
+			AvgDurationMs:    row.AvgDurationMs,
+		})
+	}
+	return items
+}
+
+func dashboardRollupTrafficBuckets(rows []db.ListProxyTrafficBucketRollupsSinceRow) []*p2pstreamv1.DashboardTrafficBucket {
 	items := make([]*p2pstreamv1.DashboardTrafficBucket, 0, len(rows))
 	for _, row := range rows {
 		items = append(items, &p2pstreamv1.DashboardTrafficBucket{
@@ -456,7 +815,7 @@ func (a *App) cleanupObservability(ctx context.Context, now time.Time) {
 	}
 
 	a.observabilityMu.Lock()
-	if !a.observabilityLastCleanup.IsZero() && now.Sub(a.observabilityLastCleanup) < time.Hour {
+	if !a.observabilityLastCleanup.IsZero() && now.Sub(a.observabilityLastCleanup) < observabilityCleanupInterval {
 		a.observabilityMu.Unlock()
 		return
 	}
@@ -464,6 +823,16 @@ func (a *App) cleanupObservability(ctx context.Context, now time.Time) {
 	a.observabilityMu.Unlock()
 
 	cutoff := now.AddDate(0, 0, -a.observabilityRetentionDays())
+	cutoffBucketUnixMillis := rollupBucketUnixMillis(cutoff)
+	if err := a.DB.DeleteProxyRequestRollupsBefore(ctx, cutoffBucketUnixMillis); err != nil {
+		log.Warn().Err(err).Msg("Failed to clean up old proxy request rollups")
+	}
+	if err := a.DB.DeleteProxyRequestTupleRollupsBefore(ctx, cutoffBucketUnixMillis); err != nil {
+		log.Warn().Err(err).Msg("Failed to clean up old proxy request tuple rollups")
+	}
+	if err := a.DB.DeleteAgentStatRollupsBefore(ctx, cutoffBucketUnixMillis); err != nil {
+		log.Warn().Err(err).Msg("Failed to clean up old agent stat rollups")
+	}
 	if err := a.DB.DeleteProxyRequestEventsBefore(ctx, cutoff); err != nil {
 		log.Warn().Err(err).Msg("Failed to clean up old proxy request events")
 	}
@@ -473,12 +842,44 @@ func (a *App) cleanupObservability(ctx context.Context, now time.Time) {
 	if err := a.DB.DeleteDisconnectedConnectionsBefore(ctx, sql.NullTime{Time: cutoff, Valid: true}); err != nil {
 		log.Warn().Err(err).Msg("Failed to clean up old disconnected agent connections")
 	}
-	if maxRows := a.observabilityMaxRows(); maxRows > 0 {
-		if err := a.DB.DeleteOldestProxyRequestEventsOverLimit(ctx, maxRows); err != nil {
+
+	maxRows := a.observabilityMaxRows()
+	if maxRows <= 0 {
+		return
+	}
+	ready, err := a.observabilityRollupsReady(ctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to check observability rollup readiness for row cap")
+		return
+	}
+	if !ready {
+		return
+	}
+
+	for i := 0; i < observabilityRowCapDeleteMaxBatches; i++ {
+		deleted, err := a.DB.DeleteOldestProxyRequestEventsOverLimit(ctx, db.DeleteOldestProxyRequestEventsOverLimitParams{
+			Offset:      maxRows,
+			DeleteLimit: observabilityRowCapDeleteBatchRows,
+		})
+		if err != nil {
 			log.Warn().Err(err).Msg("Failed to enforce proxy request event row cap")
+			break
 		}
-		if err := a.DB.DeleteOldestAgentStatsOverLimit(ctx, maxRows); err != nil {
+		if deleted < observabilityRowCapDeleteBatchRows {
+			break
+		}
+	}
+	for i := 0; i < observabilityRowCapDeleteMaxBatches; i++ {
+		deleted, err := a.DB.DeleteOldestAgentStatsOverLimit(ctx, db.DeleteOldestAgentStatsOverLimitParams{
+			Offset:      maxRows,
+			DeleteLimit: observabilityRowCapDeleteBatchRows,
+		})
+		if err != nil {
 			log.Warn().Err(err).Msg("Failed to enforce agent stat row cap")
+			break
+		}
+		if deleted < observabilityRowCapDeleteBatchRows {
+			break
 		}
 	}
 }
@@ -495,25 +896,6 @@ func (a *App) observabilityMaxRows() int64 {
 		return 0
 	}
 	return a.Config.ObservabilityMaxRows
-}
-
-func (a *App) StartObservabilityCleanup(ctx context.Context) {
-	if a == nil || a.DB == nil {
-		return
-	}
-	go func() {
-		a.cleanupObservability(ctx, time.Now().UTC())
-		ticker := time.NewTicker(observabilityCleanupInterval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case now := <-ticker.C:
-				a.cleanupObservability(ctx, now.UTC())
-			}
-		}
-	}()
 }
 
 func (a *App) agentConnectionSummary(ctx context.Context, now time.Time) (*p2pstreamv1.AgentConnectionSummary, error) {

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"database/sql"
 	"net/http"
 	"testing"
 	"time"
@@ -20,11 +21,13 @@ func TestGetDashboardIncludesCacheSummary(t *testing.T) {
 
 	insertEvent := func(cacheStatus string, cacheBytes int64) {
 		t.Helper()
-		if err := app.DB.InsertProxyRequestEvent(ctx, db.InsertProxyRequestEventParams{
-			StatusCode:  http.StatusOK,
-			DurationMs:  10,
-			CacheStatus: cacheStatus,
-			CacheBytes:  cacheBytes,
+		if err := app.insertProxyRequestEventWithRollups(ctx, db.InsertProxyRequestEventAtParams{
+			OccurredAt:   time.Now().UTC(),
+			StatusCode:   http.StatusOK,
+			DurationMs:   10,
+			CacheStatus:  cacheStatus,
+			CacheBytes:   cacheBytes,
+			RequestBytes: 0,
 		}); err != nil {
 			t.Fatalf("insert proxy request event: %v", err)
 		}
@@ -72,6 +75,194 @@ func TestGetDashboardIncludesCacheSummary(t *testing.T) {
 	}
 }
 
+func TestProxyRequestEventRollupsAreWrittenWithRawEvent(t *testing.T) {
+	ctx := context.Background()
+	app := NewApp(nil, newServerTestDB(t))
+	insertDashboardRollupAgentFixture(t, app.DB, 10)
+
+	app.recordProxyRequestEventWithCache(
+		ctx,
+		http.StatusGatewayTimeout,
+		1500*time.Millisecond,
+		"agent_timeout",
+		sqlNullInt64(7),
+		sqlNullInt64(8),
+		sqlNullInt64(9),
+		sql.NullInt64{},
+		"",
+		sqlNullInt64(10),
+		sql.NullInt64{},
+		publicCacheStatusHit,
+		123,
+		40,
+		400,
+	)
+
+	var rawEvents int64
+	if err := app.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM proxy_request_events`).Scan(&rawEvents); err != nil {
+		t.Fatalf("count raw proxy events: %v", err)
+	}
+	if rawEvents != 1 {
+		t.Fatalf("raw proxy events = %d, want 1", rawEvents)
+	}
+
+	var requests, serverError, internalError, slowRequests, cacheHits, cacheHitBytes int64
+	if err := app.DB.QueryRowContext(ctx, `
+		SELECT requests, server_error, internal_error, slow_requests, cache_hits, cache_hit_bytes
+		FROM proxy_request_rollup_minutes
+	`).Scan(&requests, &serverError, &internalError, &slowRequests, &cacheHits, &cacheHitBytes); err != nil {
+		t.Fatalf("read proxy rollup: %v", err)
+	}
+	if requests != 1 || serverError != 1 || internalError != 1 || slowRequests != 1 || cacheHits != 1 || cacheHitBytes != 123 {
+		t.Fatalf("unexpected proxy rollup metrics: requests=%d server=%d internal=%d slow=%d cache_hits=%d cache_hit_bytes=%d", requests, serverError, internalError, slowRequests, cacheHits, cacheHitBytes)
+	}
+
+	var listenerID, backendID, routeID, agentID, statusClass int64
+	var errorKind string
+	if err := app.DB.QueryRowContext(ctx, `
+		SELECT listener_id, backend_id, route_id, agent_id, error_kind, status_class
+		FROM proxy_request_tuple_rollup_minutes
+	`).Scan(&listenerID, &backendID, &routeID, &agentID, &errorKind, &statusClass); err != nil {
+		t.Fatalf("read proxy tuple rollup: %v", err)
+	}
+	if listenerID != 7 || backendID != 8 || routeID != 9 || agentID != 10 || errorKind != "agent_timeout" || statusClass != 5 {
+		t.Fatalf("unexpected tuple rollup dimensions: listener=%d backend=%d route=%d agent=%d error=%q status_class=%d", listenerID, backendID, routeID, agentID, errorKind, statusClass)
+	}
+}
+
+func TestAgentStatRollupsAreWrittenWithRawStat(t *testing.T) {
+	ctx := context.Background()
+	app := NewApp(nil, newServerTestDB(t))
+	insertDashboardRollupAgentFixture(t, app.DB, 1)
+
+	if err := app.insertAgentStatWithRollup(ctx, db.InsertAgentStatAtParams{
+		ReportedAt:       time.Now().UTC(),
+		AgentID:          sqlNullInt64(1),
+		MemoryMb:         128,
+		Goroutines:       11,
+		ReqSuccess:       3,
+		ReqClientError:   4,
+		ReqServerError:   5,
+		ReqInternalError: 6,
+		BytesRx:          700,
+		BytesTx:          800,
+		CpuPercent:       12.5,
+	}); err != nil {
+		t.Fatalf("insert agent stat with rollup: %v", err)
+	}
+
+	var rawStats int64
+	if err := app.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_stats`).Scan(&rawStats); err != nil {
+		t.Fatalf("count raw agent stats: %v", err)
+	}
+	if rawStats != 1 {
+		t.Fatalf("raw agent stats = %d, want 1", rawStats)
+	}
+
+	var samples, reqSuccess, memorySum, maxMemory int64
+	var cpuSum, maxCPU float64
+	if err := app.DB.QueryRowContext(ctx, `
+		SELECT samples, req_success, memory_mb_sum, max_memory_mb, cpu_percent_sum, max_cpu_percent
+		FROM agent_stat_rollup_minutes
+	`).Scan(&samples, &reqSuccess, &memorySum, &maxMemory, &cpuSum, &maxCPU); err != nil {
+		t.Fatalf("read agent stat rollup: %v", err)
+	}
+	if samples != 1 || reqSuccess != 3 || memorySum != 128 || maxMemory != 128 || cpuSum != 12.5 || maxCPU != 12.5 {
+		t.Fatalf("unexpected agent stat rollup: samples=%d req_success=%d memory_sum=%d max_memory=%d cpu_sum=%f max_cpu=%f", samples, reqSuccess, memorySum, maxMemory, cpuSum, maxCPU)
+	}
+}
+
+func TestDashboardUsesBackfilledRollups(t *testing.T) {
+	ctx := context.Background()
+	app := NewApp(nil, newServerTestDB(t))
+	header := createTestAdminSession(t, app)
+	seedDashboardRollupDimensionFixtures(t, app.DB)
+
+	now := time.Now().UTC()
+	insertDashboardRollupProxyEvent(t, app.DB, now.Add(-2*time.Minute), http.StatusOK, 100, "", sqlNullInt64(1), sqlNullInt64(1), sqlNullInt64(1), sqlNullInt64(1), 10, 100)
+	insertDashboardRollupProxyEvent(t, app.DB, now.Add(-30*time.Minute), http.StatusBadGateway, 1300, "agent_timeout", sqlNullInt64(1), sqlNullInt64(1), sql.NullInt64{}, sql.NullInt64{}, 20, 200)
+	insertDashboardRollupAgentStat(t, app.DB, now.Add(-2*time.Minute), 100, 8, 10, 1, 2, 3, 1000, 2000)
+	insertDashboardRollupAgentStat(t, app.DB, now.Add(-30*time.Minute), 150, 10, 20, 2, 3, 4, 3000, 4000)
+	resetRollupStateToRawMax(t, app.DB)
+
+	for {
+		progress, err := app.backfillObservabilityRollupBatch(ctx)
+		if err != nil {
+			t.Fatalf("backfill rollup batch: %v", err)
+		}
+		if !progress {
+			break
+		}
+	}
+	// A second pass must not double-count already backfilled rows.
+	if progress, err := app.backfillObservabilityRollupBatch(ctx); err != nil || progress {
+		t.Fatalf("second backfill progress=%v err=%v, want no progress", progress, err)
+	}
+
+	req := connect.NewRequest(&p2pstreamv1.GetDashboardRequest{})
+	req.Header().Set("Cookie", header.Get("Cookie"))
+	resp, err := app.GetDashboard(ctx, req)
+	if err != nil {
+		t.Fatalf("get dashboard: %v", err)
+	}
+
+	windows := dashboardTestWindowsByLabel(resp.Msg.Windows)
+	fiveMinutes := windows["5m"]
+	if fiveMinutes == nil {
+		t.Fatal("missing 5m dashboard window")
+	}
+	if fiveMinutes.ProxyRequests != 1 || fiveMinutes.ProxySuccess != 1 || fiveMinutes.AgentSamples != 1 {
+		t.Fatalf("unexpected 5m rollup window: %+v", fiveMinutes)
+	}
+	oneHour := windows["1h"]
+	if oneHour == nil {
+		t.Fatal("missing 1h dashboard window")
+	}
+	if oneHour.ProxyRequests != 2 || oneHour.ProxyServerError != 1 || oneHour.ProxyInternalError != 1 || oneHour.AgentSamples != 2 {
+		t.Fatalf("unexpected 1h rollup window: %+v", oneHour)
+	}
+	if len(resp.Msg.TopListeners) == 0 || resp.Msg.TopListeners[0].Label != "listener-one" || resp.Msg.TopListeners[0].Requests != 2 {
+		t.Fatalf("unexpected rollup top listeners: %+v", resp.Msg.TopListeners)
+	}
+	if len(resp.Msg.TopErrorKinds) != 1 || resp.Msg.TopErrorKinds[0].Label != "agent_timeout" {
+		t.Fatalf("unexpected rollup top error kinds: %+v", resp.Msg.TopErrorKinds)
+	}
+	var bucketRequests int64
+	for _, bucket := range resp.Msg.TrafficBuckets {
+		bucketRequests += bucket.Requests
+	}
+	if bucketRequests != 2 {
+		t.Fatalf("rollup bucket requests = %d, want 2", bucketRequests)
+	}
+}
+
+func TestGetDashboardDoesNotRunObservabilityCleanup(t *testing.T) {
+	ctx := context.Background()
+	app := NewApp(&config.Config{ObservabilityRetentionDays: 30}, newServerTestDB(t))
+	header := createTestAdminSession(t, app)
+
+	if _, err := app.DB.ExecContext(ctx, `
+		INSERT INTO proxy_request_events (occurred_at, status_code, duration_ms)
+		VALUES (?, ?, ?)
+	`, time.Now().UTC().AddDate(0, 0, -31), http.StatusOK, 10); err != nil {
+		t.Fatalf("insert old proxy event: %v", err)
+	}
+
+	req := connect.NewRequest(&p2pstreamv1.GetDashboardRequest{})
+	req.Header().Set("Cookie", header.Get("Cookie"))
+	if _, err := app.GetDashboard(ctx, req); err != nil {
+		t.Fatalf("get dashboard: %v", err)
+	}
+
+	var oldRows int64
+	if err := app.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM proxy_request_events`).Scan(&oldRows); err != nil {
+		t.Fatalf("count old proxy events: %v", err)
+	}
+	if oldRows != 1 {
+		t.Fatalf("old proxy rows after dashboard = %d, want 1", oldRows)
+	}
+}
+
 func TestCleanupObservabilityEnforcesProxyRequestRowCap(t *testing.T) {
 	ctx := context.Background()
 	app := NewApp(&config.Config{ObservabilityRetentionDays: 30, ObservabilityMaxRows: 3}, newServerTestDB(t))
@@ -105,4 +296,142 @@ func dashboardTestWindow(t *testing.T, windows []*p2pstreamv1.DashboardWindowSum
 	}
 	t.Fatalf("dashboard window %q not found", label)
 	return nil
+}
+
+func dashboardTestWindowsByLabel(windows []*p2pstreamv1.DashboardWindowSummary) map[string]*p2pstreamv1.DashboardWindowSummary {
+	byLabel := make(map[string]*p2pstreamv1.DashboardWindowSummary, len(windows))
+	for _, window := range windows {
+		byLabel[window.Label] = window
+	}
+	return byLabel
+}
+
+func sqlNullInt64(value int64) sql.NullInt64 {
+	return sql.NullInt64{Int64: value, Valid: true}
+}
+
+func seedDashboardRollupDimensionFixtures(t *testing.T, database *db.DB) {
+	t.Helper()
+	insertDashboardRollupAgentFixture(t, database, 1)
+	if _, err := database.ExecContext(
+		context.Background(),
+		`INSERT INTO public_backends (id, name, target_origin, backend_type, enabled) VALUES
+			(1, 'backend-one', 'http://backend-one.local', 'proxy_forward', 1)`,
+	); err != nil {
+		t.Fatalf("insert dashboard backend fixtures: %v", err)
+	}
+	if _, err := database.ExecContext(
+		context.Background(),
+		`INSERT INTO public_listeners (id, name, bind_address, port, protocol, enabled, default_backend_id) VALUES
+			(1, 'listener-one', '127.0.0.1', 18080, 'http', 1, 1)`,
+	); err != nil {
+		t.Fatalf("insert dashboard listener fixtures: %v", err)
+	}
+	if _, err := database.ExecContext(
+		context.Background(),
+		`INSERT INTO public_routes (id, listener_id, priority, host_pattern, path_prefix, backend_id, action, enabled) VALUES
+			(1, 1, 10, 'example.com', '/api', 1, 'forward', 1)`,
+	); err != nil {
+		t.Fatalf("insert dashboard route fixtures: %v", err)
+	}
+}
+
+func insertDashboardRollupAgentFixture(t *testing.T, database *db.DB, id int64) {
+	t.Helper()
+	if _, err := database.ExecContext(
+		context.Background(),
+		`INSERT INTO agents (id, public_id, name, token_hash, enabled)
+		VALUES (?, ?, ?, ?, 1)`,
+		id,
+		"agent-one-public",
+		"agent-one",
+		"hash-one",
+	); err != nil {
+		t.Fatalf("insert dashboard agent fixture: %v", err)
+	}
+}
+
+func insertDashboardRollupProxyEvent(
+	t *testing.T,
+	database *db.DB,
+	occurredAt time.Time,
+	statusCode int,
+	durationMs int64,
+	errorKind string,
+	listenerID sql.NullInt64,
+	backendID sql.NullInt64,
+	routeID sql.NullInt64,
+	agentID sql.NullInt64,
+	requestBytes int64,
+	responseBytes int64,
+) {
+	t.Helper()
+	if _, err := database.ExecContext(
+		context.Background(),
+		`INSERT INTO proxy_request_events (
+			occurred_at, status_code, duration_ms, error_kind, listener_id, backend_id, route_id,
+			agent_id, request_bytes, response_bytes
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		occurredAt,
+		statusCode,
+		durationMs,
+		errorKind,
+		listenerID,
+		backendID,
+		routeID,
+		agentID,
+		requestBytes,
+		responseBytes,
+	); err != nil {
+		t.Fatalf("insert proxy event with ids: %v", err)
+	}
+}
+
+func insertDashboardRollupAgentStat(
+	t *testing.T,
+	database *db.DB,
+	reportedAt time.Time,
+	memoryMb int64,
+	goroutines int64,
+	reqSuccess int64,
+	reqClientError int64,
+	reqServerError int64,
+	reqInternalError int64,
+	bytesRx int64,
+	bytesTx int64,
+) {
+	t.Helper()
+	if _, err := database.ExecContext(
+		context.Background(),
+		`INSERT INTO agent_stats (
+			reported_at, memory_mb, goroutines, req_success, req_client_error, req_server_error,
+			req_internal_error, bytes_rx, bytes_tx
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		reportedAt,
+		memoryMb,
+		goroutines,
+		reqSuccess,
+		reqClientError,
+		reqServerError,
+		reqInternalError,
+		bytesRx,
+		bytesTx,
+	); err != nil {
+		t.Fatalf("insert agent stat: %v", err)
+	}
+}
+
+func resetRollupStateToRawMax(t *testing.T, database *db.DB) {
+	t.Helper()
+	if _, err := database.ExecContext(context.Background(), `
+		UPDATE observability_rollup_state
+		SET proxy_backfill_upper_id = CAST(COALESCE((SELECT MAX(id) FROM proxy_request_events), 0) AS INTEGER),
+		    proxy_backfilled_through_id = 0,
+		    agent_backfill_upper_id = CAST(COALESCE((SELECT MAX(id) FROM agent_stats), 0) AS INTEGER),
+		    agent_backfilled_through_id = 0,
+		    updated_at = CURRENT_TIMESTAMP
+		WHERE id = 1
+	`); err != nil {
+		t.Fatalf("reset rollup state: %v", err)
+	}
 }

--- a/internal/server/observability_rollup.go
+++ b/internal/server/observability_rollup.go
@@ -1,0 +1,285 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"p2pstream/internal/db"
+)
+
+const (
+	observabilityRollupBackfillBatchRows = int64(10000)
+	observabilityRollupBackfillInterval  = 200 * time.Millisecond
+	observabilityRowCapDeleteBatchRows   = int64(10000)
+	observabilityRowCapDeleteMaxBatches  = 10
+)
+
+func (a *App) insertProxyRequestEventWithRollups(ctx context.Context, event db.InsertProxyRequestEventAtParams) error {
+	if a.DB == nil {
+		return nil
+	}
+
+	tx, err := a.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	qtx := a.DB.WithTx(tx)
+	if _, err := qtx.InsertProxyRequestEventAt(ctx, event); err != nil {
+		return err
+	}
+	total, tuple := proxyRequestRollupParams(event)
+	if err := qtx.UpsertProxyRequestRollupMinute(ctx, total); err != nil {
+		return err
+	}
+	if err := qtx.UpsertProxyRequestTupleRollupMinute(ctx, tuple); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (a *App) insertAgentStatWithRollup(ctx context.Context, stat db.InsertAgentStatAtParams) error {
+	if a.DB == nil {
+		return nil
+	}
+
+	tx, err := a.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	qtx := a.DB.WithTx(tx)
+	if _, err := qtx.InsertAgentStatAt(ctx, stat); err != nil {
+		return err
+	}
+	if err := qtx.UpsertAgentStatRollupMinute(ctx, db.UpsertAgentStatRollupMinuteParams{
+		BucketUnixMillis: rollupBucketUnixMillis(stat.ReportedAt),
+		Samples:          1,
+		ReqSuccess:       stat.ReqSuccess,
+		ReqClientError:   stat.ReqClientError,
+		ReqServerError:   stat.ReqServerError,
+		ReqInternalError: stat.ReqInternalError,
+		BytesRx:          stat.BytesRx,
+		BytesTx:          stat.BytesTx,
+		MemoryMbSum:      stat.MemoryMb,
+		MaxMemoryMb:      stat.MemoryMb,
+		GoroutinesSum:    stat.Goroutines,
+		MaxGoroutines:    stat.Goroutines,
+		CpuPercentSum:    stat.CpuPercent,
+		MaxCpuPercent:    stat.CpuPercent,
+	}); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func proxyRequestRollupParams(event db.InsertProxyRequestEventAtParams) (db.UpsertProxyRequestRollupMinuteParams, db.UpsertProxyRequestTupleRollupMinuteParams) {
+	success := int64Bool(event.StatusCode >= 200 && event.StatusCode < 400)
+	clientError := int64Bool(event.StatusCode >= 400 && event.StatusCode < 500)
+	serverError := int64Bool(event.StatusCode >= 500)
+	internalError := int64Bool(event.ErrorKind != "")
+	cacheHits := int64Bool(event.CacheStatus == publicCacheStatusHit)
+	cacheMisses := int64Bool(event.CacheStatus == publicCacheStatusMiss || event.CacheStatus == publicCacheStatusStored || event.CacheStatus == publicCacheStatusStoreFailed)
+	cacheBypasses := int64Bool(event.CacheStatus == publicCacheStatusBypass)
+	cacheStored := int64Bool(event.CacheStatus == publicCacheStatusStored)
+	cacheStoreFailed := int64Bool(event.CacheStatus == publicCacheStatusStoreFailed)
+	cacheHitBytes := int64(0)
+	if event.CacheStatus == publicCacheStatusHit {
+		cacheHitBytes = event.CacheBytes
+	}
+	cacheStoredBytes := int64(0)
+	if event.CacheStatus == publicCacheStatusStored {
+		cacheStoredBytes = event.CacheBytes
+	}
+
+	bucketUnixMillis := rollupBucketUnixMillis(event.OccurredAt)
+	total := db.UpsertProxyRequestRollupMinuteParams{
+		BucketUnixMillis: bucketUnixMillis,
+		Requests:         1,
+		Success:          success,
+		ClientError:      clientError,
+		ServerError:      serverError,
+		InternalError:    internalError,
+		DurationMsSum:    event.DurationMs,
+		MaxDurationMs:    event.DurationMs,
+		SlowRequests:     int64Bool(event.DurationMs >= 1000),
+		RequestBytes:     event.RequestBytes,
+		ResponseBytes:    event.ResponseBytes,
+		CacheHits:        cacheHits,
+		CacheMisses:      cacheMisses,
+		CacheBypasses:    cacheBypasses,
+		CacheStored:      cacheStored,
+		CacheStoreFailed: cacheStoreFailed,
+		CacheHitBytes:    cacheHitBytes,
+		CacheStoredBytes: cacheStoredBytes,
+	}
+	tuple := db.UpsertProxyRequestTupleRollupMinuteParams{
+		BucketUnixMillis: bucketUnixMillis,
+		ListenerID:       nullInt64Value(event.ListenerID),
+		BackendID:        nullInt64Value(event.BackendID),
+		RouteID:          nullInt64Value(event.RouteID),
+		AgentID:          nullInt64Value(event.AgentID),
+		ErrorKind:        event.ErrorKind,
+		StatusClass:      proxyStatusClass(event.StatusCode),
+		Requests:         1,
+		Success:          success,
+		ClientError:      clientError,
+		ServerError:      serverError,
+		InternalError:    internalError,
+		DurationMsSum:    event.DurationMs,
+		RequestBytes:     event.RequestBytes,
+		ResponseBytes:    event.ResponseBytes,
+	}
+	return total, tuple
+}
+
+func (a *App) observabilityRollupsReady(ctx context.Context) (bool, error) {
+	if a.DB == nil {
+		return false, nil
+	}
+	state, err := a.DB.GetObservabilityRollupState(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return state.ProxyBackfilledThroughID >= state.ProxyBackfillUpperID &&
+		state.AgentBackfilledThroughID >= state.AgentBackfillUpperID, nil
+}
+
+func (a *App) backfillObservabilityRollupBatch(ctx context.Context) (bool, error) {
+	if a == nil || a.DB == nil {
+		return false, nil
+	}
+
+	tx, err := a.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+
+	qtx := a.DB.WithTx(tx)
+	state, err := qtx.GetObservabilityRollupState(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	if state.ProxyBackfilledThroughID < state.ProxyBackfillUpperID {
+		next, err := qtx.GetNextProxyRollupBackfillThroughID(ctx, db.GetNextProxyRollupBackfillThroughIDParams{
+			CurrentID: state.ProxyBackfilledThroughID,
+			UpperID:   state.ProxyBackfillUpperID,
+			BatchSize: observabilityRollupBackfillBatchRows,
+		})
+		if err != nil {
+			return false, err
+		}
+		if next <= state.ProxyBackfilledThroughID {
+			next = state.ProxyBackfillUpperID
+		} else {
+			if err := qtx.BackfillProxyRequestRollupMinutesRange(ctx, db.BackfillProxyRequestRollupMinutesRangeParams{
+				FromID:    state.ProxyBackfilledThroughID,
+				ThroughID: next,
+			}); err != nil {
+				return false, err
+			}
+			if err := qtx.BackfillProxyRequestTupleRollupMinutesRange(ctx, db.BackfillProxyRequestTupleRollupMinutesRangeParams{
+				FromID:    state.ProxyBackfilledThroughID,
+				ThroughID: next,
+			}); err != nil {
+				return false, err
+			}
+		}
+		if err := qtx.MarkProxyRollupBackfilledThrough(ctx, next); err != nil {
+			return false, err
+		}
+		return true, tx.Commit()
+	}
+
+	if state.AgentBackfilledThroughID < state.AgentBackfillUpperID {
+		next, err := qtx.GetNextAgentRollupBackfillThroughID(ctx, db.GetNextAgentRollupBackfillThroughIDParams{
+			CurrentID: state.AgentBackfilledThroughID,
+			UpperID:   state.AgentBackfillUpperID,
+			BatchSize: observabilityRollupBackfillBatchRows,
+		})
+		if err != nil {
+			return false, err
+		}
+		if next <= state.AgentBackfilledThroughID {
+			next = state.AgentBackfillUpperID
+		} else {
+			if err := qtx.BackfillAgentStatRollupMinutesRange(ctx, db.BackfillAgentStatRollupMinutesRangeParams{
+				FromID:    state.AgentBackfilledThroughID,
+				ThroughID: next,
+			}); err != nil {
+				return false, err
+			}
+		}
+		if err := qtx.MarkAgentRollupBackfilledThrough(ctx, next); err != nil {
+			return false, err
+		}
+		return true, tx.Commit()
+	}
+
+	return false, tx.Commit()
+}
+
+func (a *App) StartObservabilityMaintenance(ctx context.Context) {
+	if a == nil || a.DB == nil {
+		return
+	}
+	go func() {
+		backfillTicker := time.NewTicker(observabilityRollupBackfillInterval)
+		cleanupTicker := time.NewTicker(observabilityCleanupInterval)
+		defer backfillTicker.Stop()
+		defer cleanupTicker.Stop()
+
+		a.runObservabilityBackfillBatch(ctx)
+		a.cleanupObservability(ctx, time.Now().UTC())
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-backfillTicker.C:
+				a.runObservabilityBackfillBatch(ctx)
+			case now := <-cleanupTicker.C:
+				a.cleanupObservability(ctx, now.UTC())
+			}
+		}
+	}()
+}
+
+func (a *App) StartObservabilityCleanup(ctx context.Context) {
+	a.StartObservabilityMaintenance(ctx)
+}
+
+func (a *App) runObservabilityBackfillBatch(ctx context.Context) {
+	if _, err := a.backfillObservabilityRollupBatch(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		log.Warn().Err(err).Msg("Failed to backfill observability rollups")
+	}
+}
+
+func rollupBucketUnixMillis(t time.Time) int64 {
+	return t.UTC().Truncate(time.Minute).UnixMilli()
+}
+
+func proxyStatusClass(statusCode int64) int64 {
+	if statusCode < 200 || statusCode >= 600 {
+		return 0
+	}
+	return statusCode / 100
+}
+
+func int64Bool(value bool) int64 {
+	if value {
+		return 1
+	}
+	return 0
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -153,7 +153,9 @@ func (a *App) ReportStats(
 		Msg("Agent Health")
 
 	if a.DB != nil {
-		err := a.DB.InsertAgentStat(ctx, db.InsertAgentStatParams{
+		reportedAt := time.Now().UTC()
+		err := a.insertAgentStatWithRollup(ctx, db.InsertAgentStatAtParams{
+			ReportedAt:       reportedAt,
 			AgentID:          sql.NullInt64{Int64: agentRow.ID, Valid: true},
 			MemoryMb:         payload.MemorySysMb,
 			Goroutines:       payload.NumGoroutine,

--- a/observability_test.go
+++ b/observability_test.go
@@ -47,6 +47,7 @@ func TestE2E_GetDashboardSummaries(t *testing.T) {
 	insertProxyEventWithIDsAt(t, database, now.Add(-30*time.Minute), http.StatusNotFound, 200, "", validInt64(1), validInt64(1), sql.NullInt64{}, sql.NullInt64{}, 20, 200)
 	insertProxyEventWithIDsAt(t, database, now.Add(-2*time.Hour), http.StatusBadGateway, 1300, "", validInt64(2), validInt64(2), sql.NullInt64{}, sql.NullInt64{}, 30, 300)
 	insertProxyEventWithIDsAt(t, database, now.Add(-2*time.Minute), http.StatusGatewayTimeout, 1400, "agent_timeout", validInt64(2), validInt64(2), sql.NullInt64{}, sql.NullInt64{}, 40, 400)
+	forceDashboardRawFallback(t, database)
 
 	req := connect.NewRequest(&p2pstreamv1.GetDashboardRequest{})
 	req.Header().Set("Cookie", cookie)
@@ -230,8 +231,6 @@ func TestProxyRequestEventRecordedCountsOnly(t *testing.T) {
 func TestObservabilityRetentionCleanup(t *testing.T) {
 	database := newTestDB(t)
 	app := server.NewApp(testManagementConfig(config.Config{ObservabilityRetentionDays: 30}), database)
-	_, client := newTestManagementClient(t, app)
-	cookie := createAdminSession(t, client)
 
 	now := time.Now().UTC()
 	insertProxyEventAt(t, database, now.AddDate(0, 0, -31), http.StatusOK, 100, "")
@@ -256,13 +255,15 @@ func TestObservabilityRetentionCleanup(t *testing.T) {
 		t.Fatalf("insert active old connection: %v", err)
 	}
 
-	req := connect.NewRequest(&p2pstreamv1.GetDashboardRequest{})
-	req.Header().Set("Cookie", cookie)
-	if _, err := client.GetDashboard(context.Background(), req); err != nil {
-		t.Fatalf("get dashboard: %v", err)
-	}
+	maintCtx, cancelMaintenance := context.WithCancel(context.Background())
+	defer cancelMaintenance()
+	app.StartObservabilityMaintenance(maintCtx)
 
 	cutoff := time.Now().UTC().AddDate(0, 0, -30)
+	waitForCount(t, database, `SELECT COUNT(*) FROM proxy_request_events WHERE occurred_at < ?`, 0, cutoff)
+	waitForCount(t, database, `SELECT COUNT(*) FROM agent_stats WHERE reported_at < ?`, 0, cutoff)
+	waitForCount(t, database, `SELECT COUNT(*) FROM connections WHERE disconnected_at IS NOT NULL AND disconnected_at < ?`, 0, cutoff)
+
 	if countRows(t, database, `SELECT COUNT(*) FROM proxy_request_events WHERE occurred_at < ?`, cutoff) != 0 {
 		t.Fatal("expected old proxy events to be cleaned up")
 	}
@@ -467,6 +468,36 @@ func countRows(t *testing.T, database *db.DB, query string, args ...any) int64 {
 		t.Fatalf("count rows: %v", err)
 	}
 	return count
+}
+
+func forceDashboardRawFallback(t *testing.T, database *db.DB) {
+	t.Helper()
+	if _, err := database.ExecContext(context.Background(), `
+		UPDATE observability_rollup_state
+		SET proxy_backfill_upper_id = CAST(COALESCE((SELECT MAX(id) FROM proxy_request_events), 0) AS INTEGER),
+		    proxy_backfilled_through_id = 0,
+		    agent_backfill_upper_id = CAST(COALESCE((SELECT MAX(id) FROM agent_stats), 0) AS INTEGER),
+		    agent_backfilled_through_id = 0,
+		    updated_at = CURRENT_TIMESTAMP
+		WHERE id = 1
+	`); err != nil {
+		t.Fatalf("force dashboard raw fallback: %v", err)
+	}
+}
+
+func waitForCount(t *testing.T, database *db.DB, query string, want int64, args ...any) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got := countRows(t, database, query, args...)
+		if got == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("count for %q = %d, want %d", query, got, want)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 }
 
 func equalStringSlices(a []string, b []string) bool {

--- a/sql/query.sql
+++ b/sql/query.sql
@@ -15,6 +15,14 @@ INSERT INTO agent_stats (
     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 );
 
+-- name: InsertAgentStatAt :one
+INSERT INTO agent_stats (
+    reported_at, agent_id, memory_mb, goroutines, req_success, req_client_error, req_server_error, req_internal_error, bytes_rx, bytes_tx, cpu_percent
+) VALUES (
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+)
+RETURNING id;
+
 -- name: GetLatestAgentStat :one
 SELECT * FROM agent_stats
 ORDER BY id DESC
@@ -26,6 +34,86 @@ INSERT INTO proxy_request_events (
 ) VALUES (
     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 );
+
+-- name: InsertProxyRequestEventAt :one
+INSERT INTO proxy_request_events (
+    occurred_at, status_code, duration_ms, error_kind, listener_id, backend_id, route_id, waf_rule_id, waf_action, agent_id, request_bytes, response_bytes, cache_rule_id, cache_status, cache_bytes
+) VALUES (
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+)
+RETURNING id;
+
+-- name: UpsertProxyRequestRollupMinute :exec
+INSERT INTO proxy_request_rollup_minutes (
+    bucket_unix_millis, requests, success, client_error, server_error, internal_error,
+    duration_ms_sum, max_duration_ms, slow_requests, request_bytes, response_bytes,
+    cache_hits, cache_misses, cache_bypasses, cache_stored, cache_store_failed,
+    cache_hit_bytes, cache_stored_bytes
+) VALUES (
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+)
+ON CONFLICT(bucket_unix_millis) DO UPDATE SET
+    requests = proxy_request_rollup_minutes.requests + excluded.requests,
+    success = proxy_request_rollup_minutes.success + excluded.success,
+    client_error = proxy_request_rollup_minutes.client_error + excluded.client_error,
+    server_error = proxy_request_rollup_minutes.server_error + excluded.server_error,
+    internal_error = proxy_request_rollup_minutes.internal_error + excluded.internal_error,
+    duration_ms_sum = proxy_request_rollup_minutes.duration_ms_sum + excluded.duration_ms_sum,
+    max_duration_ms = MAX(proxy_request_rollup_minutes.max_duration_ms, excluded.max_duration_ms),
+    slow_requests = proxy_request_rollup_minutes.slow_requests + excluded.slow_requests,
+    request_bytes = proxy_request_rollup_minutes.request_bytes + excluded.request_bytes,
+    response_bytes = proxy_request_rollup_minutes.response_bytes + excluded.response_bytes,
+    cache_hits = proxy_request_rollup_minutes.cache_hits + excluded.cache_hits,
+    cache_misses = proxy_request_rollup_minutes.cache_misses + excluded.cache_misses,
+    cache_bypasses = proxy_request_rollup_minutes.cache_bypasses + excluded.cache_bypasses,
+    cache_stored = proxy_request_rollup_minutes.cache_stored + excluded.cache_stored,
+    cache_store_failed = proxy_request_rollup_minutes.cache_store_failed + excluded.cache_store_failed,
+    cache_hit_bytes = proxy_request_rollup_minutes.cache_hit_bytes + excluded.cache_hit_bytes,
+    cache_stored_bytes = proxy_request_rollup_minutes.cache_stored_bytes + excluded.cache_stored_bytes,
+    updated_at = CURRENT_TIMESTAMP;
+
+-- name: UpsertProxyRequestTupleRollupMinute :exec
+INSERT INTO proxy_request_tuple_rollup_minutes (
+    bucket_unix_millis, listener_id, backend_id, route_id, agent_id, error_kind, status_class,
+    requests, success, client_error, server_error, internal_error, duration_ms_sum,
+    request_bytes, response_bytes
+) VALUES (
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+)
+ON CONFLICT(bucket_unix_millis, listener_id, backend_id, route_id, agent_id, error_kind, status_class) DO UPDATE SET
+    requests = proxy_request_tuple_rollup_minutes.requests + excluded.requests,
+    success = proxy_request_tuple_rollup_minutes.success + excluded.success,
+    client_error = proxy_request_tuple_rollup_minutes.client_error + excluded.client_error,
+    server_error = proxy_request_tuple_rollup_minutes.server_error + excluded.server_error,
+    internal_error = proxy_request_tuple_rollup_minutes.internal_error + excluded.internal_error,
+    duration_ms_sum = proxy_request_tuple_rollup_minutes.duration_ms_sum + excluded.duration_ms_sum,
+    request_bytes = proxy_request_tuple_rollup_minutes.request_bytes + excluded.request_bytes,
+    response_bytes = proxy_request_tuple_rollup_minutes.response_bytes + excluded.response_bytes,
+    updated_at = CURRENT_TIMESTAMP;
+
+-- name: UpsertAgentStatRollupMinute :exec
+INSERT INTO agent_stat_rollup_minutes (
+    bucket_unix_millis, samples, req_success, req_client_error, req_server_error, req_internal_error,
+    bytes_rx, bytes_tx, memory_mb_sum, max_memory_mb, goroutines_sum, max_goroutines,
+    cpu_percent_sum, max_cpu_percent
+) VALUES (
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+)
+ON CONFLICT(bucket_unix_millis) DO UPDATE SET
+    samples = agent_stat_rollup_minutes.samples + excluded.samples,
+    req_success = agent_stat_rollup_minutes.req_success + excluded.req_success,
+    req_client_error = agent_stat_rollup_minutes.req_client_error + excluded.req_client_error,
+    req_server_error = agent_stat_rollup_minutes.req_server_error + excluded.req_server_error,
+    req_internal_error = agent_stat_rollup_minutes.req_internal_error + excluded.req_internal_error,
+    bytes_rx = agent_stat_rollup_minutes.bytes_rx + excluded.bytes_rx,
+    bytes_tx = agent_stat_rollup_minutes.bytes_tx + excluded.bytes_tx,
+    memory_mb_sum = agent_stat_rollup_minutes.memory_mb_sum + excluded.memory_mb_sum,
+    max_memory_mb = MAX(agent_stat_rollup_minutes.max_memory_mb, excluded.max_memory_mb),
+    goroutines_sum = agent_stat_rollup_minutes.goroutines_sum + excluded.goroutines_sum,
+    max_goroutines = MAX(agent_stat_rollup_minutes.max_goroutines, excluded.max_goroutines),
+    cpu_percent_sum = agent_stat_rollup_minutes.cpu_percent_sum + excluded.cpu_percent_sum,
+    max_cpu_percent = MAX(agent_stat_rollup_minutes.max_cpu_percent, excluded.max_cpu_percent),
+    updated_at = CURRENT_TIMESTAMP;
 
 -- name: GetProxyRequestSummarySince :one
 SELECT
@@ -64,7 +152,7 @@ SELECT
     CAST(COALESCE(AVG(pre.duration_ms), 0) AS INTEGER) AS avg_duration_ms,
     CAST(COALESCE(SUM(pre.request_bytes), 0) AS INTEGER) AS request_bytes,
     CAST(COALESCE(SUM(pre.response_bytes), 0) AS INTEGER) AS response_bytes
-FROM proxy_request_events pre
+FROM proxy_request_events AS pre INDEXED BY idx_proxy_request_events_occurred_at
 LEFT JOIN public_listeners pl ON pl.id = pre.listener_id
 WHERE pre.occurred_at >= ?
 GROUP BY pre.listener_id, pl.name
@@ -83,7 +171,7 @@ SELECT
     CAST(COALESCE(AVG(pre.duration_ms), 0) AS INTEGER) AS avg_duration_ms,
     CAST(COALESCE(SUM(pre.request_bytes), 0) AS INTEGER) AS request_bytes,
     CAST(COALESCE(SUM(pre.response_bytes), 0) AS INTEGER) AS response_bytes
-FROM proxy_request_events pre
+FROM proxy_request_events AS pre INDEXED BY idx_proxy_request_events_occurred_at
 LEFT JOIN public_backends pb ON pb.id = pre.backend_id
 WHERE pre.occurred_at >= ?
 GROUP BY pre.backend_id, pb.name
@@ -109,7 +197,7 @@ SELECT
     CAST(COALESCE(AVG(pre.duration_ms), 0) AS INTEGER) AS avg_duration_ms,
     CAST(COALESCE(SUM(pre.request_bytes), 0) AS INTEGER) AS request_bytes,
     CAST(COALESCE(SUM(pre.response_bytes), 0) AS INTEGER) AS response_bytes
-FROM proxy_request_events pre
+FROM proxy_request_events AS pre INDEXED BY idx_proxy_request_events_occurred_at
 LEFT JOIN public_routes pr ON pr.id = pre.route_id
 WHERE pre.occurred_at >= ?
 GROUP BY pre.route_id, pr.id, pr.host_pattern, pr.path_prefix
@@ -128,7 +216,7 @@ SELECT
     CAST(COALESCE(AVG(pre.duration_ms), 0) AS INTEGER) AS avg_duration_ms,
     CAST(COALESCE(SUM(pre.request_bytes), 0) AS INTEGER) AS request_bytes,
     CAST(COALESCE(SUM(pre.response_bytes), 0) AS INTEGER) AS response_bytes
-FROM proxy_request_events pre
+FROM proxy_request_events AS pre INDEXED BY idx_proxy_request_events_occurred_at
 LEFT JOIN agents a ON a.id = pre.agent_id
 WHERE pre.occurred_at >= ?
   AND pre.agent_id IS NOT NULL
@@ -148,7 +236,7 @@ SELECT
     CAST(COALESCE(AVG(duration_ms), 0) AS INTEGER) AS avg_duration_ms,
     CAST(COALESCE(SUM(request_bytes), 0) AS INTEGER) AS request_bytes,
     CAST(COALESCE(SUM(response_bytes), 0) AS INTEGER) AS response_bytes
-FROM proxy_request_events
+FROM proxy_request_events INDEXED BY idx_proxy_request_events_occurred_at
 WHERE occurred_at >= ?
   AND error_kind != ''
 GROUP BY error_kind
@@ -167,7 +255,7 @@ SELECT
     CAST(COALESCE(AVG(duration_ms), 0) AS INTEGER) AS avg_duration_ms,
     CAST(COALESCE(SUM(request_bytes), 0) AS INTEGER) AS request_bytes,
     CAST(COALESCE(SUM(response_bytes), 0) AS INTEGER) AS response_bytes
-FROM proxy_request_events
+FROM proxy_request_events INDEXED BY idx_proxy_request_events_occurred_at
 WHERE occurred_at >= ?
   AND status_code >= 200
   AND status_code < 600
@@ -185,7 +273,7 @@ SELECT
     CAST(COALESCE(SUM(request_bytes), 0) AS INTEGER) AS request_bytes,
     CAST(COALESCE(SUM(response_bytes), 0) AS INTEGER) AS response_bytes,
     CAST(COALESCE(AVG(duration_ms), 0) AS INTEGER) AS avg_duration_ms
-FROM proxy_request_events
+FROM proxy_request_events INDEXED BY idx_proxy_request_events_occurred_at
 WHERE occurred_at >= sqlc.arg(since)
 GROUP BY bucket_unix_millis
 ORDER BY bucket_unix_millis ASC;
@@ -207,6 +295,187 @@ SELECT
     CAST(COALESCE(MAX(cpu_percent), 0) AS REAL) AS max_cpu_percent
 FROM agent_stats
 WHERE reported_at >= ?;
+
+-- name: GetProxyRequestRollupSummarySince :one
+SELECT
+    CAST(COALESCE(SUM(requests), 0) AS INTEGER) AS total_requests,
+    CAST(COALESCE(SUM(success), 0) AS INTEGER) AS success,
+    CAST(COALESCE(SUM(client_error), 0) AS INTEGER) AS client_error,
+    CAST(COALESCE(SUM(server_error), 0) AS INTEGER) AS server_error,
+    CAST(COALESCE(SUM(internal_error), 0) AS INTEGER) AS internal_error,
+    CAST(CASE WHEN COALESCE(SUM(requests), 0) > 0 THEN COALESCE(SUM(duration_ms_sum), 0) / SUM(requests) ELSE 0 END AS INTEGER) AS avg_duration_ms,
+    CAST(COALESCE(SUM(request_bytes), 0) AS INTEGER) AS request_bytes,
+    CAST(COALESCE(SUM(response_bytes), 0) AS INTEGER) AS response_bytes,
+    CAST(COALESCE(SUM(request_bytes + response_bytes), 0) AS INTEGER) AS total_bytes,
+    CAST(CASE WHEN COALESCE(SUM(requests), 0) > 0 THEN COALESCE(SUM(request_bytes), 0) / SUM(requests) ELSE 0 END AS INTEGER) AS avg_request_bytes,
+    CAST(CASE WHEN COALESCE(SUM(requests), 0) > 0 THEN COALESCE(SUM(response_bytes), 0) / SUM(requests) ELSE 0 END AS INTEGER) AS avg_response_bytes,
+    CAST(COALESCE(MAX(max_duration_ms), 0) AS INTEGER) AS max_duration_ms,
+    CAST(COALESCE(SUM(slow_requests), 0) AS INTEGER) AS slow_requests,
+    CAST(COALESCE(SUM(cache_hits), 0) AS INTEGER) AS cache_hits,
+    CAST(COALESCE(SUM(cache_misses), 0) AS INTEGER) AS cache_misses,
+    CAST(COALESCE(SUM(cache_bypasses), 0) AS INTEGER) AS cache_bypasses,
+    CAST(COALESCE(SUM(cache_stored), 0) AS INTEGER) AS cache_stored,
+    CAST(COALESCE(SUM(cache_store_failed), 0) AS INTEGER) AS cache_store_failed,
+    CAST(COALESCE(SUM(cache_hit_bytes), 0) AS INTEGER) AS cache_hit_bytes,
+    CAST(COALESCE(SUM(cache_stored_bytes), 0) AS INTEGER) AS cache_stored_bytes
+FROM proxy_request_rollup_minutes
+WHERE bucket_unix_millis >= ?;
+
+-- name: GetAgentStatsRollupSummarySince :one
+SELECT
+    CAST(COALESCE(SUM(samples), 0) AS INTEGER) AS samples,
+    CAST(COALESCE(SUM(req_success), 0) AS INTEGER) AS req_success,
+    CAST(COALESCE(SUM(req_client_error), 0) AS INTEGER) AS req_client_error,
+    CAST(COALESCE(SUM(req_server_error), 0) AS INTEGER) AS req_server_error,
+    CAST(COALESCE(SUM(req_internal_error), 0) AS INTEGER) AS req_internal_error,
+    CAST(COALESCE(SUM(bytes_rx), 0) AS INTEGER) AS bytes_rx,
+    CAST(COALESCE(SUM(bytes_tx), 0) AS INTEGER) AS bytes_tx,
+    CAST(CASE WHEN COALESCE(SUM(samples), 0) > 0 THEN COALESCE(SUM(memory_mb_sum), 0) / SUM(samples) ELSE 0 END AS INTEGER) AS avg_memory_mb,
+    CAST(COALESCE(MAX(max_memory_mb), 0) AS INTEGER) AS max_memory_mb,
+    CAST(CASE WHEN COALESCE(SUM(samples), 0) > 0 THEN COALESCE(SUM(goroutines_sum), 0) / SUM(samples) ELSE 0 END AS INTEGER) AS avg_goroutines,
+    CAST(COALESCE(MAX(max_goroutines), 0) AS INTEGER) AS max_goroutines,
+    CAST(CASE WHEN COALESCE(SUM(samples), 0) > 0 THEN COALESCE(SUM(cpu_percent_sum), 0) / SUM(samples) ELSE 0 END AS REAL) AS avg_cpu_percent,
+    CAST(COALESCE(MAX(max_cpu_percent), 0) AS REAL) AS max_cpu_percent
+FROM agent_stat_rollup_minutes
+WHERE bucket_unix_millis >= ?;
+
+-- name: ListTopProxyListenersRollupsSince :many
+SELECT
+    r.listener_id AS id,
+    COALESCE(pl.name, CASE WHEN r.listener_id = 0 THEN 'unknown listener' ELSE 'listener #' || r.listener_id END) AS label,
+    CAST(COALESCE(SUM(r.requests), 0) AS INTEGER) AS requests,
+    CAST(COALESCE(SUM(r.success), 0) AS INTEGER) AS success,
+    CAST(COALESCE(SUM(r.client_error), 0) AS INTEGER) AS client_error,
+    CAST(COALESCE(SUM(r.server_error), 0) AS INTEGER) AS server_error,
+    CAST(COALESCE(SUM(r.internal_error), 0) AS INTEGER) AS internal_error,
+    CAST(CASE WHEN COALESCE(SUM(r.requests), 0) > 0 THEN COALESCE(SUM(r.duration_ms_sum), 0) / SUM(r.requests) ELSE 0 END AS INTEGER) AS avg_duration_ms,
+    CAST(COALESCE(SUM(r.request_bytes), 0) AS INTEGER) AS request_bytes,
+    CAST(COALESCE(SUM(r.response_bytes), 0) AS INTEGER) AS response_bytes
+FROM proxy_request_tuple_rollup_minutes r
+LEFT JOIN public_listeners pl ON pl.id = r.listener_id
+WHERE r.bucket_unix_millis >= ?
+GROUP BY r.listener_id, pl.name
+ORDER BY requests DESC, id ASC
+LIMIT 5;
+
+-- name: ListTopProxyBackendsRollupsSince :many
+SELECT
+    r.backend_id AS id,
+    COALESCE(pb.name, CASE WHEN r.backend_id = 0 THEN 'unknown backend' ELSE 'backend #' || r.backend_id END) AS label,
+    CAST(COALESCE(SUM(r.requests), 0) AS INTEGER) AS requests,
+    CAST(COALESCE(SUM(r.success), 0) AS INTEGER) AS success,
+    CAST(COALESCE(SUM(r.client_error), 0) AS INTEGER) AS client_error,
+    CAST(COALESCE(SUM(r.server_error), 0) AS INTEGER) AS server_error,
+    CAST(COALESCE(SUM(r.internal_error), 0) AS INTEGER) AS internal_error,
+    CAST(CASE WHEN COALESCE(SUM(r.requests), 0) > 0 THEN COALESCE(SUM(r.duration_ms_sum), 0) / SUM(r.requests) ELSE 0 END AS INTEGER) AS avg_duration_ms,
+    CAST(COALESCE(SUM(r.request_bytes), 0) AS INTEGER) AS request_bytes,
+    CAST(COALESCE(SUM(r.response_bytes), 0) AS INTEGER) AS response_bytes
+FROM proxy_request_tuple_rollup_minutes r
+LEFT JOIN public_backends pb ON pb.id = r.backend_id
+WHERE r.bucket_unix_millis >= ?
+GROUP BY r.backend_id, pb.name
+ORDER BY requests DESC, id ASC
+LIMIT 5;
+
+-- name: ListTopProxyRoutesRollupsSince :many
+SELECT
+    r.route_id AS id,
+    CASE
+        WHEN r.route_id = 0 THEN 'Default route'
+        WHEN pr.id IS NULL THEN 'route #' || r.route_id
+        WHEN pr.host_pattern != '' AND pr.path_prefix != '' THEN pr.host_pattern || ' ' || pr.path_prefix
+        WHEN pr.host_pattern != '' THEN pr.host_pattern
+        WHEN pr.path_prefix != '' THEN pr.path_prefix
+        ELSE 'route #' || pr.id
+    END AS label,
+    CAST(COALESCE(SUM(r.requests), 0) AS INTEGER) AS requests,
+    CAST(COALESCE(SUM(r.success), 0) AS INTEGER) AS success,
+    CAST(COALESCE(SUM(r.client_error), 0) AS INTEGER) AS client_error,
+    CAST(COALESCE(SUM(r.server_error), 0) AS INTEGER) AS server_error,
+    CAST(COALESCE(SUM(r.internal_error), 0) AS INTEGER) AS internal_error,
+    CAST(CASE WHEN COALESCE(SUM(r.requests), 0) > 0 THEN COALESCE(SUM(r.duration_ms_sum), 0) / SUM(r.requests) ELSE 0 END AS INTEGER) AS avg_duration_ms,
+    CAST(COALESCE(SUM(r.request_bytes), 0) AS INTEGER) AS request_bytes,
+    CAST(COALESCE(SUM(r.response_bytes), 0) AS INTEGER) AS response_bytes
+FROM proxy_request_tuple_rollup_minutes r
+LEFT JOIN public_routes pr ON pr.id = r.route_id
+WHERE r.bucket_unix_millis >= ?
+GROUP BY r.route_id, pr.id, pr.host_pattern, pr.path_prefix
+ORDER BY requests DESC, id ASC
+LIMIT 5;
+
+-- name: ListTopProxyAgentsRollupsSince :many
+SELECT
+    r.agent_id AS id,
+    COALESCE(a.name, 'agent #' || r.agent_id) AS label,
+    CAST(COALESCE(SUM(r.requests), 0) AS INTEGER) AS requests,
+    CAST(COALESCE(SUM(r.success), 0) AS INTEGER) AS success,
+    CAST(COALESCE(SUM(r.client_error), 0) AS INTEGER) AS client_error,
+    CAST(COALESCE(SUM(r.server_error), 0) AS INTEGER) AS server_error,
+    CAST(COALESCE(SUM(r.internal_error), 0) AS INTEGER) AS internal_error,
+    CAST(CASE WHEN COALESCE(SUM(r.requests), 0) > 0 THEN COALESCE(SUM(r.duration_ms_sum), 0) / SUM(r.requests) ELSE 0 END AS INTEGER) AS avg_duration_ms,
+    CAST(COALESCE(SUM(r.request_bytes), 0) AS INTEGER) AS request_bytes,
+    CAST(COALESCE(SUM(r.response_bytes), 0) AS INTEGER) AS response_bytes
+FROM proxy_request_tuple_rollup_minutes r
+LEFT JOIN agents a ON a.id = r.agent_id
+WHERE r.bucket_unix_millis >= ?
+  AND r.agent_id != 0
+GROUP BY r.agent_id, a.name
+ORDER BY requests DESC, id ASC
+LIMIT 5;
+
+-- name: ListTopProxyErrorKindsRollupsSince :many
+SELECT
+    CAST(0 AS INTEGER) AS id,
+    r.error_kind AS label,
+    CAST(COALESCE(SUM(r.requests), 0) AS INTEGER) AS requests,
+    CAST(COALESCE(SUM(r.success), 0) AS INTEGER) AS success,
+    CAST(COALESCE(SUM(r.client_error), 0) AS INTEGER) AS client_error,
+    CAST(COALESCE(SUM(r.server_error), 0) AS INTEGER) AS server_error,
+    CAST(COALESCE(SUM(r.internal_error), 0) AS INTEGER) AS internal_error,
+    CAST(CASE WHEN COALESCE(SUM(r.requests), 0) > 0 THEN COALESCE(SUM(r.duration_ms_sum), 0) / SUM(r.requests) ELSE 0 END AS INTEGER) AS avg_duration_ms,
+    CAST(COALESCE(SUM(r.request_bytes), 0) AS INTEGER) AS request_bytes,
+    CAST(COALESCE(SUM(r.response_bytes), 0) AS INTEGER) AS response_bytes
+FROM proxy_request_tuple_rollup_minutes r
+WHERE r.bucket_unix_millis >= ?
+  AND r.error_kind != ''
+GROUP BY r.error_kind
+ORDER BY requests DESC, label ASC
+LIMIT 5;
+
+-- name: ListProxyStatusClassesRollupsSince :many
+SELECT
+    r.status_class AS id,
+    CAST(r.status_class AS TEXT) || 'xx' AS label,
+    CAST(COALESCE(SUM(r.requests), 0) AS INTEGER) AS requests,
+    CAST(COALESCE(SUM(r.success), 0) AS INTEGER) AS success,
+    CAST(COALESCE(SUM(r.client_error), 0) AS INTEGER) AS client_error,
+    CAST(COALESCE(SUM(r.server_error), 0) AS INTEGER) AS server_error,
+    CAST(COALESCE(SUM(r.internal_error), 0) AS INTEGER) AS internal_error,
+    CAST(CASE WHEN COALESCE(SUM(r.requests), 0) > 0 THEN COALESCE(SUM(r.duration_ms_sum), 0) / SUM(r.requests) ELSE 0 END AS INTEGER) AS avg_duration_ms,
+    CAST(COALESCE(SUM(r.request_bytes), 0) AS INTEGER) AS request_bytes,
+    CAST(COALESCE(SUM(r.response_bytes), 0) AS INTEGER) AS response_bytes
+FROM proxy_request_tuple_rollup_minutes r
+WHERE r.bucket_unix_millis >= ?
+  AND r.status_class >= 2
+  AND r.status_class < 6
+GROUP BY r.status_class
+ORDER BY id ASC;
+
+-- name: ListProxyTrafficBucketRollupsSince :many
+SELECT
+    CAST((bucket_unix_millis / (CAST(sqlc.arg(bucket_seconds) AS INTEGER) * 1000)) * (CAST(sqlc.arg(bucket_seconds) AS INTEGER) * 1000) AS INTEGER) AS bucket_unix_millis,
+    CAST(COALESCE(SUM(requests), 0) AS INTEGER) AS requests,
+    CAST(COALESCE(SUM(success), 0) AS INTEGER) AS success,
+    CAST(COALESCE(SUM(client_error), 0) AS INTEGER) AS client_error,
+    CAST(COALESCE(SUM(server_error), 0) AS INTEGER) AS server_error,
+    CAST(COALESCE(SUM(internal_error), 0) AS INTEGER) AS internal_error,
+    CAST(COALESCE(SUM(request_bytes), 0) AS INTEGER) AS request_bytes,
+    CAST(COALESCE(SUM(response_bytes), 0) AS INTEGER) AS response_bytes,
+    CAST(CASE WHEN COALESCE(SUM(requests), 0) > 0 THEN COALESCE(SUM(duration_ms_sum), 0) / SUM(requests) ELSE 0 END AS INTEGER) AS avg_duration_ms
+FROM proxy_request_rollup_minutes
+WHERE bucket_unix_millis >= sqlc.arg(since_unix_millis)
+GROUP BY 1
+ORDER BY bucket_unix_millis ASC;
 
 -- name: GetConnectionSummarySince :one
 SELECT
@@ -314,32 +583,221 @@ LIMIT 1;
 DELETE FROM proxy_request_events
 WHERE occurred_at < ?;
 
--- name: DeleteOldestProxyRequestEventsOverLimit :exec
+-- name: DeleteOldestProxyRequestEventsOverLimit :execrows
 DELETE FROM proxy_request_events
 WHERE id IN (
     SELECT id
-    FROM proxy_request_events
-    ORDER BY occurred_at DESC, id DESC
-    LIMIT -1 OFFSET ?
+    FROM (
+        SELECT id
+        FROM proxy_request_events
+        ORDER BY occurred_at DESC, id DESC
+        LIMIT -1 OFFSET sqlc.arg(offset)
+    )
+    ORDER BY id ASC
+    LIMIT sqlc.arg(delete_limit)
 );
 
 -- name: DeleteAgentStatsBefore :exec
 DELETE FROM agent_stats
 WHERE reported_at < ?;
 
--- name: DeleteOldestAgentStatsOverLimit :exec
+-- name: DeleteOldestAgentStatsOverLimit :execrows
 DELETE FROM agent_stats
 WHERE id IN (
     SELECT id
-    FROM agent_stats
-    ORDER BY reported_at DESC, id DESC
-    LIMIT -1 OFFSET ?
+    FROM (
+        SELECT id
+        FROM agent_stats
+        ORDER BY reported_at DESC, id DESC
+        LIMIT -1 OFFSET sqlc.arg(offset)
+    )
+    ORDER BY id ASC
+    LIMIT sqlc.arg(delete_limit)
 );
 
 -- name: DeleteDisconnectedConnectionsBefore :exec
 DELETE FROM connections
 WHERE disconnected_at IS NOT NULL
   AND disconnected_at < ?;
+
+-- name: DeleteProxyRequestRollupsBefore :exec
+DELETE FROM proxy_request_rollup_minutes
+WHERE bucket_unix_millis < ?;
+
+-- name: DeleteProxyRequestTupleRollupsBefore :exec
+DELETE FROM proxy_request_tuple_rollup_minutes
+WHERE bucket_unix_millis < ?;
+
+-- name: DeleteAgentStatRollupsBefore :exec
+DELETE FROM agent_stat_rollup_minutes
+WHERE bucket_unix_millis < ?;
+
+-- name: GetObservabilityRollupState :one
+SELECT id, proxy_backfill_upper_id, proxy_backfilled_through_id, agent_backfill_upper_id, agent_backfilled_through_id, created_at, updated_at
+FROM observability_rollup_state
+WHERE id = 1;
+
+-- name: GetNextProxyRollupBackfillThroughID :one
+SELECT CAST(COALESCE(MAX(id), sqlc.arg(current_id)) AS INTEGER) AS through_id
+FROM (
+    SELECT id
+    FROM proxy_request_events
+    WHERE id > sqlc.arg(current_id)
+      AND id <= sqlc.arg(upper_id)
+    ORDER BY id ASC
+    LIMIT sqlc.arg(batch_size)
+);
+
+-- name: GetNextAgentRollupBackfillThroughID :one
+SELECT CAST(COALESCE(MAX(id), sqlc.arg(current_id)) AS INTEGER) AS through_id
+FROM (
+    SELECT id
+    FROM agent_stats
+    WHERE id > sqlc.arg(current_id)
+      AND id <= sqlc.arg(upper_id)
+    ORDER BY id ASC
+    LIMIT sqlc.arg(batch_size)
+);
+
+-- name: BackfillProxyRequestRollupMinutesRange :exec
+INSERT INTO proxy_request_rollup_minutes (
+    bucket_unix_millis, requests, success, client_error, server_error, internal_error,
+    duration_ms_sum, max_duration_ms, slow_requests, request_bytes, response_bytes,
+    cache_hits, cache_misses, cache_bypasses, cache_stored, cache_store_failed,
+    cache_hit_bytes, cache_stored_bytes
+)
+SELECT
+    CAST((unixepoch(occurred_at) / 60) * 60 * 1000 AS INTEGER) AS bucket_unix_millis,
+    COUNT(*) AS requests,
+    CAST(COALESCE(SUM(CASE WHEN status_code >= 200 AND status_code < 400 THEN 1 ELSE 0 END), 0) AS INTEGER) AS success,
+    CAST(COALESCE(SUM(CASE WHEN status_code >= 400 AND status_code < 500 THEN 1 ELSE 0 END), 0) AS INTEGER) AS client_error,
+    CAST(COALESCE(SUM(CASE WHEN status_code >= 500 THEN 1 ELSE 0 END), 0) AS INTEGER) AS server_error,
+    CAST(COALESCE(SUM(CASE WHEN error_kind != '' THEN 1 ELSE 0 END), 0) AS INTEGER) AS internal_error,
+    CAST(COALESCE(SUM(duration_ms), 0) AS INTEGER) AS duration_ms_sum,
+    CAST(COALESCE(MAX(duration_ms), 0) AS INTEGER) AS max_duration_ms,
+    CAST(COALESCE(SUM(CASE WHEN duration_ms >= 1000 THEN 1 ELSE 0 END), 0) AS INTEGER) AS slow_requests,
+    CAST(COALESCE(SUM(request_bytes), 0) AS INTEGER) AS request_bytes,
+    CAST(COALESCE(SUM(response_bytes), 0) AS INTEGER) AS response_bytes,
+    CAST(COALESCE(SUM(CASE WHEN cache_status = 'hit' THEN 1 ELSE 0 END), 0) AS INTEGER) AS cache_hits,
+    CAST(COALESCE(SUM(CASE WHEN cache_status IN ('miss', 'stored', 'store_failed') THEN 1 ELSE 0 END), 0) AS INTEGER) AS cache_misses,
+    CAST(COALESCE(SUM(CASE WHEN cache_status = 'bypass' THEN 1 ELSE 0 END), 0) AS INTEGER) AS cache_bypasses,
+    CAST(COALESCE(SUM(CASE WHEN cache_status = 'stored' THEN 1 ELSE 0 END), 0) AS INTEGER) AS cache_stored,
+    CAST(COALESCE(SUM(CASE WHEN cache_status = 'store_failed' THEN 1 ELSE 0 END), 0) AS INTEGER) AS cache_store_failed,
+    CAST(COALESCE(SUM(CASE WHEN cache_status = 'hit' THEN cache_bytes ELSE 0 END), 0) AS INTEGER) AS cache_hit_bytes,
+    CAST(COALESCE(SUM(CASE WHEN cache_status = 'stored' THEN cache_bytes ELSE 0 END), 0) AS INTEGER) AS cache_stored_bytes
+FROM proxy_request_events
+WHERE id > sqlc.arg(from_id)
+  AND id <= sqlc.arg(through_id)
+GROUP BY bucket_unix_millis
+ON CONFLICT(bucket_unix_millis) DO UPDATE SET
+    requests = proxy_request_rollup_minutes.requests + excluded.requests,
+    success = proxy_request_rollup_minutes.success + excluded.success,
+    client_error = proxy_request_rollup_minutes.client_error + excluded.client_error,
+    server_error = proxy_request_rollup_minutes.server_error + excluded.server_error,
+    internal_error = proxy_request_rollup_minutes.internal_error + excluded.internal_error,
+    duration_ms_sum = proxy_request_rollup_minutes.duration_ms_sum + excluded.duration_ms_sum,
+    max_duration_ms = MAX(proxy_request_rollup_minutes.max_duration_ms, excluded.max_duration_ms),
+    slow_requests = proxy_request_rollup_minutes.slow_requests + excluded.slow_requests,
+    request_bytes = proxy_request_rollup_minutes.request_bytes + excluded.request_bytes,
+    response_bytes = proxy_request_rollup_minutes.response_bytes + excluded.response_bytes,
+    cache_hits = proxy_request_rollup_minutes.cache_hits + excluded.cache_hits,
+    cache_misses = proxy_request_rollup_minutes.cache_misses + excluded.cache_misses,
+    cache_bypasses = proxy_request_rollup_minutes.cache_bypasses + excluded.cache_bypasses,
+    cache_stored = proxy_request_rollup_minutes.cache_stored + excluded.cache_stored,
+    cache_store_failed = proxy_request_rollup_minutes.cache_store_failed + excluded.cache_store_failed,
+    cache_hit_bytes = proxy_request_rollup_minutes.cache_hit_bytes + excluded.cache_hit_bytes,
+    cache_stored_bytes = proxy_request_rollup_minutes.cache_stored_bytes + excluded.cache_stored_bytes,
+    updated_at = CURRENT_TIMESTAMP;
+
+-- name: BackfillProxyRequestTupleRollupMinutesRange :exec
+INSERT INTO proxy_request_tuple_rollup_minutes (
+    bucket_unix_millis, listener_id, backend_id, route_id, agent_id, error_kind, status_class,
+    requests, success, client_error, server_error, internal_error, duration_ms_sum,
+    request_bytes, response_bytes
+)
+SELECT
+    CAST((unixepoch(occurred_at) / 60) * 60 * 1000 AS INTEGER) AS bucket_unix_millis,
+    CAST(COALESCE(listener_id, 0) AS INTEGER) AS listener_id,
+    CAST(COALESCE(backend_id, 0) AS INTEGER) AS backend_id,
+    CAST(COALESCE(route_id, 0) AS INTEGER) AS route_id,
+    CAST(COALESCE(agent_id, 0) AS INTEGER) AS agent_id,
+    error_kind,
+    CAST(CASE WHEN status_code >= 200 AND status_code < 600 THEN status_code / 100 ELSE 0 END AS INTEGER) AS status_class,
+    COUNT(*) AS requests,
+    CAST(COALESCE(SUM(CASE WHEN status_code >= 200 AND status_code < 400 THEN 1 ELSE 0 END), 0) AS INTEGER) AS success,
+    CAST(COALESCE(SUM(CASE WHEN status_code >= 400 AND status_code < 500 THEN 1 ELSE 0 END), 0) AS INTEGER) AS client_error,
+    CAST(COALESCE(SUM(CASE WHEN status_code >= 500 THEN 1 ELSE 0 END), 0) AS INTEGER) AS server_error,
+    CAST(COALESCE(SUM(CASE WHEN error_kind != '' THEN 1 ELSE 0 END), 0) AS INTEGER) AS internal_error,
+    CAST(COALESCE(SUM(duration_ms), 0) AS INTEGER) AS duration_ms_sum,
+    CAST(COALESCE(SUM(request_bytes), 0) AS INTEGER) AS request_bytes,
+    CAST(COALESCE(SUM(response_bytes), 0) AS INTEGER) AS response_bytes
+FROM proxy_request_events
+WHERE id > sqlc.arg(from_id)
+  AND id <= sqlc.arg(through_id)
+GROUP BY bucket_unix_millis, listener_id, backend_id, route_id, agent_id, error_kind, status_class
+ON CONFLICT(bucket_unix_millis, listener_id, backend_id, route_id, agent_id, error_kind, status_class) DO UPDATE SET
+    requests = proxy_request_tuple_rollup_minutes.requests + excluded.requests,
+    success = proxy_request_tuple_rollup_minutes.success + excluded.success,
+    client_error = proxy_request_tuple_rollup_minutes.client_error + excluded.client_error,
+    server_error = proxy_request_tuple_rollup_minutes.server_error + excluded.server_error,
+    internal_error = proxy_request_tuple_rollup_minutes.internal_error + excluded.internal_error,
+    duration_ms_sum = proxy_request_tuple_rollup_minutes.duration_ms_sum + excluded.duration_ms_sum,
+    request_bytes = proxy_request_tuple_rollup_minutes.request_bytes + excluded.request_bytes,
+    response_bytes = proxy_request_tuple_rollup_minutes.response_bytes + excluded.response_bytes,
+    updated_at = CURRENT_TIMESTAMP;
+
+-- name: BackfillAgentStatRollupMinutesRange :exec
+INSERT INTO agent_stat_rollup_minutes (
+    bucket_unix_millis, samples, req_success, req_client_error, req_server_error, req_internal_error,
+    bytes_rx, bytes_tx, memory_mb_sum, max_memory_mb, goroutines_sum, max_goroutines,
+    cpu_percent_sum, max_cpu_percent
+)
+SELECT
+    CAST((unixepoch(reported_at) / 60) * 60 * 1000 AS INTEGER) AS bucket_unix_millis,
+    COUNT(*) AS samples,
+    CAST(COALESCE(SUM(req_success), 0) AS INTEGER) AS req_success,
+    CAST(COALESCE(SUM(req_client_error), 0) AS INTEGER) AS req_client_error,
+    CAST(COALESCE(SUM(req_server_error), 0) AS INTEGER) AS req_server_error,
+    CAST(COALESCE(SUM(req_internal_error), 0) AS INTEGER) AS req_internal_error,
+    CAST(COALESCE(SUM(bytes_rx), 0) AS INTEGER) AS bytes_rx,
+    CAST(COALESCE(SUM(bytes_tx), 0) AS INTEGER) AS bytes_tx,
+    CAST(COALESCE(SUM(memory_mb), 0) AS INTEGER) AS memory_mb_sum,
+    CAST(COALESCE(MAX(memory_mb), 0) AS INTEGER) AS max_memory_mb,
+    CAST(COALESCE(SUM(goroutines), 0) AS INTEGER) AS goroutines_sum,
+    CAST(COALESCE(MAX(goroutines), 0) AS INTEGER) AS max_goroutines,
+    CAST(COALESCE(SUM(cpu_percent), 0) AS REAL) AS cpu_percent_sum,
+    CAST(COALESCE(MAX(cpu_percent), 0) AS REAL) AS max_cpu_percent
+FROM agent_stats
+WHERE id > sqlc.arg(from_id)
+  AND id <= sqlc.arg(through_id)
+GROUP BY bucket_unix_millis
+ON CONFLICT(bucket_unix_millis) DO UPDATE SET
+    samples = agent_stat_rollup_minutes.samples + excluded.samples,
+    req_success = agent_stat_rollup_minutes.req_success + excluded.req_success,
+    req_client_error = agent_stat_rollup_minutes.req_client_error + excluded.req_client_error,
+    req_server_error = agent_stat_rollup_minutes.req_server_error + excluded.req_server_error,
+    req_internal_error = agent_stat_rollup_minutes.req_internal_error + excluded.req_internal_error,
+    bytes_rx = agent_stat_rollup_minutes.bytes_rx + excluded.bytes_rx,
+    bytes_tx = agent_stat_rollup_minutes.bytes_tx + excluded.bytes_tx,
+    memory_mb_sum = agent_stat_rollup_minutes.memory_mb_sum + excluded.memory_mb_sum,
+    max_memory_mb = MAX(agent_stat_rollup_minutes.max_memory_mb, excluded.max_memory_mb),
+    goroutines_sum = agent_stat_rollup_minutes.goroutines_sum + excluded.goroutines_sum,
+    max_goroutines = MAX(agent_stat_rollup_minutes.max_goroutines, excluded.max_goroutines),
+    cpu_percent_sum = agent_stat_rollup_minutes.cpu_percent_sum + excluded.cpu_percent_sum,
+    max_cpu_percent = MAX(agent_stat_rollup_minutes.max_cpu_percent, excluded.max_cpu_percent),
+    updated_at = CURRENT_TIMESTAMP;
+
+-- name: MarkProxyRollupBackfilledThrough :exec
+UPDATE observability_rollup_state
+SET proxy_backfilled_through_id = ?,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = 1;
+
+-- name: MarkAgentRollupBackfilledThrough :exec
+UPDATE observability_rollup_state
+SET agent_backfilled_through_id = ?,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = 1;
 
 -- name: CountUsers :one
 SELECT COUNT(*) FROM users;

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -51,6 +51,90 @@ CREATE TABLE IF NOT EXISTS proxy_request_events (
     cache_bytes INTEGER NOT NULL DEFAULT 0
 );
 
+CREATE TABLE IF NOT EXISTS proxy_request_rollup_minutes (
+    bucket_unix_millis INTEGER PRIMARY KEY,
+    requests INTEGER NOT NULL DEFAULT 0,
+    success INTEGER NOT NULL DEFAULT 0,
+    client_error INTEGER NOT NULL DEFAULT 0,
+    server_error INTEGER NOT NULL DEFAULT 0,
+    internal_error INTEGER NOT NULL DEFAULT 0,
+    duration_ms_sum INTEGER NOT NULL DEFAULT 0,
+    max_duration_ms INTEGER NOT NULL DEFAULT 0,
+    slow_requests INTEGER NOT NULL DEFAULT 0,
+    request_bytes INTEGER NOT NULL DEFAULT 0,
+    response_bytes INTEGER NOT NULL DEFAULT 0,
+    cache_hits INTEGER NOT NULL DEFAULT 0,
+    cache_misses INTEGER NOT NULL DEFAULT 0,
+    cache_bypasses INTEGER NOT NULL DEFAULT 0,
+    cache_stored INTEGER NOT NULL DEFAULT 0,
+    cache_store_failed INTEGER NOT NULL DEFAULT 0,
+    cache_hit_bytes INTEGER NOT NULL DEFAULT 0,
+    cache_stored_bytes INTEGER NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS proxy_request_tuple_rollup_minutes (
+    bucket_unix_millis INTEGER NOT NULL,
+    listener_id INTEGER NOT NULL DEFAULT 0,
+    backend_id INTEGER NOT NULL DEFAULT 0,
+    route_id INTEGER NOT NULL DEFAULT 0,
+    agent_id INTEGER NOT NULL DEFAULT 0,
+    error_kind TEXT NOT NULL DEFAULT '',
+    status_class INTEGER NOT NULL DEFAULT 0,
+    requests INTEGER NOT NULL DEFAULT 0,
+    success INTEGER NOT NULL DEFAULT 0,
+    client_error INTEGER NOT NULL DEFAULT 0,
+    server_error INTEGER NOT NULL DEFAULT 0,
+    internal_error INTEGER NOT NULL DEFAULT 0,
+    duration_ms_sum INTEGER NOT NULL DEFAULT 0,
+    request_bytes INTEGER NOT NULL DEFAULT 0,
+    response_bytes INTEGER NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (bucket_unix_millis, listener_id, backend_id, route_id, agent_id, error_kind, status_class)
+);
+
+CREATE TABLE IF NOT EXISTS agent_stat_rollup_minutes (
+    bucket_unix_millis INTEGER PRIMARY KEY,
+    samples INTEGER NOT NULL DEFAULT 0,
+    req_success INTEGER NOT NULL DEFAULT 0,
+    req_client_error INTEGER NOT NULL DEFAULT 0,
+    req_server_error INTEGER NOT NULL DEFAULT 0,
+    req_internal_error INTEGER NOT NULL DEFAULT 0,
+    bytes_rx INTEGER NOT NULL DEFAULT 0,
+    bytes_tx INTEGER NOT NULL DEFAULT 0,
+    memory_mb_sum INTEGER NOT NULL DEFAULT 0,
+    max_memory_mb INTEGER NOT NULL DEFAULT 0,
+    goroutines_sum INTEGER NOT NULL DEFAULT 0,
+    max_goroutines INTEGER NOT NULL DEFAULT 0,
+    cpu_percent_sum REAL NOT NULL DEFAULT 0,
+    max_cpu_percent REAL NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS observability_rollup_state (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    proxy_backfill_upper_id INTEGER NOT NULL DEFAULT 0,
+    proxy_backfilled_through_id INTEGER NOT NULL DEFAULT 0,
+    agent_backfill_upper_id INTEGER NOT NULL DEFAULT 0,
+    agent_backfilled_through_id INTEGER NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO observability_rollup_state (
+    id, proxy_backfill_upper_id, proxy_backfilled_through_id, agent_backfill_upper_id, agent_backfilled_through_id
+)
+SELECT
+    1,
+    CAST(COALESCE((SELECT MAX(id) FROM proxy_request_events), 0) AS INTEGER),
+    0,
+    CAST(COALESCE((SELECT MAX(id) FROM agent_stats), 0) AS INTEGER),
+    0
+WHERE NOT EXISTS (SELECT 1 FROM observability_rollup_state WHERE id = 1);
+
 CREATE TABLE IF NOT EXISTS public_response_templates (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL UNIQUE,
@@ -512,3 +596,6 @@ ON connections (agent_id);
 
 CREATE INDEX IF NOT EXISTS idx_connections_connected_at
 ON connections (connected_at);
+
+CREATE INDEX IF NOT EXISTS idx_connections_disconnected_at
+ON connections (disconnected_at);


### PR DESCRIPTION
## Summary
- Add a management bind address setting and switch server startup to bind management on loopback by default, while logging a usable local URL and the effective bind address.
- Introduce first-admin setup tokens, including config support, proto/API fields, startup token generation/logging, and updated first-login documentation.
- Harden public cache rules by requiring an explicit acknowledgment when `allow_cookie_requests` is enabled, with matching API/schema/docs updates.
- Add observability retention maintenance and row-cap support for long-lived proxy and agent stats data.
- Strengthen security-sensitive storage and proxy behavior, including tighter SQLite file permissions and updated security hardening guidance.

## Testing
- Ran/updated Go unit and integration coverage across management setup, cache rules, login throttling, public routing, and observability paths.
- Added/updated tests for management listen/display address behavior, setup token handling, and cache rule validation.
- Updated e2e and docker smoke test configuration to exercise the new management setup token flow.
- Not run: full local test suite and end-to-end compose environment verification in this turn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard performance improved through automatic pre-aggregation of proxy request and agent metrics in the database.
  * Dashboard now uses precomputed metrics when available, reducing query overhead.

* **Performance Improvements**
  * Enhanced database query execution with improved indexing strategies.
  * Streamlined observability data retention with more efficient batched cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->