### PR TITLE
Fix agent reinstall lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,10 @@ jobs:
         run: git diff --exit-code
 
       - name: Check installer syntax
-        run: bash -n scripts/install-agent.sh
+        run: bash -n scripts/install-agent.sh scripts/uninstall-agent.sh
+
+      - name: Run installer lifecycle tests
+        run: scripts/test-agent-lifecycle.sh
 
       - name: Run Go tests
         run: go test ./...

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,7 +48,10 @@ jobs:
         run: git diff --exit-code
 
       - name: Check installer syntax
-        run: bash -n scripts/install-agent.sh
+        run: bash -n scripts/install-agent.sh scripts/uninstall-agent.sh
+
+      - name: Run installer lifecycle tests
+        run: scripts/test-agent-lifecycle.sh
 
       - name: Run Go tests
         run: go test ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,10 @@ jobs:
         run: git diff --exit-code
 
       - name: Check installer syntax
-        run: bash -n scripts/install-agent.sh
+        run: bash -n scripts/install-agent.sh scripts/uninstall-agent.sh
+
+      - name: Run installer lifecycle tests
+        run: scripts/test-agent-lifecycle.sh
 
       - name: Run Go tests
         run: go test ./...

--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -40,7 +40,7 @@ By default, agents reject insecure HTTP management URLs and verify HTTPS certifi
 | `MANAGEMENT_CA_FILE` | Path to a PEM CA bundle on the agent host. |
 | `MANAGEMENT_CA_PEM_BASE64` | Base64-encoded PEM CA bundle, useful for generated snippets. |
 
-The Agent Setup dialog can generate a one-line Linux systemd installer, a Docker Compose service, or a direct CLI command. The Linux installer downloads the release binary, verifies the checksum, writes `/etc/p2pstream/agent.env`, and enables `p2pstream-agent.service`.
+The Agent Setup dialog can generate a one-line Linux systemd installer, a Docker Compose service, or a direct CLI command. The Linux installer downloads the release binary, verifies the checksum, writes `/etc/p2pstream/agent.env`, enables `p2pstream-agent.service`, and restarts it. After token rotation, run the generated Linux reinstall command on the existing agent host so the new token and TLS material are loaded by a fresh process.
 
 If management requires agent client certificates, configure:
 
@@ -51,7 +51,7 @@ AGENT_TLS_KEY_FILE=/etc/p2pstream/agent.key.pem
 
 ## Common Mistakes
 
-- Reusing an old token after rotating it in management.
+- Reusing an old token after rotating it in management instead of running the generated reinstall command on the agent host.
 - Setting `MANAGEMENT_URL` to a public listener instead of management.
 - Putting management behind a reverse proxy that blocks HTTP/1.1 upgrade streaming for `p2pstream-yamux` or closes idle upgraded connections too aggressively.
 - Forgetting CA material when management uses the auto-generated local CA.

--- a/docs/guides/expose-a-home-lab-app.md
+++ b/docs/guides/expose-a-home-lab-app.md
@@ -49,7 +49,7 @@ Example:
      bash
    ```
 
-   The installer creates `/usr/local/bin/p2pstream`, `/etc/p2pstream/agent.env`, and `p2pstream-agent.service`.
+   The installer creates `/usr/local/bin/p2pstream`, `/etc/p2pstream/agent.env`, and `p2pstream-agent.service`, then restarts the agent service. You can run the generated Linux command again after token rotation to reinstall the existing agent with the new token.
 
 3. Check the agent service:
 

--- a/docs/operations/systemd.md
+++ b/docs/operations/systemd.md
@@ -92,13 +92,13 @@ sudo systemctl restart p2pstream-agent
 sudo journalctl -u p2pstream-agent -f
 ```
 
-After rotating an agent token, update `/etc/p2pstream/agent.env` and restart the agent.
+After rotating an agent token, run the generated Linux reinstall command on the existing agent host. The installer rewrites `/etc/p2pstream/agent.env`, refreshes installer-managed management CA material, and restarts `p2pstream-agent` so the new token and TLS settings are loaded.
 
 ## Uninstall Agent
 
 Use this only for agents installed with the generated Linux systemd installer. Docker Compose agents should be removed with your Compose workflow instead.
 
-The full-purge uninstall removes the agent service, `/etc/p2pstream`, `/usr/local/bin/p2pstream`, and the `p2pstream` service user and group. Do not run it on a host where those paths or that user are shared with a p2pstream server or another install you want to keep.
+The full-purge uninstall removes the agent service, service drop-ins, `/etc/p2pstream`, `/usr/local/bin/p2pstream`, and the `p2pstream` service user and group. Do not run it on a host where those paths or that user are shared with a p2pstream server or another install you want to keep.
 
 Generated command:
 
@@ -129,7 +129,7 @@ sudo systemctl status p2pstream-agent
 | Symptom | Check |
 | --- | --- |
 | Server cannot bind low ports | Run as root or use capabilities/high ports. |
-| Agent fails after token rotation | Update `/etc/p2pstream/agent.env` and restart. |
+| Agent fails after token rotation | Run the generated Linux reinstall command on the existing agent host. |
 | Uninstall refuses to run | Set `P2PSTREAM_UNINSTALL_CONFIRM=full-purge`; unsafe paths are intentionally rejected. |
 
 ## Next Steps

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -69,7 +69,7 @@ When diagnosing public traffic, open **Traffic**, enable tracing, reproduce the 
 | --- | --- |
 | `MANAGEMENT_URL` | It must point to management, usually `https://host:8081`. |
 | CA trust | Use `MANAGEMENT_CA_FILE` or `MANAGEMENT_CA_PEM_BASE64` for auto TLS. |
