### PR TITLE
Add staging release channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     branches:
       - dev
+      - staging
       - main
   push:
     branches:
       - dev
+      - staging
 
 permissions:
   contents: read
@@ -20,6 +22,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  main-source-gate:
+    if: github.event_name == 'pull_request'
+    name: Main source gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require staging source for main
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          if [[ "${{ github.base_ref }}" == "main" && "${{ github.head_ref }}" != "staging" ]]; then
+            echo "Pull requests to main must come from the staging branch." >&2
+            exit 1
+          fi
+
   verify:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     name: Verify

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     branches:
       - dev
+      - staging
       - main
   push:
     branches:
       - dev
+      - staging
       - main
   schedule:
     - cron: "29 3 * * 1"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - dev
+      - staging
       - main
     paths:
       - "docs/**"
@@ -11,6 +12,7 @@ on:
   push:
     branches:
       - dev
+      - staging
       - main
     paths:
       - "docs/**"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,260 @@
+name: Staging
+
+on:
+  push:
+    branches:
+      - staging
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: write
+
+concurrency:
+  group: staging
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  STAGING_TAG: staging
+
+jobs:
+  verify:
+    name: Verify staging
+    runs-on: ubuntu-latest
+    outputs:
+      commit_sha: ${{ steps.version.outputs.commit_sha }}
+      image: ${{ steps.image.outputs.image }}
+      short_sha: ${{ steps.version.outputs.short_sha }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.18
+
+      - name: Generate code
+        run: make generate
+
+      - name: Verify generated files are committed
+        run: git diff --exit-code
+
+      - name: Check installer syntax
+        run: bash -n scripts/install-agent.sh scripts/uninstall-agent.sh
+
+      - name: Run installer lifecycle tests
+        run: scripts/test-agent-lifecycle.sh
+
+      - name: Run Go tests
+        run: go test ./...
+
+      - name: Run Go vet
+        run: go vet ./...
+
+      - name: Run frontend unit tests
+        run: cd web/management && bun test src/lib/*.test.ts
+
+      - name: Typecheck management UI
+        run: cd web/management && bun run typecheck
+
+      - name: Build management UI
+        run: cd web/management && bun run build
+
+      - name: Resolve staging metadata
+        id: version
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          echo "commit_sha=$(git rev-parse HEAD)" >>"$GITHUB_OUTPUT"
+          echo "short_sha=$(git rev-parse --short=7 HEAD)" >>"$GITHUB_OUTPUT"
+
+      - name: Set image name
+        id: image
+        shell: bash
+        run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}" >>"$GITHUB_OUTPUT"
+
+  binary:
+    name: Build Linux ${{ matrix.arch }} staging binary
+    needs: verify
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.verify.outputs.commit_sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.18
+
+      - name: Build binary
+        shell: bash
+        env:
+          ARCH: ${{ matrix.arch }}
+          COMMIT_SHA: ${{ needs.verify.outputs.commit_sha }}
+          SOURCE_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -Eeuo pipefail
+          mkdir -p dist
+          go build -trimpath -ldflags "-s -w -X p2pstream/internal/buildinfo.Version=${STAGING_TAG} -X p2pstream/internal/buildinfo.Commit=${COMMIT_SHA} -X p2pstream/internal/buildinfo.Repository=${SOURCE_REPOSITORY}" -o dist/p2pstream main.go
+          chmod +x dist/p2pstream
+          VERSION="${STAGING_TAG}" COMMIT="${COMMIT_SHA}" SOURCE_REPOSITORY="${SOURCE_REPOSITORY}" make legal-notices
+          mkdir -p dist/package
+          cp dist/p2pstream dist/package/p2pstream
+          cp -R dist/legal/. dist/package/
+          tar -C dist/package -czf "p2pstream_${STAGING_TAG}_linux_${ARCH}.tar.gz" .
+
+      - name: Upload binary archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: staging-binary-linux-${{ matrix.arch }}
+          path: p2pstream_staging_linux_${{ matrix.arch }}.tar.gz
+          if-no-files-found: error
+
+  image:
+    name: Build Linux ${{ matrix.arch }} staging image
+    needs: verify
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.verify.outputs.commit_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push architecture image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          target: runtime
+          platforms: linux/${{ matrix.arch }}
+          push: true
+          build-args: |
+            VERSION=${{ env.STAGING_TAG }}
+            COMMIT=${{ needs.verify.outputs.commit_sha }}
+            SOURCE_REPOSITORY=${{ github.repository }}
+            VITE_RELEASE_REPOSITORY=${{ github.repository }}
+            VITE_RELEASE_REF=${{ env.STAGING_TAG }}
+          tags: |
+            ${{ needs.verify.outputs.image }}:${{ env.STAGING_TAG }}-linux-${{ matrix.arch }}
+            ${{ needs.verify.outputs.image }}:${{ env.STAGING_TAG }}-sha-${{ needs.verify.outputs.short_sha }}-linux-${{ matrix.arch }}
+
+  publish:
+    name: Publish staging release
+    needs:
+      - verify
+      - binary
+      - image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.verify.outputs.commit_sha }}
+
+      - name: Download binary archives
+        uses: actions/download-artifact@v8
+        with:
+          pattern: staging-binary-linux-*
+          path: dist/artifacts
+
+      - name: Prepare staging assets
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          mkdir -p dist/assets
+          find dist/artifacts -type f -name '*.tar.gz' -exec cp {} dist/assets/ \;
+          git archive --format=tar.gz --prefix="p2pstream-${STAGING_TAG}/" -o "dist/assets/p2pstream_${STAGING_TAG}_source.tar.gz" HEAD
+          (cd dist/assets && sha256sum *.tar.gz > checksums.txt)
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Publish multi-arch staging tags
+        shell: bash
+        env:
+          IMAGE: ${{ needs.verify.outputs.image }}
+          SHORT_SHA: ${{ needs.verify.outputs.short_sha }}
+        run: |
+          set -Eeuo pipefail
+          docker buildx imagetools create \
+            -t "${IMAGE}:${STAGING_TAG}" \
+            -t "${IMAGE}:${STAGING_TAG}-sha-${SHORT_SHA}" \
+            "${IMAGE}:${STAGING_TAG}-linux-amd64" \
+            "${IMAGE}:${STAGING_TAG}-linux-arm64"
+
+      - name: Publish mutable staging release
+        shell: bash
+        env:
+          COMMIT_SHA: ${{ needs.verify.outputs.commit_sha }}
+          GH_TOKEN: ${{ github.token }}
+          SHORT_SHA: ${{ needs.verify.outputs.short_sha }}
+        run: |
+          set -Eeuo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch --tags --force
+          git tag -fa "${STAGING_TAG}" -m "Staging ${COMMIT_SHA}"
+          git push --force origin "refs/tags/${STAGING_TAG}"
+
+          printf -v notes '%s\n\n%s' \
+            "Mutable p2pstream staging build for commit ${SHORT_SHA}." \
+            "This prerelease is rebuilt from the staging branch and is intended for validation before merging staging to main."
+
+          if gh release view "${STAGING_TAG}" >/dev/null 2>&1; then
+            gh release edit "${STAGING_TAG}" --prerelease --title "${STAGING_TAG}" --notes "$notes"
+            gh release upload "${STAGING_TAG}" dist/assets/* --clobber
+          else
+            gh release create "${STAGING_TAG}" dist/assets/* --prerelease --target "${COMMIT_SHA}" --title "${STAGING_TAG}" --notes "$notes"
+          fi

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Published images are available from GitHub Container Registry:
 ghcr.io/kirari04/p2pstream:latest
 ```
 
-Use `latest` or a pinned `vX.Y.Z` tag for stable deployments. The `nightly` tag is rebuilt from the `dev` branch for testing unreleased changes.
+Use `latest` or a pinned `vX.Y.Z` tag for stable deployments. The mutable `staging` tag is rebuilt from the `staging` branch for pre-release validation, including Linux agent installer assets. The `nightly` tag is rebuilt from the `dev` branch as a Docker-only development channel.
 
 ## Default Deployment Notes
 
@@ -122,11 +122,11 @@ make docker-build
 make docker-smoke
 ```
 
-Development happens on the `dev` branch. Open normal feature and dependency PRs against `dev`; merge `dev` into `main` only when you want to publish a stable release.
+Development happens on the `dev` branch. Open normal feature and dependency PRs against `dev`, merge `dev` into `staging` to publish staging binaries/images for validation, and merge `staging` into `main` only when you want to publish a stable release.
 
 ## Releases
 
-GitHub Actions verifies the project, publishes a multi-arch Linux container to GHCR, creates the next patch tag from `main`, and attaches Linux `amd64` and `arm64` binary release archives plus `checksums.txt`. The `main` branch is release-only; merging `dev` into `main` publishes the next stable release.
+GitHub Actions verifies the project and publishes release artifacts by channel. The `staging` branch updates the mutable `staging` GitHub prerelease, Linux `amd64` and `arm64` binary archives, checksums, source archive, and `ghcr.io/kirari04/p2pstream:staging` image tags. The `main` branch is release-only; merging `staging` into `main` rebuilds the final stable release, creates the next patch tag, publishes `latest`, and attaches stable Linux binary archives plus `checksums.txt`.
 
 A scheduled nightly workflow builds the current `dev` branch and publishes the Docker-only `ghcr.io/kirari04/p2pstream:nightly` tag. Nightly images are for development validation and should not be used as repeatable production pins.
 

--- a/docs/guides/expose-a-home-lab-app.md
+++ b/docs/guides/expose-a-home-lab-app.md
@@ -46,10 +46,11 @@ Example:
      AGENT_ID='agent-...' \
      AGENT_TOKEN='...' \
      P2PSTREAM_REPOSITORY='Kirari04/p2pstream' \
+     P2PSTREAM_VERSION='latest' \
      bash
    ```
 
-   The installer creates `/usr/local/bin/p2pstream`, `/etc/p2pstream/agent.env`, and `p2pstream-agent.service`, then restarts the agent service. You can run the generated Linux command again after token rotation to reinstall the existing agent with the new token.
+   The installer creates `/usr/local/bin/p2pstream`, `/etc/p2pstream/agent.env`, and `p2pstream-agent.service`, then restarts the agent service. You can run the generated Linux command again after token rotation to reinstall the existing agent with the new token. Staging management UIs generate the same command with `P2PSTREAM_VERSION='staging'` and the installer script loaded from the `staging` branch.
 
 3. Check the agent service:
 

--- a/docs/operations/upgrades.md
+++ b/docs/operations/upgrades.md
@@ -11,6 +11,7 @@ Use this when moving to a new container tag, updating a binary/systemd install, 
 - A current backup of `CONFIG_DIR`, `/data` in Compose.
 - The same `p2pstream-data` volume or binary install data directory will remain mounted.
 - Optional: a pinned image tag for repeatable deployments.
+- Avoid `staging` for production upgrades unless you are intentionally validating the next release candidate.
 - Avoid `nightly` for production upgrades unless you are intentionally testing unreleased development changes.
 
 ## Steps
@@ -34,7 +35,15 @@ Use this when moving to a new container tag, updating a binary/systemd install, 
    image: ghcr.io/kirari04/p2pstream:vX.Y.Z
    ```
 
-4. Use the Docker-only `nightly` tag only for development validation:
+4. Use the mutable `staging` tag only for pre-release validation:
+
+   ```yaml
+   image: ghcr.io/kirari04/p2pstream:staging
+   ```
+
+   `staging` is rebuilt from the `staging` branch and can change before the final release. Staging management UIs generate matching staging Linux agent installer commands.
+
+5. Use the Docker-only `nightly` tag only for development validation:
 
    ```yaml
    image: ghcr.io/kirari04/p2pstream:nightly
@@ -42,20 +51,20 @@ Use this when moving to a new container tag, updating a binary/systemd install, 
 
    `nightly` is rebuilt from the `dev` branch and can change without a stable release.
 
-5. For binary/systemd installs:
+6. For binary/systemd installs:
 
    ```bash
    sudo install -m 0755 p2pstream /usr/local/bin/p2pstream
    sudo systemctl restart p2pstream
    ```
 
-6. Use the same server and agent tag when you want server and agent capabilities to move together.
+7. Use the same server and agent tag when you want server and agent capabilities to move together.
 
    After the Yamux tunnel transport change, server and agent versions must match. Old WebSocket agents are incompatible with Yamux-tunnel servers, and Yamux agents are incompatible with old WebSocket-only servers.
 
-7. For installations created before the route-target model, public backend configuration is migrated into route targets automatically. Old public backend CRUD/API surfaces are removed, and existing cache entries are discarded because cache keys are target-aware.
+8. For installations created before the route-target model, public backend configuration is migrated into route targets automatically. Old public backend CRUD/API surfaces are removed, and existing cache entries are discarded because cache keys are target-aware.
 
-8. The route-target-only observability migration resets retained proxy request events and proxy rollups so legacy backend IDs are removed. Agent stats history is not reset.
+9. The route-target-only observability migration resets retained proxy request events and proxy rollups so legacy backend IDs are removed. Agent stats history is not reset.
 
 ## Verification
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -61,7 +61,7 @@ Set these as environment variables before running the Linux agent installer scri
 | Variable                 | Default                    | Description                                                                  |
 | ------------------------ | -------------------------- | ---------------------------------------------------------------------------- |
 | `P2PSTREAM_REPOSITORY`   | `Kirari04/p2pstream`       | GitHub owner/repo used by the installer.                                     |
-| `P2PSTREAM_VERSION`      | `latest`                   | Release tag such as `vX.Y.Z`, or `latest`.                                   |
+| `P2PSTREAM_VERSION`      | `latest`                   | Installer binary channel: `latest`, `staging`, or a release tag such as `vX.Y.Z`. |
 | `P2PSTREAM_CONFIG_DIR`   | `/etc/p2pstream`           | Agent config directory created by installer.                                 |
 | `P2PSTREAM_INSTALL_PATH` | `/usr/local/bin/p2pstream` | Binary install path.                                                         |
 | `P2PSTREAM_SYSTEMD_DIR`  | `/etc/systemd/system`      | Systemd unit directory used by installer and uninstaller.                    |

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -16,11 +16,13 @@ Common tags:
 latest
 vX.Y.Z
 sha-abcdef0
+staging
+staging-sha-abcdef0
 nightly
 nightly-sha-abcdef0
 ```
 
-Stable releases publish `latest`, a version tag such as `vX.Y.Z`, and a commit tag such as `sha-abcdef0` from the `main` branch. The `nightly` tags are Docker-only development images built from the `dev` branch; use them for testing unreleased changes, not for repeatable production deployments.
+Stable releases publish `latest`, a version tag such as `vX.Y.Z`, and a commit tag such as `sha-abcdef0` from the `main` branch. The mutable `staging` tags are pre-release images built from the `staging` branch and are intended for validation before a stable release. The `nightly` tags are Docker-only development images built from the `dev` branch; use them for testing unreleased changes, not for repeatable production deployments.
 
 The runtime image:
 
@@ -52,6 +54,7 @@ ports:
 - The application does not read a `PORT` environment variable for public listeners.
 - Public listener ports are stored in SQLite and managed through **Proxy**.
 - Use a pinned release tag instead of `latest` when repeatability matters.
+- Treat `staging` as mutable. It follows the current `staging` branch and can change before the final release.
 - Treat `nightly` as unstable. It follows the current `dev` branch and can change without a release note.
 
 ## Runtime Effects

--- a/scripts/build-legal-notices.sh
+++ b/scripts/build-legal-notices.sh
@@ -20,7 +20,7 @@ if [[ -z "${repository_slug}" ]]; then
 fi
 
 source_ref="${VERSION_VALUE}"
-if [[ -z "${source_ref}" || "${source_ref}" == "dev" || "${source_ref}" == "nightly" ]]; then
+if [[ -z "${source_ref}" || "${source_ref}" == "dev" || "${source_ref}" == "nightly" || "${source_ref}" == "staging" ]]; then
   source_ref="${COMMIT_VALUE}"
 fi
 

--- a/scripts/install-agent.sh
+++ b/scripts/install-agent.sh
@@ -239,13 +239,16 @@ main() {
     || fail "P2PSTREAM_REPOSITORY must use GitHub owner/repo with letters, numbers, dots, underscores, or hyphens"
 
   arch="$(detect_arch)"
+  version="$(single_line "$version")"
   if [[ "$version" == "latest" ]]; then
     tag="$(latest_release_tag "$repository")"
+  elif [[ "$version" == "staging" ]]; then
+    tag="staging"
+  elif [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    tag="$version"
   else
-    tag="$(single_line "$version")"
+    fail "P2PSTREAM_VERSION must be latest, staging, or vX.Y.Z"
   fi
-
-  [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "release version must look like vX.Y.Z"
 
   asset="p2pstream_${tag}_linux_${arch}.tar.gz"
   base_url="https://github.com/${repository}/releases/download/${tag}"

--- a/scripts/test-agent-lifecycle.sh
+++ b/scripts/test-agent-lifecycle.sh
@@ -149,7 +149,9 @@ setup_fixture() {
     'done' \
     'if [[ "$url" == *"api.github.com"* ]]; then printf "{\"tag_name\":\"v1.2.3\"}\n"; exit 0; fi' \
     '[[ -n "$output" ]] || { printf "missing -o\n" >&2; exit 1; }' \
+    'printf "curl %s\n" "$url" >>"${FAKE_COMMAND_LOG:?}"' \
     'case "$url" in' \
+    '  */staging/checksums.txt) printf "0000000000000000000000000000000000000000000000000000000000000000  p2pstream_staging_linux_amd64.tar.gz\n" >"$output" ;;' \
     '  *checksums.txt) printf "0000000000000000000000000000000000000000000000000000000000000000  p2pstream_v1.2.3_linux_amd64.tar.gz\n" >"$output" ;;' \
     '  *) printf "archive" >"$output" ;;' \
     'esac'
