### PR TITLE
Default management bind to all interfaces

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -134,7 +134,7 @@ func managementListenAddress(cfg *config.Config) string {
 	}
 	bind := cfg.ManagementBindAddress
 	if bind == "" {
-		bind = "127.0.0.1"
+		bind = "0.0.0.0"
 	}
 	port := cfg.ManagementPort
 	if port == "" {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -6,17 +6,17 @@ import (
 	"p2pstream/internal/config"
 )
 
-func TestManagementListenAddressDefaultsToLoopback(t *testing.T) {
+func TestManagementListenAddressDefaultsToAllInterfaces(t *testing.T) {
 	got := managementListenAddress(&config.Config{})
-	if got != "127.0.0.1:8081" {
-		t.Fatalf("managementListenAddress = %q, want 127.0.0.1:8081", got)
+	if got != "0.0.0.0:8081" {
+		t.Fatalf("managementListenAddress = %q, want 0.0.0.0:8081", got)
 	}
 }
 
-func TestManagementListenAddressAllowsAllInterfaces(t *testing.T) {
-	got := managementListenAddress(&config.Config{ManagementBindAddress: "0.0.0.0", ManagementPort: "9443"})
-	if got != "0.0.0.0:9443" {
-		t.Fatalf("managementListenAddress = %q, want 0.0.0.0:9443", got)
+func TestManagementListenAddressAllowsLoopback(t *testing.T) {
+	got := managementListenAddress(&config.Config{ManagementBindAddress: "127.0.0.1", ManagementPort: "9443"})
+	if got != "127.0.0.1:9443" {
+		t.Fatalf("managementListenAddress = %q, want 127.0.0.1:9443", got)
 	}
 }
 

--- a/docs/operations/security-hardening.md
+++ b/docs/operations/security-hardening.md
@@ -17,7 +17,8 @@ Use this before exposing management beyond a private network, after adding agent
 1. Harden management access:
 
    - Keep management HTTPS enabled.
-   - Keep `MANAGEMENT_BIND_ADDRESS=127.0.0.1` unless management must be reachable from another host.
+   - Keep `MANAGEMENT_BIND_ADDRESS=0.0.0.0` when agents or admins connect from other hosts.
+   - Set `MANAGEMENT_BIND_ADDRESS=127.0.0.1` only when a local reverse proxy, VPN sidecar, or SSH tunnel fronts management.
    - Prefer firewall allowlists, VPN, or a private admin network for `8081`.
    - Set `MANAGEMENT_PUBLIC_URL` to the real management URL used by browsers and agents.
    - Set a deployment secret as `MANAGEMENT_SETUP_TOKEN` before first setup, or capture the generated startup token from trusted logs.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -13,7 +13,7 @@ Set these on the server process via `.env` or environment. They control manageme
 | Variable                         | Default                      | Description                                                                                  |
 | -------------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------- |
 | `MANAGEMENT_PORT`                | `8081`                       | Management UI/API and agent HTTPS/WSS port.                                                  |
-| `MANAGEMENT_BIND_ADDRESS`        | `127.0.0.1`                  | Management bind address. Set `0.0.0.0` only when remote management exposure is intentional.   |
+| `MANAGEMENT_BIND_ADDRESS`        | `0.0.0.0`                    | Management bind address. Set `127.0.0.1` only when local-only management is intentional.      |
 | `CONFIG_DIR`                     | `p2pstream-data`             | Directory for default SQLite database and certificates. Docker sets `/data`.                 |
 | `DATABASE_URL`                   | derived                      | SQLite DSN. When unset, uses `${CONFIG_DIR}/p2pstream.db` with WAL and foreign keys enabled. |
 | `ENV`                            | `development`                | Use `production` for production logging/cookie behavior.                                     |
@@ -72,7 +72,7 @@ Set these as environment variables before running the Linux agent installer scri
 - `MANAGEMENT_TLS_MODE=provided` requires both cert and key files.
 - `MANAGEMENT_TLS_MODE=off` requires `MANAGEMENT_ALLOW_INSECURE_HTTP=true`.
 - `MANAGEMENT_PUBLIC_URL` must be absolute and must use `https`, unless management TLS is off and insecure HTTP is explicitly allowed.
-- `MANAGEMENT_BIND_ADDRESS` defaults to loopback for binary/systemd installs. Compose sets `0.0.0.0` explicitly inside the container.
+- `MANAGEMENT_BIND_ADDRESS` defaults to all interfaces so agents and remote clients can connect. Set it to `127.0.0.1` only for local-only management or when a local reverse proxy fronts management.
 - Bootstrap agent ID, name, and token must all be set together.
 - Agent boolean parsing accepts `1`, `true`, `yes`, `y`, and `on`.
 
@@ -95,13 +95,13 @@ P2PSTREAM_HTTPS_PORT=443
 P2PSTREAM_MANAGEMENT_PORT=8081
 ```
 
-Compose defaults `MANAGEMENT_BIND_ADDRESS` to `0.0.0.0` inside the container; set it in `.env` to a narrower address when the management service should not listen on every container interface.
+Compose defaults `MANAGEMENT_BIND_ADDRESS` to `0.0.0.0` inside the container; set it in `.env` to a narrower address only when the management service should not listen on every container interface.
 
 Binary/systemd server environment:
 
 ```ini
 CONFIG_DIR=/var/lib/p2pstream
-MANAGEMENT_BIND_ADDRESS=127.0.0.1
+MANAGEMENT_BIND_ADDRESS=0.0.0.0
 MANAGEMENT_PUBLIC_URL=https://proxy.example.com:8081
 ENV=production
 ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,7 +22,7 @@ const (
 
 type Config struct {
 	ManagementPort              string `env:"MANAGEMENT_PORT" envDefault:"8081"`
-	ManagementBindAddress       string `env:"MANAGEMENT_BIND_ADDRESS" envDefault:"127.0.0.1"`
+	ManagementBindAddress       string `env:"MANAGEMENT_BIND_ADDRESS" envDefault:"0.0.0.0"`
 	ConfigDir                   string `env:"CONFIG_DIR" envDefault:"p2pstream-data"`
 	DatabaseURL                 string `env:"DATABASE_URL"`
 	Env                         string `env:"ENV" envDefault:"development"` // development or production
@@ -100,7 +100,7 @@ func Load() (*Config, error) {
 func validateManagementTLSConfig(cfg *Config) error {
 	cfg.ManagementBindAddress = strings.TrimSpace(cfg.ManagementBindAddress)
 	if cfg.ManagementBindAddress == "" {
-		cfg.ManagementBindAddress = "127.0.0.1"
+		cfg.ManagementBindAddress = "0.0.0.0"
 	}
 	if cfg.ObservabilityMaxRows < 0 {
 		return errors.New("OBSERVABILITY_MAX_ROWS must be greater than or equal to 0")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -106,8 +106,8 @@ func TestLoadManagementBindAndSecurityDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
 	}
-	if cfg.ManagementBindAddress != "127.0.0.1" {
-		t.Fatalf("ManagementBindAddress = %q, want loopback default", cfg.ManagementBindAddress)
+	if cfg.ManagementBindAddress != "0.0.0.0" {
+		t.Fatalf("ManagementBindAddress = %q, want all-interface default", cfg.ManagementBindAddress)
 	}
 	if cfg.ObservabilityMaxRows != 1_000_000 {
 		t.Fatalf("ObservabilityMaxRows = %d, want 1000000", cfg.ObservabilityMaxRows)
@@ -120,14 +120,14 @@ func TestLoadManagementBindAndSecurityDefaults(t *testing.T) {
 func TestLoadRespectsExplicitManagementBindAddress(t *testing.T) {
 	workDir := isolatedConfigTestDir(t)
 	t.Setenv("CONFIG_DIR", filepath.Join(workDir, "data"))
-	t.Setenv("MANAGEMENT_BIND_ADDRESS", "0.0.0.0")
+	t.Setenv("MANAGEMENT_BIND_ADDRESS", "127.0.0.1")
 
 	cfg, err := Load()
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
 	}
-	if cfg.ManagementBindAddress != "0.0.0.0" {
-		t.Fatalf("ManagementBindAddress = %q, want 0.0.0.0", cfg.ManagementBindAddress)
+	if cfg.ManagementBindAddress != "127.0.0.1" {
+		t.Fatalf("ManagementBindAddress = %q, want 127.0.0.1", cfg.ManagementBindAddress)
 	}
 }
 


### PR DESCRIPTION
## Summary\n- Restore MANAGEMENT_BIND_ADDRESS default to 0.0.0.0 so agents and remote clients can connect by default\n- Keep 127.0.0.1 as an explicit local-only override\n- Update bind-address tests and docs\n\n## Tests\n- go test ./cmd ./internal/config\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default management server bind address to all interfaces instead of localhost only.

* **Documentation**
  * Updated security hardening and configuration reference guides with clarified management server binding behavior and recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->