-| Token | Rotate the token and update the agent env file. |
+| Token | Rotate the token and run the generated Linux reinstall command on the agent host. |
 | Agent ID | Use the generated `agent-...` public ID. |
 | Firewall/NAT | Agent host must reach management HTTPS/TLS and `/agent/tunnel`. |
 | Insecure URL | HTTP requires `AGENT_ALLOW_INSECURE_MANAGEMENT=true`, intended for development only. |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -61,9 +61,10 @@ Set these as environment variables before running the Linux agent installer scri
 | Variable                 | Default                    | Description                                                                  |
 | ------------------------ | -------------------------- | ---------------------------------------------------------------------------- |
 | `P2PSTREAM_REPOSITORY`   | `Kirari04/p2pstream`       | GitHub owner/repo used by the installer.                                     |
-| `P2PSTREAM_VERSION`      | `latest`                   | Release tag such as `vX.Y.Z`, `latest`, or `nightly` for development builds. |
+| `P2PSTREAM_VERSION`      | `latest`                   | Release tag such as `vX.Y.Z`, or `latest`.                                   |
 | `P2PSTREAM_CONFIG_DIR`   | `/etc/p2pstream`           | Agent config directory created by installer.                                 |
 | `P2PSTREAM_INSTALL_PATH` | `/usr/local/bin/p2pstream` | Binary install path.                                                         |
+| `P2PSTREAM_SYSTEMD_DIR`  | `/etc/systemd/system`      | Systemd unit directory used by installer and uninstaller.                    |
 
 ## Validation Rules
 
@@ -75,6 +76,7 @@ Set these as environment variables before running the Linux agent installer scri
 - `MANAGEMENT_BIND_ADDRESS` defaults to all interfaces so agents and remote clients can connect. Set it to `127.0.0.1` only for local-only management or when a local reverse proxy fronts management.
 - Bootstrap agent ID, name, and token must all be set together.
 - Agent boolean parsing accepts `1`, `true`, `yes`, `y`, and `on`.
+- Linux agent installs require `AGENT_TLS_CERT_FILE` and `AGENT_TLS_KEY_FILE` together, require user-supplied TLS files to be readable, and reject CA/client-certificate settings with HTTP management URLs.
 
 ## Runtime Effects
 

--- a/scripts/install-agent.sh
+++ b/scripts/install-agent.sh
@@ -5,15 +5,23 @@ readonly DEFAULT_REPOSITORY="Kirari04/p2pstream"
 readonly SERVICE_NAME="p2pstream-agent"
 readonly CONFIG_DIR="${P2PSTREAM_CONFIG_DIR:-/etc/p2pstream}"
 readonly ENV_FILE="${CONFIG_DIR}/agent.env"
-readonly SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
+readonly SYSTEMD_DIR="${P2PSTREAM_SYSTEMD_DIR:-/etc/systemd/system}"
+readonly SERVICE_FILE="${SYSTEMD_DIR}/${SERVICE_NAME}.service"
 readonly INSTALL_PATH="${P2PSTREAM_INSTALL_PATH:-/usr/local/bin/p2pstream}"
 readonly MANAGEMENT_CA_PEM_FILE="${CONFIG_DIR}/management-ca.pem"
 readonly SERVICE_USER="p2pstream"
 readonly SERVICE_GROUP="p2pstream"