@@ -263,6 +265,19 @@ test_reinstall_without_ca_removes_stale_managed_ca() {
   assert_not_contains "${CONFIG_DIR}/agent.env" "MANAGEMENT_CA_FILE"
 }
 
+test_staging_version_downloads_staging_asset() {
+  setup_fixture
+  run_installer \
+    P2PSTREAM_VERSION="staging" \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="token-one"
+
+  assert_contains "$COMMAND_LOG" "https://github.com/ExampleUser/p2pstream/releases/download/staging/p2pstream_staging_linux_amd64.tar.gz"
+  assert_contains "$COMMAND_LOG" "https://github.com/ExampleUser/p2pstream/releases/download/staging/checksums.txt"
+  assert_exists "$INSTALL_PATH"
+}
+
 test_validation_failures() {
   setup_fixture
   if run_installer MANAGEMENT_URL="https://mgmt.example.test:8081" AGENT_ID="agent-one" >/dev/null 2>"${TEST_DIR}/missing-token.err"; then
@@ -279,6 +294,11 @@ test_validation_failures() {
     fail "HTTP management URL without opt-in should fail"
   fi
   assert_contains "${TEST_DIR}/http.err" "refusing insecure MANAGEMENT_URL"
+
+  if run_installer P2PSTREAM_VERSION="nightly" MANAGEMENT_URL="https://mgmt.example.test:8081" AGENT_ID="agent-one" AGENT_TOKEN="token-one" >/dev/null 2>"${TEST_DIR}/version.err"; then
+    fail "unsupported P2PSTREAM_VERSION should fail"
+  fi
+  assert_contains "${TEST_DIR}/version.err" "P2PSTREAM_VERSION must be latest, staging, or vX.Y.Z"
 }
 
 test_uninstall_full_purge() {
@@ -336,6 +356,7 @@ run_test() {
 run_test "first install" test_first_install
 run_test "reinstall overwrites token and CA" test_reinstall_overwrites_token_and_ca
 run_test "reinstall without CA removes stale managed CA" test_reinstall_without_ca_removes_stale_managed_ca
+run_test "staging version downloads staging asset" test_staging_version_downloads_staging_asset
 run_test "validation failures" test_validation_failures
 run_test "uninstall full purge" test_uninstall_full_purge
 run_test "uninstall dry-run and unsafe paths" test_uninstall_dry_run_and_unsafe_paths

--- a/web/management/src/lib/agentSetupSnippets.test.ts
+++ b/web/management/src/lib/agentSetupSnippets.test.ts
@@ -3,10 +3,14 @@ import {
   cliSnippet,
   dockerComposeSnippet,
   dockerImageForRepository,
+  isValidScriptRef,
   isValidRepository,
   linuxInstallSnippet,
   linuxUninstallSnippet,
+  normalizeReleaseVersion,
   normalizeRepository,
+  normalizeScriptRef,
+  scriptRefForVersion,
   shellQuote,
   yamlQuote,
 } from "@/lib/agentSetupSnippets";
@@ -54,6 +58,8 @@ describe("agentSetupSnippets", () => {
 
   test("uses GHCR image default from repository", () => {
     expect(dockerImageForRepository("ExampleUser/p2pstream")).toBe("ghcr.io/exampleuser/p2pstream:latest");
+    expect(dockerImageForRepository("ExampleUser/p2pstream", "staging")).toBe("ghcr.io/exampleuser/p2pstream:staging");
+    expect(dockerImageForRepository("ExampleUser/p2pstream", "v1.2.3")).toBe("ghcr.io/exampleuser/p2pstream:v1.2.3");
   });
 
   test("builds one-line Linux installer snippet", () => {
@@ -65,16 +71,49 @@ describe("agentSetupSnippets", () => {
     expect(snippet).toContain("AGENT_ID='agent-mfrggzdfmztwq2lkmmxgg33nna'");
     expect(snippet).toContain("AGENT_TOKEN='token'\\''value'");
     expect(snippet).toContain("P2PSTREAM_REPOSITORY='ExampleUser/p2pstream'");
-    expect(snippet).not.toContain("P2PSTREAM_VERSION");
+    expect(snippet).toContain("P2PSTREAM_VERSION='latest'");
     expect(snippet).not.toContain("\n");
   });
 
-  test("adds pinned release version to Linux installer snippets only", () => {
+  test("adds staging version and script ref to Linux installer snippets", () => {
+    const snippet = linuxInstallSnippet({ ...baseInput, version: "staging" });
+
+    expect(snippet).toContain("curl -fsSL https://raw.githubusercontent.com/ExampleUser/p2pstream/staging/scripts/install-agent.sh");
+    expect(snippet).toContain("P2PSTREAM_VERSION='staging'");
+    expect(dockerComposeSnippet({ ...baseInput, version: "staging" })).toContain("image: \"ghcr.io/exampleuser/p2pstream:staging\"");
+  });
+
+  test("adds pinned release version to Linux installer and Docker snippets", () => {
     const snippet = linuxInstallSnippet({ ...baseInput, version: "v1.2.3" });
 
+    expect(snippet).toContain("curl -fsSL https://raw.githubusercontent.com/ExampleUser/p2pstream/v1.2.3/scripts/install-agent.sh");
     expect(snippet).toContain("P2PSTREAM_VERSION='v1.2.3'");
-    expect(dockerComposeSnippet({ ...baseInput, version: "v1.2.3" })).not.toContain("P2PSTREAM_VERSION");
+    expect(dockerComposeSnippet({ ...baseInput, version: "v1.2.3" })).toContain("image: \"ghcr.io/exampleuser/p2pstream:v1.2.3\"");
     expect(cliSnippet({ ...baseInput, version: "v1.2.3" })).not.toContain("P2PSTREAM_VERSION");
+  });
+
+  test("validates release versions and installer script refs", () => {
+    expect(normalizeReleaseVersion("")).toBe("latest");
+    expect(normalizeReleaseVersion("staging")).toBe("staging");
+    expect(scriptRefForVersion("latest")).toBe("main");
+    expect(scriptRefForVersion("staging")).toBe("staging");
+    expect(scriptRefForVersion("v1.2.3")).toBe("v1.2.3");
+    expect(normalizeScriptRef("", "latest")).toBe("main");
+    expect(normalizeScriptRef("abcdef0", "latest")).toBe("abcdef0");
+    expect(isValidScriptRef("staging")).toBe(true);
+
+    for (const version of ["nightly", "dev", "v1.2", "v1.2.3-rc.1", "latest;id"]) {
+      expect(() => normalizeReleaseVersion(version)).toThrow("Release version must be latest, staging, or vX.Y.Z.");
+      expect(() => linuxInstallSnippet({ ...baseInput, version })).toThrow("Release version must be latest, staging, or vX.Y.Z.");
+      expect(() => dockerComposeSnippet({ ...baseInput, version })).toThrow("Release version must be latest, staging, or vX.Y.Z.");
+    }
+
+    for (const scriptRef of ["main;id", "feature/test", "../main", "main\nid", ""]) {
+      if (scriptRef === "") continue;
+      expect(isValidScriptRef(scriptRef)).toBe(false);
+      expect(() => normalizeScriptRef(scriptRef, "latest")).toThrow("Installer script ref must be main, staging, vX.Y.Z, or a commit SHA.");
+      expect(() => linuxInstallSnippet({ ...baseInput, scriptRef })).toThrow("Installer script ref must be main, staging, vX.Y.Z, or a commit SHA.");
+    }
   });
 
   test("builds Linux uninstall snippet with default repository", () => {

--- a/web/management/src/lib/agentSetupSnippets.ts
+++ b/web/management/src/lib/agentSetupSnippets.ts
@@ -13,12 +13,15 @@ export type AgentSetupSnippetInput = {
   agentToken: string;
   repository?: string;
   version?: string;
+  scriptRef?: string;
   dockerImage?: string;
   tls?: AgentSetupTLSConfig;
 };
 
 export const FALLBACK_RELEASE_REPOSITORY = "Kirari04/p2pstream";
 const RELEASE_REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const RELEASE_VERSION_PATTERN = /^v\d+\.\d+\.\d+$/;
+const SCRIPT_REF_PATTERN = /^(main|staging|v\d+\.\d+\.\d+|[A-Fa-f0-9]{7,40})$/;
 
 export function normalizeManagementUrl(value: string): string {
   return value.trim().replace(/\/+$/, "");
@@ -37,24 +40,49 @@ export function isValidRepository(value: string | undefined): boolean {
 	return RELEASE_REPOSITORY_PATTERN.test((value ?? "").trim());
 }
 
-export function dockerImageForRepository(repository: string | undefined): string {
-  return `ghcr.io/${normalizeRepository(repository).toLowerCase()}:latest`;
+export function normalizeReleaseVersion(value: string | undefined): string {
+  const version = singleLine(value ?? "").trim() || "latest";
+  if (version === "latest" || version === "staging" || RELEASE_VERSION_PATTERN.test(version)) {
+    return version;
+  }
+  throw new Error("Release version must be latest, staging, or vX.Y.Z.");
+}
+
+export function isValidScriptRef(value: string | undefined): boolean {
+  return SCRIPT_REF_PATTERN.test(singleLine(value ?? "").trim());
+}
+
+export function scriptRefForVersion(version: string | undefined): string {
+  const normalized = normalizeReleaseVersion(version);
+  return normalized === "latest" ? "main" : normalized;
+}
+
+export function normalizeScriptRef(value: string | undefined, version: string | undefined): string {
+  const scriptRef = singleLine(value ?? "").trim() || scriptRefForVersion(version);
+  if (!isValidScriptRef(scriptRef)) {
+    throw new Error("Installer script ref must be main, staging, vX.Y.Z, or a commit SHA.");
+  }
+  return scriptRef;
+}
+
+export function dockerImageForRepository(repository: string | undefined, version?: string): string {
+  const imageTag = normalizeReleaseVersion(version);
+  return `ghcr.io/${normalizeRepository(repository).toLowerCase()}:${imageTag}`;
 }
 
 export function linuxInstallSnippet(input: AgentSetupSnippetInput): string {
   const repository = normalizeRepository(input.repository);
+  const version = normalizeReleaseVersion(input.version);
+  const scriptRef = normalizeScriptRef(input.scriptRef, version);
   const parts = [
     `MANAGEMENT_URL=${shellQuote(normalizeManagementUrl(input.managementUrl))}`,
     ...installTLSParts(input.tls),
     `AGENT_ID=${shellQuote(input.agentId)}`,
     `AGENT_TOKEN=${shellQuote(input.agentToken)}`,
     `P2PSTREAM_REPOSITORY=${shellQuote(repository)}`,
+    `P2PSTREAM_VERSION=${shellQuote(version)}`,
   ];
-  const version = singleLine(input.version ?? "").trim();
-  if (version) {
-    parts.push(`P2PSTREAM_VERSION=${shellQuote(version)}`);
-  }
-  return `curl -fsSL https://raw.githubusercontent.com/${repository}/main/scripts/install-agent.sh | sudo env ${parts.join(" ")} bash`;
+  return `curl -fsSL https://raw.githubusercontent.com/${repository}/${scriptRef}/scripts/install-agent.sh | sudo env ${parts.join(" ")} bash`;
 }
 
 export function linuxUninstallSnippet(input: Pick<AgentSetupSnippetInput, "repository">): string {
@@ -63,7 +91,8 @@ export function linuxUninstallSnippet(input: Pick<AgentSetupSnippetInput, "repos
 }
 
 export function dockerComposeSnippet(input: AgentSetupSnippetInput): string {
-  const image = input.dockerImage?.trim() || dockerImageForRepository(input.repository);
+  const version = normalizeReleaseVersion(input.version);
+  const image = input.dockerImage?.trim() || dockerImageForRepository(input.repository, version);
   return `services:
   p2pstream-agent:
     image: ${yamlQuote(image)}

--- a/web/management/src/views/AgentHealth.vue
+++ b/web/management/src/views/AgentHealth.vue
@@ -85,7 +85,8 @@ const setupAgentTLSCertFile = ref("/etc/p2pstream/agent.crt.pem");
 const setupAgentTLSKeyFile = ref("/etc/p2pstream/agent.key.pem");
 const setupAllowInsecureManagement = ref(false);
 const setupReleaseRepository = ref(defaultReleaseRepository());
-const setupDockerImage = ref(dockerImageForRepository(setupReleaseRepository.value));
+const setupReleaseVersion = ref(defaultReleaseVersion());
+const setupDockerImage = ref(defaultDockerImage(setupReleaseRepository.value, setupReleaseVersion.value));
 const setupDockerImageTouched = ref(false);
 const setupTab = ref<"install" | "docker" | "cli">("install");
 const setupCopyLabel = ref("Copy");
@@ -144,9 +145,9 @@ function buildSetupSnippet(): string {
   }
 }
 
-watch(setupReleaseRepository, (repository) => {
+watch([setupReleaseRepository, setupReleaseVersion], ([repository, version]) => {
   if (!setupDockerImageTouched.value) {
-    setupDockerImage.value = dockerImageForRepository(repository);
+    setupDockerImage.value = defaultDockerImage(repository, version);
   }
 });
 
@@ -305,7 +306,8 @@ function openSetupModal(agent: Agent | null, token: string, context: "create" | 
   setupAgentTLSKeyFile.value = "/etc/p2pstream/agent.key.pem";
   setupAllowInsecureManagement.value = false;
   setupReleaseRepository.value = defaultReleaseRepository();
-  setupDockerImage.value = dockerImageForRepository(setupReleaseRepository.value);
+  setupReleaseVersion.value = defaultReleaseVersion();
+  setupDockerImage.value = defaultDockerImage(setupReleaseRepository.value, setupReleaseVersion.value);
   setupDockerImageTouched.value = false;
   setupTab.value = "install";
   setupCopyLabel.value = "Copy";
@@ -335,11 +337,27 @@ function defaultReleaseRepository(): string {
   return typeof configured === "string" && configured.trim() ? configured.trim() : FALLBACK_RELEASE_REPOSITORY;
 }
 
-function stableReleaseVersion(): string {
+function defaultReleaseVersion(): string {
   const configured = import.meta.env.VITE_RELEASE_REF;
-  if (typeof configured !== "string") return "";
+  if (typeof configured !== "string") return "latest";
   const version = configured.trim();
-  return /^v\d+\.\d+\.\d+$/.test(version) ? version : "";
+  if (version === "staging" || /^v\d+\.\d+\.\d+$/.test(version)) {
+    return version;
+  }
+  return "latest";
+}
+
+function defaultDockerImage(repository: string, version: string): string {
+  try {
+    return dockerImageForRepository(repository, version);
+  } catch {
+    return dockerImageForRepository(repository);
+  }
+}
+
+function installerScriptRef(): string {
+  const version = setupReleaseVersion.value.trim();
+  return version === "latest" || version === "" ? "main" : version;
 }
 
 function linuxInstallerSnippet(): string {
@@ -367,7 +385,8 @@ function setupSnippetInput() {
     agentId: issuedAgent.value?.publicId ?? "",
     agentToken: issuedToken.value,
     repository: setupReleaseRepository.value,
-    version: stableReleaseVersion(),
+    version: setupReleaseVersion.value,
+    scriptRef: installerScriptRef(),
     dockerImage: setupDockerImage.value,
     tls: {
       enabled: managementUsesTLS.value,
@@ -735,6 +754,10 @@ async function copyUninstallSnippet() {
           <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[#888]">
             GitHub Repository
             <input v-model="setupReleaseRepository" class="vercel-input text-sm normal-case tracking-normal" placeholder="Kirari04/p2pstream" required />
+          </label>
+          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[#888]">
+            Release Version
+            <input v-model="setupReleaseVersion" class="vercel-input text-sm normal-case tracking-normal" placeholder="latest, staging, or vX.Y.Z" required />
           </label>
           <label v-if="setupTab === 'docker'" class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[#888]">
             Docker Image


### PR DESCRIPTION
## Summary
- add a protected staging release channel workflow for mutable staging binaries, source archive, checksums, and GHCR images
- add CI branch coverage and a main-source gate requiring PRs to main to come from staging
- update Linux installer, agent setup snippets, and management UI defaults for `P2PSTREAM_VERSION=staging`
- document dev -> staging -> main release flow and staging/nightly/stable tags

## Tests
- bash -n scripts/install-agent.sh
- bash -n scripts/uninstall-agent.sh
- bash -n scripts/test-agent-lifecycle.sh
- scripts/test-agent-lifecycle.sh
- go test ./...
- go vet ./...
- cd web/management && bun test src/lib/*.test.ts
- cd web/management && bun run typecheck
- cd web/management && bun run build

## Follow-up after merge
- create `staging` from updated `origin/dev`
- add branch protection/rulesets for `staging`
- make `Main source gate` required on `main`
- open and merge `dev -> staging` to publish the first staging build