+INSTALL_TMP_DIR=""
 
 fail() {
   printf 'p2pstream agent install failed: %s\n' "$*" >&2
   exit 1
+}
+
+cleanup_tmp_dir() {
+  if [[ -n "$INSTALL_TMP_DIR" ]]; then
+    rm -rf "$INSTALL_TMP_DIR"
+  fi
 }
 
 require_command() {
@@ -24,6 +32,14 @@ require_env() {
   local name="$1"
   if [[ -z "${!name:-}" ]]; then
     fail "missing required environment variable: ${name}"
+  fi
+}
+
+require_readable_file() {
+  local name="$1"
+  local path="$2"
+  if [[ ! -f "$path" || ! -r "$path" ]]; then
+    fail "${name} must reference a readable file: ${path}"
   fi
 }
 
@@ -116,6 +132,43 @@ ensure_service_user() {
   fi
 }
 
+validate_management_url_inputs() {
+  local url_lower
+  url_lower="$(single_line "$MANAGEMENT_URL")"
+  url_lower="${url_lower,,}"
+  case "$url_lower" in
+    https://*)
+      ;;
+    http://*)
+      if [[ "${AGENT_ALLOW_INSECURE_MANAGEMENT:-}" != "true" ]]; then
+        fail "refusing insecure MANAGEMENT_URL; use https or set AGENT_ALLOW_INSECURE_MANAGEMENT=true"
+      fi
+      if [[ -n "${MANAGEMENT_CA_FILE:-}" || -n "${MANAGEMENT_CA_PEM_BASE64:-}" || -n "${AGENT_TLS_CERT_FILE:-}" || -n "${AGENT_TLS_KEY_FILE:-}" ]]; then
+        fail "agent TLS files require an https MANAGEMENT_URL"
+      fi
+      ;;
+    *)
+      fail "MANAGEMENT_URL must start with https:// or http://"
+      ;;
+  esac
+}
+
+validate_tls_inputs() {
+  if [[ -n "${AGENT_TLS_CERT_FILE:-}" && -z "${AGENT_TLS_KEY_FILE:-}" ]]; then
+    fail "AGENT_TLS_CERT_FILE and AGENT_TLS_KEY_FILE must be set together"
+  fi
+  if [[ -z "${AGENT_TLS_CERT_FILE:-}" && -n "${AGENT_TLS_KEY_FILE:-}" ]]; then
+    fail "AGENT_TLS_CERT_FILE and AGENT_TLS_KEY_FILE must be set together"
+  fi
+  if [[ -n "${MANAGEMENT_CA_FILE:-}" && -z "${MANAGEMENT_CA_PEM_BASE64:-}" ]]; then
+    require_readable_file MANAGEMENT_CA_FILE "$MANAGEMENT_CA_FILE"
+  fi
+  if [[ -n "${AGENT_TLS_CERT_FILE:-}" ]]; then
+    require_readable_file AGENT_TLS_CERT_FILE "$AGENT_TLS_CERT_FILE"
+    require_readable_file AGENT_TLS_KEY_FILE "$AGENT_TLS_KEY_FILE"
+  fi
+}
+
 decode_management_ca_pem() {
   if [[ -z "${MANAGEMENT_CA_PEM_BASE64:-}" ]]; then
     return
@@ -123,6 +176,33 @@ decode_management_ca_pem() {
   require_command base64
   printf '%s' "$MANAGEMENT_CA_PEM_BASE64" | base64 -d >"$1" 2>/dev/null \
     || fail "MANAGEMENT_CA_PEM_BASE64 is not valid base64"
+}
+
+sync_management_ca() {
+  local tmp_dir="$1"
+  if [[ -n "${MANAGEMENT_CA_PEM_BASE64:-}" ]]; then
+    decode_management_ca_pem "${tmp_dir}/management-ca.pem"
+    install -m 0644 "${tmp_dir}/management-ca.pem" "$MANAGEMENT_CA_PEM_FILE"
+    MANAGEMENT_CA_FILE="$MANAGEMENT_CA_PEM_FILE"
+    return
+  fi
+  if [[ -n "${MANAGEMENT_CA_FILE:-}" ]]; then
+    return
+  fi
+  if [[ -e "$MANAGEMENT_CA_PEM_FILE" || -L "$MANAGEMENT_CA_PEM_FILE" ]]; then
+    rm -f "$MANAGEMENT_CA_PEM_FILE"
+  fi
+}
+
+restart_service() {
+  systemctl daemon-reload
+  systemctl enable "$SERVICE_NAME"
+  if ! systemctl restart "$SERVICE_NAME"; then
+    printf 'p2pstream agent install failed: systemctl restart %s failed\n' "$SERVICE_NAME" >&2
+    printf 'Check status with: sudo systemctl status %s\n' "$SERVICE_NAME" >&2
+    printf 'View logs with: sudo journalctl -u %s -n 100 --no-pager\n' "$SERVICE_NAME" >&2
+    exit 1
+  fi
 }
 
 main() {
@@ -135,6 +215,7 @@ main() {
   require_command groupadd
   require_command useradd
   require_command mktemp
+  require_command rm
   require_command sed
   require_command sha256sum
   require_command systemctl
@@ -145,9 +226,8 @@ main() {
   require_env MANAGEMENT_URL
   require_env AGENT_ID
   require_env AGENT_TOKEN
-  if [[ "$MANAGEMENT_URL" == http://* && "${AGENT_ALLOW_INSECURE_MANAGEMENT:-}" != "true" ]]; then
-    fail "refusing insecure MANAGEMENT_URL; use https or set AGENT_ALLOW_INSECURE_MANAGEMENT=true"
-  fi
+  validate_management_url_inputs
+  validate_tls_inputs
   ensure_service_user
 
   local repository="${P2PSTREAM_REPOSITORY:-$DEFAULT_REPOSITORY}"
@@ -170,7 +250,8 @@ main() {
   asset="p2pstream_${tag}_linux_${arch}.tar.gz"
   base_url="https://github.com/${repository}/releases/download/${tag}"
   tmp_dir="$(mktemp -d)"
-  trap 'rm -rf "$tmp_dir"' EXIT
+  INSTALL_TMP_DIR="$tmp_dir"
+  trap cleanup_tmp_dir EXIT
 
   printf 'Downloading p2pstream %s for linux/%s...\n' "$tag" "$arch"
   curl -fL "${base_url}/${asset}" -o "${tmp_dir}/${asset}"
@@ -187,21 +268,17 @@ main() {
   install -m 0755 "${tmp_dir}/p2pstream" "$INSTALL_PATH"
 
   install -d -m 0755 "$CONFIG_DIR"
-  if [[ -n "${MANAGEMENT_CA_PEM_BASE64:-}" ]]; then
-    decode_management_ca_pem "${tmp_dir}/management-ca.pem"
-    install -m 0644 "${tmp_dir}/management-ca.pem" "$MANAGEMENT_CA_PEM_FILE"
-    MANAGEMENT_CA_FILE="$MANAGEMENT_CA_PEM_FILE"
-  fi
+  sync_management_ca "$tmp_dir"
   write_agent_env "${tmp_dir}/agent.env"
   install -o "$SERVICE_USER" -g "$SERVICE_GROUP" -m 0600 "${tmp_dir}/agent.env" "$ENV_FILE"
 
   write_service_file "${tmp_dir}/${SERVICE_NAME}.service"
+  install -d -m 0755 "$SYSTEMD_DIR"
   install -m 0644 "${tmp_dir}/${SERVICE_NAME}.service" "$SERVICE_FILE"
 
-  systemctl daemon-reload
-  systemctl enable --now "$SERVICE_NAME"
+  restart_service
 
-  printf 'p2pstream agent installed and started.\n'
+  printf 'p2pstream agent installed and restarted.\n'
   printf 'Check status with: sudo systemctl status %s\n' "$SERVICE_NAME"
   printf 'View logs with: sudo journalctl -u %s -f\n' "$SERVICE_NAME"
 }

--- a/scripts/test-agent-lifecycle.sh
+++ b/scripts/test-agent-lifecycle.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+INSTALL_SCRIPT="${ROOT_DIR}/scripts/install-agent.sh"
+UNINSTALL_SCRIPT="${ROOT_DIR}/scripts/uninstall-agent.sh"
+REAL_PATH="$PATH"
+TEST_DIR=""
+
+fail() {
+  printf 'agent lifecycle test failed: %s\n' "$*" >&2
+  if [[ -n "${TEST_DIR:-}" ]]; then
+    printf 'fixture kept at: %s\n' "$TEST_DIR" >&2
+  fi
+  exit 1
+}
+
+assert_exists() {
+  [[ -e "$1" ]] || fail "expected path to exist: $1"
+}
+
+assert_absent() {
+  [[ ! -e "$1" && ! -L "$1" ]] || fail "expected path to be absent: $1"
+}
+
+assert_contains() {
+  local path="$1"
+  local text="$2"
+  grep -Fq -- "$text" "$path" || fail "expected ${path} to contain: ${text}"
+}
+
+assert_not_contains() {
+  local path="$1"
+  local text="$2"
+  if grep -Fq -- "$text" "$path"; then
+    fail "expected ${path} not to contain: ${text}"
+  fi
+}
+
+assert_systemctl_enable_before_restart() {
+  local enable_line restart_line
+  enable_line="$(grep -n '^enable p2pstream-agent$' "$SYSTEMCTL_LOG" | tail -n 1 | cut -d: -f1)"
+  restart_line="$(grep -n '^restart p2pstream-agent$' "$SYSTEMCTL_LOG" | tail -n 1 | cut -d: -f1)"
+  [[ -n "$enable_line" ]] || fail "systemctl enable was not called"
+  [[ -n "$restart_line" ]] || fail "systemctl restart was not called"
+  (( enable_line < restart_line )) || fail "systemctl enable should run before restart"
+}
+
+base64_value() {
+  printf '%s' "$1" | base64 | tr -d '\n'
+}
+
+write_executable() {
+  local path="$1"
+  shift
+  printf '%s\n' "$@" >"$path"
+  chmod +x "$path"
+}
+
+setup_fixture() {
+  TEST_DIR="$(mktemp -d)"
+  FAKE_BIN="${TEST_DIR}/bin"
+  CONFIG_DIR="${TEST_DIR}/etc/p2pstream"
+  INSTALL_PATH="${TEST_DIR}/usr/local/bin/p2pstream"
+  SYSTEMD_DIR="${TEST_DIR}/systemd"
+  SYSTEMCTL_LOG="${TEST_DIR}/systemctl.log"
+  COMMAND_LOG="${TEST_DIR}/commands.log"
+  mkdir -p "$FAKE_BIN" "$CONFIG_DIR" "$(dirname "$INSTALL_PATH")" "$SYSTEMD_DIR"
+  : >"$SYSTEMCTL_LOG"
+  : >"$COMMAND_LOG"
+
+  write_executable "${FAKE_BIN}/uname" \
+    '#!/usr/bin/env bash' \
+    'case "${1:-}" in' \
+    '  -s) printf "Linux\n" ;;' \
+    '  -m) printf "x86_64\n" ;;' \
+    '  *) printf "Linux\n" ;;' \
+    'esac'
+
+  write_executable "${FAKE_BIN}/id" \
+    '#!/usr/bin/env bash' \
+    'if [[ "${1:-}" == "-u" && $# -eq 1 ]]; then printf "0\n"; exit 0; fi' \
+    'if [[ "${1:-}" == "-u" && "${2:-}" == "p2pstream" ]]; then' \
+    '  [[ "${FAKE_USER_EXISTS:-}" == "1" ]] && { printf "123\n"; exit 0; }' \
+    '  exit 1' \
+    'fi' \
+    'exit 1'
+
+  write_executable "${FAKE_BIN}/getent" \
+    '#!/usr/bin/env bash' \
+    'if [[ "${1:-}" == "group" && "${2:-}" == "p2pstream" ]]; then' \
+    '  [[ "${FAKE_GROUP_EXISTS:-}" == "1" ]] && exit 0' \
+    '  exit 1' \
+    'fi' \
+    'exit 1'
+
+  for command in groupadd useradd userdel groupdel; do
+    write_executable "${FAKE_BIN}/${command}" \
+      '#!/usr/bin/env bash' \
+      'printf "%s" "$(basename "$0")" >>"${FAKE_COMMAND_LOG:?}"' \
+      'printf " %q" "$@" >>"${FAKE_COMMAND_LOG:?}"' \
+      'printf "\n" >>"${FAKE_COMMAND_LOG:?}"'
+  done
+
+  write_executable "${FAKE_BIN}/systemctl" \
+    '#!/usr/bin/env bash' \
+    'printf "%s" "$*" >>"${FAKE_SYSTEMCTL_LOG:?}"' \
+    'printf "\n" >>"${FAKE_SYSTEMCTL_LOG:?}"' \
+    'if [[ "${1:-}" == "--version" ]]; then printf "systemd 252\n"; exit 0; fi' \
+    'if [[ "${FAKE_SYSTEMCTL_FAIL_RESTART:-}" == "1" && "${1:-}" == "restart" ]]; then exit 1; fi' \
+    'exit 0'
+
+  write_executable "${FAKE_BIN}/install" \
+    '#!/usr/bin/env bash' \
+    'set -Eeuo pipefail' \
+    'mode=""' \
+    'make_dir=false' \
+    'args=()' \
+    'while (($#)); do' \
+    '  case "$1" in' \
+    '    -d) make_dir=true; shift ;;' \
+    '    -m) mode="$2"; shift 2 ;;' \
+    '    -o|-g) shift 2 ;;' \
+    '    *) args+=("$1"); shift ;;' \
+    '  esac' \
+    'done' \
+    'if [[ "$make_dir" == "true" ]]; then' \
+    '  for dir in "${args[@]}"; do mkdir -p "$dir"; [[ -z "$mode" ]] || chmod "$mode" "$dir"; done' \
+    'else' \
+    '  src="${args[0]}"' \
+    '  dst="${args[1]}"' \
+    '  mkdir -p "$(dirname "$dst")"' \
+    '  cp "$src" "$dst"' \
+    '  [[ -z "$mode" ]] || chmod "$mode" "$dst"' \
+    'fi'
+
+  write_executable "${FAKE_BIN}/curl" \
+    '#!/usr/bin/env bash' \
+    'set -Eeuo pipefail' \
+    'output=""' \
+    'url=""' \
+    'while (($#)); do' \
+    '  case "$1" in' \
+    '    -o) output="$2"; shift 2 ;;' \
+    '    -*) shift ;;' \
+    '    *) url="$1"; shift ;;' \
+    '  esac' \
+    'done' \
+    'if [[ "$url" == *"api.github.com"* ]]; then printf "{\"tag_name\":\"v1.2.3\"}\n"; exit 0; fi' \
+    '[[ -n "$output" ]] || { printf "missing -o\n" >&2; exit 1; }' \
+    'case "$url" in' \
+    '  *checksums.txt) printf "0000000000000000000000000000000000000000000000000000000000000000  p2pstream_v1.2.3_linux_amd64.tar.gz\n" >"$output" ;;' \
+    '  *) printf "archive" >"$output" ;;' \
+    'esac'
+
+  write_executable "${FAKE_BIN}/sha256sum" \
+    '#!/usr/bin/env bash' \
+    'cat >/dev/null' \
+    'exit 0'
+
+  write_executable "${FAKE_BIN}/tar" \
+    '#!/usr/bin/env bash' \
+    'set -Eeuo pipefail' \
+    'dest=""' \
+    'while (($#)); do' \
+    '  case "$1" in' \
+    '    -C) dest="$2"; shift 2 ;;' \
+    '    *) shift ;;' \
+    '  esac' \
+    'done' \
+    '[[ -n "$dest" ]] || { printf "missing -C\n" >&2; exit 1; }' \
+    'mkdir -p "$dest"' \
+    'printf "#!/usr/bin/env sh\n" >"${dest}/p2pstream"' \
+    'printf "printf p2pstream\n" >>"${dest}/p2pstream"' \
+    'chmod +x "${dest}/p2pstream"'
+}
+
+run_installer() {
+  env -i \
+    PATH="${FAKE_BIN}:${REAL_PATH}" \
+    FAKE_SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
+    FAKE_COMMAND_LOG="$COMMAND_LOG" \
+    P2PSTREAM_CONFIG_DIR="$CONFIG_DIR" \
+    P2PSTREAM_INSTALL_PATH="$INSTALL_PATH" \
+    P2PSTREAM_SYSTEMD_DIR="$SYSTEMD_DIR" \
+    P2PSTREAM_REPOSITORY="ExampleUser/p2pstream" \
+    P2PSTREAM_VERSION="v1.2.3" \
+    "$@" \
+    bash "$INSTALL_SCRIPT"
+}
+
+run_uninstaller() {
+  env -i \
+    PATH="${FAKE_BIN}:${REAL_PATH}" \
+    FAKE_SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
+    FAKE_COMMAND_LOG="$COMMAND_LOG" \
+    FAKE_USER_EXISTS="1" \
+    FAKE_GROUP_EXISTS="1" \
+    P2PSTREAM_CONFIG_DIR="$CONFIG_DIR" \
+    P2PSTREAM_INSTALL_PATH="$INSTALL_PATH" \
+    P2PSTREAM_SYSTEMD_DIR="$SYSTEMD_DIR" \
+    P2PSTREAM_UNINSTALL_CONFIRM="full-purge" \
+    "$@" \
+    bash "$UNINSTALL_SCRIPT"
+}
+
+test_first_install() {
+  setup_fixture
+  run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    MANAGEMENT_CA_PEM_BASE64="$(base64_value "CA-one")" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="token-one"
+
+  assert_exists "$INSTALL_PATH"
+  assert_exists "${CONFIG_DIR}/agent.env"
+  assert_exists "${CONFIG_DIR}/management-ca.pem"
+  assert_exists "${SYSTEMD_DIR}/p2pstream-agent.service"
+  assert_contains "${CONFIG_DIR}/agent.env" "MANAGEMENT_URL=\"https://mgmt.example.test:8081\""
+  assert_contains "${CONFIG_DIR}/agent.env" "MANAGEMENT_CA_FILE=\"${CONFIG_DIR}/management-ca.pem\""
+  assert_contains "${CONFIG_DIR}/agent.env" "AGENT_ID=\"agent-one\""
+  assert_contains "${CONFIG_DIR}/agent.env" "AGENT_TOKEN=\"token-one\""
+  assert_contains "${CONFIG_DIR}/management-ca.pem" "CA-one"
+  assert_contains "${SYSTEMD_DIR}/p2pstream-agent.service" "EnvironmentFile=${CONFIG_DIR}/agent.env"
+  assert_systemctl_enable_before_restart
+  assert_not_contains "$SYSTEMCTL_LOG" "enable --now"
+}
+
+test_reinstall_overwrites_token_and_ca() {
+  setup_fixture
+  run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    MANAGEMENT_CA_PEM_BASE64="$(base64_value "old CA")" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="old-token"
+  : >"$SYSTEMCTL_LOG"
+
+  run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    MANAGEMENT_CA_PEM_BASE64="$(base64_value "new CA")" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="new-token"
+
+  assert_contains "${CONFIG_DIR}/agent.env" "AGENT_TOKEN=\"new-token\""
+  assert_not_contains "${CONFIG_DIR}/agent.env" "old-token"
+  assert_contains "${CONFIG_DIR}/management-ca.pem" "new CA"
+  assert_not_contains "${CONFIG_DIR}/management-ca.pem" "old CA"
+  assert_systemctl_enable_before_restart
+  assert_not_contains "$SYSTEMCTL_LOG" "enable --now"
+}
+
+test_reinstall_without_ca_removes_stale_managed_ca() {
+  setup_fixture
+  printf 'stale CA\n' >"${CONFIG_DIR}/management-ca.pem"
+
+  run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="token-one"
+
+  assert_absent "${CONFIG_DIR}/management-ca.pem"
+  assert_not_contains "${CONFIG_DIR}/agent.env" "MANAGEMENT_CA_FILE"
+}
+
+test_validation_failures() {
+  setup_fixture
+  if run_installer MANAGEMENT_URL="https://mgmt.example.test:8081" AGENT_ID="agent-one" >/dev/null 2>"${TEST_DIR}/missing-token.err"; then
+    fail "missing AGENT_TOKEN should fail"
+  fi
+  assert_contains "${TEST_DIR}/missing-token.err" "missing required environment variable: AGENT_TOKEN"
+
+  if run_installer MANAGEMENT_URL="https://mgmt.example.test:8081" AGENT_ID="agent-one" AGENT_TOKEN="token-one" AGENT_TLS_CERT_FILE="/tmp/agent.crt.pem" >/dev/null 2>"${TEST_DIR}/partial-mtls.err"; then
+    fail "partial mTLS configuration should fail"
+  fi
+  assert_contains "${TEST_DIR}/partial-mtls.err" "AGENT_TLS_CERT_FILE and AGENT_TLS_KEY_FILE must be set together"
+
+  if run_installer MANAGEMENT_URL="http://mgmt.example.test:8081" AGENT_ID="agent-one" AGENT_TOKEN="token-one" >/dev/null 2>"${TEST_DIR}/http.err"; then
+    fail "HTTP management URL without opt-in should fail"
+  fi
+  assert_contains "${TEST_DIR}/http.err" "refusing insecure MANAGEMENT_URL"
+}
+
+test_uninstall_full_purge() {
+  setup_fixture
+  mkdir -p "${SYSTEMD_DIR}/p2pstream-agent.service.d" "$CONFIG_DIR" "$(dirname "$INSTALL_PATH")"
+  printf 'unit\n' >"${SYSTEMD_DIR}/p2pstream-agent.service"
+  printf 'dropin\n' >"${SYSTEMD_DIR}/p2pstream-agent.service.d/override.conf"
+  printf 'env\n' >"${CONFIG_DIR}/agent.env"
+  printf 'binary\n' >"$INSTALL_PATH"
+
+  run_uninstaller
+
+  assert_absent "${SYSTEMD_DIR}/p2pstream-agent.service"
+  assert_absent "${SYSTEMD_DIR}/p2pstream-agent.service.d"
+  assert_absent "$CONFIG_DIR"
+  assert_absent "$INSTALL_PATH"
+  assert_contains "$SYSTEMCTL_LOG" "disable --now p2pstream-agent"
+  assert_contains "$SYSTEMCTL_LOG" "daemon-reload"
+  assert_contains "$SYSTEMCTL_LOG" "reset-failed p2pstream-agent"
+  assert_contains "$COMMAND_LOG" "userdel p2pstream"
+  assert_contains "$COMMAND_LOG" "groupdel p2pstream"
+}
+
+test_uninstall_dry_run_and_unsafe_paths() {
+  setup_fixture
+  mkdir -p "${SYSTEMD_DIR}/p2pstream-agent.service.d" "$CONFIG_DIR" "$(dirname "$INSTALL_PATH")"
+  printf 'unit\n' >"${SYSTEMD_DIR}/p2pstream-agent.service"
+  printf 'dropin\n' >"${SYSTEMD_DIR}/p2pstream-agent.service.d/override.conf"
+  printf 'env\n' >"${CONFIG_DIR}/agent.env"
+  printf 'binary\n' >"$INSTALL_PATH"
+
+  run_uninstaller P2PSTREAM_UNINSTALL_DRY_RUN="true" >"${TEST_DIR}/dry-run.out"
+  assert_exists "${SYSTEMD_DIR}/p2pstream-agent.service"
+  assert_exists "${SYSTEMD_DIR}/p2pstream-agent.service.d"
+  assert_exists "$CONFIG_DIR"
+  assert_exists "$INSTALL_PATH"
+  assert_contains "${TEST_DIR}/dry-run.out" "p2pstream-agent.service.d"
+
+  if run_uninstaller P2PSTREAM_CONFIG_DIR="/" >/dev/null 2>"${TEST_DIR}/unsafe.err"; then
+    fail "unsafe config dir should fail"
+  fi
+  assert_contains "${TEST_DIR}/unsafe.err" "refusing to remove unsafe P2PSTREAM_CONFIG_DIR"
+}
+
+run_test() {
+  local name="$1"
+  shift
+  TEST_DIR=""
+  printf 'Running %s...\n' "$name"
+  "$@"
+  rm -rf "$TEST_DIR"
+  TEST_DIR=""
+}
+
+run_test "first install" test_first_install
+run_test "reinstall overwrites token and CA" test_reinstall_overwrites_token_and_ca
+run_test "reinstall without CA removes stale managed CA" test_reinstall_without_ca_removes_stale_managed_ca
+run_test "validation failures" test_validation_failures
+run_test "uninstall full purge" test_uninstall_full_purge
+run_test "uninstall dry-run and unsafe paths" test_uninstall_dry_run_and_unsafe_paths
+
+printf 'agent lifecycle tests passed.\n'

--- a/scripts/uninstall-agent.sh
+++ b/scripts/uninstall-agent.sh
@@ -4,7 +4,9 @@ set -Eeuo pipefail
 readonly SERVICE_NAME="p2pstream-agent"
 readonly CONFIG_DIR="${P2PSTREAM_CONFIG_DIR:-/etc/p2pstream}"
 readonly INSTALL_PATH="${P2PSTREAM_INSTALL_PATH:-/usr/local/bin/p2pstream}"
-readonly SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
+readonly SYSTEMD_DIR="${P2PSTREAM_SYSTEMD_DIR:-/etc/systemd/system}"
+readonly SERVICE_FILE="${SYSTEMD_DIR}/${SERVICE_NAME}.service"
+readonly SERVICE_DROPIN_DIR="${SERVICE_FILE}.d"
 readonly SERVICE_USER="p2pstream"
 readonly SERVICE_GROUP="p2pstream"
 readonly CONFIRM_VALUE="full-purge"
@@ -143,6 +145,7 @@ main() {
   info "Uninstalling p2pstream agent with full purge."
   info "Service: ${SERVICE_NAME}"
   info "Service file: ${SERVICE_FILE}"
+  info "Service drop-ins: ${SERVICE_DROPIN_DIR}"
   info "Config directory: ${CONFIG_DIR}"
   info "Binary: ${INSTALL_PATH}"
   if is_dry_run; then
@@ -151,6 +154,7 @@ main() {
 
   stop_service
   remove_file "$SERVICE_FILE"
+  remove_dir "$SERVICE_DROPIN_DIR"
   reload_systemd
   remove_dir "$CONFIG_DIR"
   remove_file "$INSTALL_PATH"

--- a/web/management/src/lib/agentSetupSnippets.test.ts
+++ b/web/management/src/lib/agentSetupSnippets.test.ts
@@ -65,7 +65,16 @@ describe("agentSetupSnippets", () => {
     expect(snippet).toContain("AGENT_ID='agent-mfrggzdfmztwq2lkmmxgg33nna'");
     expect(snippet).toContain("AGENT_TOKEN='token'\\''value'");
     expect(snippet).toContain("P2PSTREAM_REPOSITORY='ExampleUser/p2pstream'");
+    expect(snippet).not.toContain("P2PSTREAM_VERSION");
     expect(snippet).not.toContain("\n");
+  });
+
+  test("adds pinned release version to Linux installer snippets only", () => {
+    const snippet = linuxInstallSnippet({ ...baseInput, version: "v1.2.3" });
+
+    expect(snippet).toContain("P2PSTREAM_VERSION='v1.2.3'");
+    expect(dockerComposeSnippet({ ...baseInput, version: "v1.2.3" })).not.toContain("P2PSTREAM_VERSION");
+    expect(cliSnippet({ ...baseInput, version: "v1.2.3" })).not.toContain("P2PSTREAM_VERSION");
   });
 
   test("builds Linux uninstall snippet with default repository", () => {

--- a/web/management/src/lib/agentSetupSnippets.ts
+++ b/web/management/src/lib/agentSetupSnippets.ts
@@ -12,6 +12,7 @@ export type AgentSetupSnippetInput = {
   agentId: string;
   agentToken: string;
   repository?: string;
+  version?: string;
   dockerImage?: string;
   tls?: AgentSetupTLSConfig;
 };
@@ -49,6 +50,10 @@ export function linuxInstallSnippet(input: AgentSetupSnippetInput): string {
     `AGENT_TOKEN=${shellQuote(input.agentToken)}`,
     `P2PSTREAM_REPOSITORY=${shellQuote(repository)}`,
   ];
+  const version = singleLine(input.version ?? "").trim();
+  if (version) {
+    parts.push(`P2PSTREAM_VERSION=${shellQuote(version)}`);
+  }
   return `curl -fsSL https://raw.githubusercontent.com/${repository}/main/scripts/install-agent.sh | sudo env ${parts.join(" ")} bash`;
 }
 

--- a/web/management/src/views/AgentHealth.vue
+++ b/web/management/src/views/AgentHealth.vue
@@ -78,6 +78,7 @@ const agentEditor = ref<InstanceType<typeof AgentEditorModal> | null>(null);
 const rotateAgentToConfirm = ref<Agent | null>(null);
 const issuedToken = ref("");
 const issuedAgent = ref<Agent | null>(null);
+const setupContext = ref<"create" | "rotate">("create");
 const setupManagementUrl = ref(defaultManagementUrl());
 const setupManagementCAFile = ref("");
 const setupAgentTLSCertFile = ref("/etc/p2pstream/agent.crt.pem");
@@ -98,6 +99,9 @@ const busyDisabledReason = computed(() => isBusy?.value ? BUSY_REASON : "");
 const normalizedManagementUrl = computed(() => normalizeSetupManagementUrl(setupManagementUrl.value));
 const managementUsesTLS = computed(() => normalizedManagementUrl.value.toLowerCase().startsWith("https://"));
 const agentClientCertificateRequired = computed(() => Boolean(managementSecurity.value?.agentClientCertificateRequired));
+const setupIsRotation = computed(() => setupContext.value === "rotate");
+const setupModalTitle = computed(() => setupIsRotation.value ? "Agent Reinstall" : "Agent Setup");
+const setupLinuxTabLabel = computed(() => setupIsRotation.value ? "Linux reinstall" : "Linux install");
 const embeddedManagementCAPEMBase64 = computed(() => {
   const pem = managementSecurity.value?.managementCaPem ?? "";
   if (!pem || !managementUsesTLS.value) return "";
@@ -269,7 +273,7 @@ async function confirmRotateAgentToken() {
   if (!agent) return;
   const ok = await run(async () => {
     const resp = await managementClient.rotateAgentToken({ id: agent.id });
-    openSetupModal(resp.agent ?? agent, resp.token);
+    openSetupModal(resp.agent ?? agent, resp.token, "rotate");
   });
   if (ok) {
     closeRotateAgentModal();
@@ -286,13 +290,15 @@ async function deleteAgent(agent: Agent) {
 function clearIssuedToken() {
   issuedToken.value = "";
   issuedAgent.value = null;
+  setupContext.value = "create";
   setupCopyLabel.value = "Copy";
 }
 
-function openSetupModal(agent: Agent | null, token: string) {
+function openSetupModal(agent: Agent | null, token: string, context: "create" | "rotate" = "create") {
   if (!agent || !token) return;
   issuedAgent.value = agent;
   issuedToken.value = token;
+  setupContext.value = context;
   setupManagementUrl.value = defaultManagementUrl();
   setupManagementCAFile.value = "";
   setupAgentTLSCertFile.value = "/etc/p2pstream/agent.crt.pem";
@@ -329,6 +335,13 @@ function defaultReleaseRepository(): string {
   return typeof configured === "string" && configured.trim() ? configured.trim() : FALLBACK_RELEASE_REPOSITORY;
 }
 
+function stableReleaseVersion(): string {
+  const configured = import.meta.env.VITE_RELEASE_REF;
+  if (typeof configured !== "string") return "";
+  const version = configured.trim();
+  return /^v\d+\.\d+\.\d+$/.test(version) ? version : "";
+}
+
 function linuxInstallerSnippet(): string {
   if (!issuedAgent.value) return "";
   return linuxInstallSnippet(setupSnippetInput());
@@ -354,6 +367,7 @@ function setupSnippetInput() {
     agentId: issuedAgent.value?.publicId ?? "",
     agentToken: issuedToken.value,
     repository: setupReleaseRepository.value,
+    version: stableReleaseVersion(),
     dockerImage: setupDockerImage.value,
     tls: {
       enabled: managementUsesTLS.value,
@@ -688,7 +702,7 @@ async function copyUninstallSnippet() {
       </div>
     </Modal>
 
-    <Modal :model-value="Boolean(issuedToken && issuedAgent)" title="Agent Setup" max-width="48rem" @update:model-value="clearIssuedToken">
+    <Modal :model-value="Boolean(issuedToken && issuedAgent)" :title="setupModalTitle" max-width="48rem" @update:model-value="clearIssuedToken">
       <div v-if="issuedAgent" class="grid gap-5">
         <div class="grid gap-3 md:grid-cols-2">
           <div class="grid gap-1.5">
@@ -705,6 +719,13 @@ async function copyUninstallSnippet() {
           One-Time Token
           <code class="block break-all rounded-md border border-[#333] bg-[#0b0b0b] p-3 font-mono text-xs text-white">{{ issuedToken }}</code>
         </label>
+
+        <div v-if="setupIsRotation" class="rounded-md border border-[#29465f] bg-[#07111c] p-3 text-xs leading-5 text-[#9cccf5]">
+          <p class="font-semibold uppercase tracking-wider">Existing Linux agent</p>
+          <p class="mt-1 text-[#7ba8cf]">
+            Run the Linux reinstall command on the existing agent host. It rewrites the agent environment, refreshes embedded management CA material, and restarts p2pstream-agent.
+          </p>
+        </div>
 
         <div class="grid gap-3 md:grid-cols-2">
           <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[#888]">
@@ -767,7 +788,7 @@ async function copyUninstallSnippet() {
             :class="setupTab === 'install' ? 'border-white bg-white text-black' : 'border-[#333] bg-[#0b0b0b] text-[#d4d4d8] hover:border-[#555] hover:text-white'"
             @click="setupTab = 'install'"
           >
-            Linux install
+            {{ setupLinuxTabLabel }}
           </button>
           <button
             type="button"


### PR DESCRIPTION
## Summary
- restart the systemd agent during Linux reinstall so rotated tokens and TLS material are loaded
- clean stale installer-managed management CA files and validate TLS inputs
- add lifecycle tests, UI reinstall wording, stable release pinning, and docs updates

## Verification
- bash -n scripts/install-agent.sh scripts/uninstall-agent.sh
- scripts/test-agent-lifecycle.sh
- cd web/management && bun test src/lib/*.test.ts
- cd web/management && bun run typecheck
- go test ./...