### PR TITLE
Improve ACME renewal logging

### DIFF
--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -93,7 +93,7 @@ When diagnosing public traffic, open **Traffic**, enable tracing, reproduce the 
 | Cause | Fix |
 | --- | --- |
 | No matching certificate mapping | Add a mapping for the exact host or wildcard in **TLS**. |
-| ACME certificate not ready | Check certificate status and last error. |
+| ACME certificate not ready | Check certificate status, last attempt, last error, and next renewal or retry time in **TLS**. |
 | Request SNI mismatch | Test with the real hostname, not the IP address. |
 | Listener not restarted | Stop/start the listener or wait for automatic restart after certificate issuance. |
 
@@ -112,6 +112,8 @@ When diagnosing public traffic, open **Traffic**, enable tracing, reproduce the 
 | DNS-01 | Cloudflare zone ID and API token must be valid and enabled. |
 | Wildcard | Use DNS-01; HTTP-01 and TLS-ALPN-01 do not support wildcard issuance. |
 | CA | Test with staging before production. |
+
+ACME renewal logs use `component=public_acme`. Filter those entries and inspect `cert_id`, `hostname`, `challenge_type`, `ca`, `trigger`, `stage`, `attempt_at`, `duration`, `next_renewal_at`, and `retry_at`. A successful attempt logs `ACME certificate renewal succeeded`; a failed attempt logs `ACME certificate renewal failed` with the failed stage and retry time. Failed renewals retry automatically after 1 hour.
 
 ## Route Does Not Match
 

--- a/docs/reference/public-tls-acme.md
+++ b/docs/reference/public-tls-acme.md
@@ -30,7 +30,7 @@ Statuses:
 | Pending | Waiting for initial issuance. |
 | Renewing | Issuance or renewal is running. |
 | Ready | Certificate material is available. |
-| Error | Last issuance attempt failed; check `last_error`. |
+| Error | Last issuance attempt failed; check `last_error` and the next retry time. |
 
 ## Validation Rules
 
@@ -43,9 +43,13 @@ Statuses:
 
 ## Runtime Effects
 
-Uploaded and generated public certificate material is written under `${CONFIG_DIR}/certs/public-listener-<listener-id>/`. ACME certificates renew when missing, expired, or within 30 days of expiry. Failed renewals are retried after a delay.
+Uploaded and generated public certificate material is written under `${CONFIG_DIR}/certs/public-listener-<listener-id>/`. ACME certificates renew when missing, expired, or within 30 days of expiry. Failed renewals are retried after 1 hour.
 
-The management UI shows certificate validity when metadata is stored or the certificate file can be parsed.
+For ready ACME certificates, `next_renewal_at` is the next planned renewal time. For failed ACME certificates, `next_renewal_at` is the next automatic retry time. While a renewal is running, the next schedule is cleared until the attempt succeeds or fails.
+
+The management UI shows certificate validity when metadata is stored or the certificate file can be parsed. For ACME certificates it also shows the last attempt time, the next renewal or retry time, and the last error.
+
+Server logs for ACME use `component=public_acme`. Renewal entries include fields such as `cert_id`, `listener_id`, `hostname`, `challenge_type`, `ca`, `trigger`, `stage`, `attempt_at`, `duration`, `expires_at`, `next_renewal_at`, and `retry_at`. Challenge tokens, DNS TXT values, DNS API tokens, and private key material are not logged.
 
 <figure class="doc-screenshot">
   <img src="../assets/new/tls_page.png" alt="p2pstream TLS page showing certificate mappings, ACME challenge type, status, renewal time, and DNS credentials">

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -186,6 +186,7 @@ type Querier interface {
 	UpdatePublicRouteTarget(ctx context.Context, arg UpdatePublicRouteTargetParams) (PublicRouteTarget, error)
 	UpdatePublicTlsCertificate(ctx context.Context, arg UpdatePublicTlsCertificateParams) (PublicTlsCertificate, error)
 	UpdatePublicTlsCertificateIssueState(ctx context.Context, arg UpdatePublicTlsCertificateIssueStateParams) (PublicTlsCertificate, error)
+	UpdatePublicTlsCertificateRenewalStatus(ctx context.Context, arg UpdatePublicTlsCertificateRenewalStatusParams) (PublicTlsCertificate, error)
 	UpdatePublicTlsCertificateStatus(ctx context.Context, arg UpdatePublicTlsCertificateStatusParams) (PublicTlsCertificate, error)
 	UpdatePublicTlsDnsCredential(ctx context.Context, arg UpdatePublicTlsDnsCredentialParams) (PublicTlsDnsCredential, error)
 	UpdatePublicTrafficShaperRule(ctx context.Context, arg UpdatePublicTrafficShaperRuleParams) (PublicTrafficShaperRule, error)

--- a/internal/db/query.sql.go
+++ b/internal/db/query.sql.go
@@ -7174,6 +7174,58 @@ func (q *Queries) UpdatePublicTlsCertificateIssueState(ctx context.Context, arg 
 	return i, err
 }
 
+const updatePublicTlsCertificateRenewalStatus = `-- name: UpdatePublicTlsCertificateRenewalStatus :one
+UPDATE public_tls_certificates
+SET status = ?,
+    last_error = ?,
+    next_renewal_at = ?,
+    last_renewal_attempt_at = ?,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = ?
+RETURNING id, listener_id, hostname_pattern, cert_path, key_path, enabled, source, acme_challenge_type, acme_ca, acme_email, dns_credential_id, status, last_error, issued_at, expires_at, next_renewal_at, last_renewal_attempt_at, created_at, updated_at
+`
+
+type UpdatePublicTlsCertificateRenewalStatusParams struct {
+	Status               string       `json:"status"`
+	LastError            string       `json:"last_error"`
+	NextRenewalAt        sql.NullTime `json:"next_renewal_at"`
+	LastRenewalAttemptAt sql.NullTime `json:"last_renewal_attempt_at"`
+	ID                   int64        `json:"id"`
+}
+
+func (q *Queries) UpdatePublicTlsCertificateRenewalStatus(ctx context.Context, arg UpdatePublicTlsCertificateRenewalStatusParams) (PublicTlsCertificate, error) {
+	row := q.db.QueryRowContext(ctx, updatePublicTlsCertificateRenewalStatus,
+		arg.Status,
+		arg.LastError,
+		arg.NextRenewalAt,
+		arg.LastRenewalAttemptAt,
+		arg.ID,
+	)
+	var i PublicTlsCertificate
+	err := row.Scan(
+		&i.ID,
+		&i.ListenerID,
+		&i.HostnamePattern,
+		&i.CertPath,
+		&i.KeyPath,
+		&i.Enabled,
+		&i.Source,
+		&i.AcmeChallengeType,
+		&i.AcmeCa,
+		&i.AcmeEmail,
+		&i.DnsCredentialID,
+		&i.Status,
+		&i.LastError,
+		&i.IssuedAt,
+		&i.ExpiresAt,
+		&i.NextRenewalAt,
+		&i.LastRenewalAttemptAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const updatePublicTlsCertificateStatus = `-- name: UpdatePublicTlsCertificateStatus :one
 UPDATE public_tls_certificates
 SET status = ?,

--- a/internal/server/public_acme.go
+++ b/internal/server/public_acme.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/crypto/acme"
 
@@ -32,6 +33,42 @@ const (
 	publicACMERenewBefore         = 30 * 24 * time.Hour
 	publicACMERetryAfterFailure   = time.Hour
 	publicACMESchedulerInterval   = 30 * time.Minute
+)
+
+const (
+	publicACMELogComponent = "public_acme"
+
+	publicACMETriggerStartupScan   = "startup_scan"
+	publicACMETriggerScheduledScan = "scheduled_scan"
+	publicACMETriggerManual        = "manual"
+	publicACMETriggerConfigChange  = "config_change"
+
+	publicACMEStageSchedulerScan        = "scheduler_scan"
+	publicACMEStageSchedulerSkip        = "scheduler_skip"
+	publicACMEStageQueued               = "queued"
+	publicACMEStageDuplicateInFlight    = "duplicate_in_flight"
+	publicACMEStageLoadCertificate      = "load_certificate"
+	publicACMEStageMarkRenewing         = "mark_renewing"
+	publicACMEStageIssueConfig          = "issue_config"
+	publicACMEStageIssueCertificate     = "issue_certificate"
+	publicACMEStageParseCertificate     = "parse_certificate"
+	publicACMEStageWriteCertificate     = "write_certificate"
+	publicACMEStageRecordSuccess        = "record_success"
+	publicACMEStageRecordFailure        = "record_failure"
+	publicACMEStageRefreshProxySnapshot = "refresh_proxy_snapshot"
+	publicACMEStageAccountKey           = "account_key"
+	publicACMEStageAccountRegistration  = "account_registration"
+	publicACMEStageOrderCreate          = "order_create"
+	publicACMEStageAuthorizationLookup  = "authorization_lookup"
+	publicACMEStageChallengeSelection   = "challenge_selection"
+	publicACMEStageChallengeProvision   = "challenge_provision"
+	publicACMEStageChallengeAccept      = "challenge_accept"
+	publicACMEStageAuthorizationWait    = "authorization_wait"
+	publicACMEStageChallengeCleanup     = "challenge_cleanup"
+	publicACMEStageOrderWait            = "order_wait"
+	publicACMEStageCSRCreate            = "csr_create"
+	publicACMEStageFinalizeCertificate  = "certificate_finalization"
+	publicACMEStageMarshalKey           = "marshal_private_key"
 )
 
 type publicACMEManager struct {
@@ -52,6 +89,8 @@ type publicACMEIssueConfig struct {
 	ChallengeType string
 	CA            string
 	Email         string
+	Trigger       string
+	AttemptAt     time.Time
 	DNSCredential *db.PublicTlsDnsCredential
 }
 
@@ -68,6 +107,98 @@ type publicACMEIssuer interface {
 type publicACMEChallengeStore interface {
 	SetHTTPChallenge(path string, response string) func()
 	SetTLSALPNChallenge(hostname string, cert tls.Certificate) func()
+}
+
+type publicACMEScheduleDecision struct {
+	Due           bool
+	Reason        string
+	NextAttemptAt sql.NullTime
+}
+
+type publicACMEStageError struct {
+	stage string
+	err   error
+}
+
+func (e publicACMEStageError) Error() string {
+	if e.err == nil {
+		return e.stage
+	}
+	return e.stage + ": " + e.err.Error()
+}
+
+func (e publicACMEStageError) Unwrap() error {
+	return e.err
+}
+
+func publicACMEStageWrap(stage string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var stageErr publicACMEStageError
+	if errors.As(err, &stageErr) {
+		return err
+	}
+	return publicACMEStageError{stage: stage, err: err}
+}
+
+func publicACMEErrorStage(err error, fallback string) string {
+	var stageErr publicACMEStageError
+	if errors.As(err, &stageErr) && stageErr.stage != "" {
+		return stageErr.stage
+	}
+	return fallback
+}
+
+func publicACMELog(event *zerolog.Event, trigger string, stage string) *zerolog.Event {
+	event = event.Str("component", publicACMELogComponent)
+	if trigger != "" {
+		event = event.Str("trigger", trigger)
+	}
+	if stage != "" {
+		event = event.Str("stage", stage)
+	}
+	return event
+}
+
+func publicACMELogCertificate(event *zerolog.Event, cert db.PublicTlsCertificate, trigger string, stage string) *zerolog.Event {
+	return publicACMELog(event, trigger, stage).
+		Int64("cert_id", cert.ID).
+		Int64("listener_id", cert.ListenerID).
+		Str("hostname", cert.HostnamePattern).
+		Str("challenge_type", normalizePublicACMEChallengeType(cert.AcmeChallengeType)).
+		Str("ca", normalizePublicACMECA(cert.AcmeCa))
+}
+
+func publicACMELogIssueConfig(event *zerolog.Event, cfg publicACMEIssueConfig, stage string) *zerolog.Event {
+	event = publicACMELog(event, cfg.Trigger, stage).
+		Int64("cert_id", cfg.CertificateID).
+		Int64("listener_id", cfg.ListenerID).
+		Str("hostname", cfg.Domain).
+		Str("challenge_type", cfg.ChallengeType).
+		Str("ca", cfg.CA)
+	if !cfg.AttemptAt.IsZero() {
+		event = event.Time("attempt_at", cfg.AttemptAt.UTC())
+	}
+	return event
+}
+
+func publicACMELogOptionalTime(event *zerolog.Event, field string, value sql.NullTime) *zerolog.Event {
+	if value.Valid {
+		return event.Time(field, value.Time.UTC())
+	}
+	return event
+}
+
+func publicACMEMinNullTime(current sql.NullTime, candidate sql.NullTime) sql.NullTime {
+	if !candidate.Valid {
+		return current
+	}
+	candidate.Time = candidate.Time.UTC()
+	if !current.Valid || candidate.Time.Before(current.Time) {
+		return candidate
+	}
+	return current
 }
 
 func newPublicACMEManager(app *App) *publicACMEManager {
@@ -96,7 +227,7 @@ func (m *publicACMEManager) Start(ctx context.Context) {
 	m.mu.Unlock()
 
 	go func() {
-		m.queueDueCertificates(ctx)
+		m.queueDueCertificates(ctx, publicACMETriggerStartupScan)
 		ticker := time.NewTicker(publicACMESchedulerInterval)
 		defer ticker.Stop()
 		for {
@@ -104,17 +235,29 @@ func (m *publicACMEManager) Start(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				m.queueDueCertificates(ctx)
+				m.queueDueCertificates(ctx, publicACMETriggerScheduledScan)
 			}
 		}
 	}()
 }
 
-func (m *publicACMEManager) QueueIssue(certID int64) {
+func (m *publicACMEManager) QueueIssue(certID int64, trigger string) {
 	if m == nil || certID <= 0 {
 		return
 	}
-	go m.issueCertificate(context.Background(), certID)
+	publicACMELog(log.Info(), trigger, publicACMEStageQueued).
+		Int64("cert_id", certID).
+		Msg("ACME certificate renewal queued")
+	go m.issueCertificate(context.Background(), certID, trigger)
+}
+
+func (m *publicACMEManager) QueueCertificate(cert db.PublicTlsCertificate, trigger string) {
+	if m == nil || cert.ID <= 0 {
+		return
+	}
+	publicACMELogCertificate(log.Info(), cert, trigger, publicACMEStageQueued).
+		Msg("ACME certificate renewal queued")
+	go m.issueCertificate(context.Background(), cert.ID, trigger)
 }
 
 func (m *publicACMEManager) ServeHTTPChallenge(w http.ResponseWriter, r *http.Request) bool {
@@ -167,95 +310,170 @@ func (m *publicACMEManager) SetTLSALPNChallenge(hostname string, cert tls.Certif
 	}
 }
 
-func (m *publicACMEManager) queueDueCertificates(ctx context.Context) {
+func (m *publicACMEManager) queueDueCertificates(ctx context.Context, trigger string) {
 	if m == nil || m.app == nil || m.app.DB == nil {
 		return
 	}
 	certs, err := m.app.DB.ListPublicTlsCertificates(ctx)
 	if err != nil {
-		log.Warn().Err(err).Msg("Failed to list ACME certificates")
+		publicACMELog(log.Warn().Err(err), trigger, publicACMEStageSchedulerScan).
+			Msg("Failed to list ACME certificates")
 		return
 	}
 	now := time.Now().UTC()
+	enabledACMECount := 0
+	dueCount := 0
+	queuedCount := 0
+	var earliestNextAttempt sql.NullTime
 	for _, cert := range certs {
-		if !publicACMECertificateDue(cert, now) {
+		decision := publicACMECertificateScheduleDecision(cert, now)
+		if normalizePublicTLSCertificateSource(cert.Source) != publicTLSCertificateSourceACME || cert.Enabled == 0 {
 			continue
 		}
-		go m.issueCertificate(ctx, cert.ID)
+		enabledACMECount++
+		earliestNextAttempt = publicACMEMinNullTime(earliestNextAttempt, decision.NextAttemptAt)
+		if !decision.Due {
+			publicACMELogOptionalTime(
+				publicACMELogCertificate(log.Debug(), cert, trigger, publicACMEStageSchedulerSkip).
+					Str("reason", decision.Reason),
+				"next_renewal_at",
+				decision.NextAttemptAt,
+			).Msg("ACME certificate renewal skipped")
+			continue
+		}
+		dueCount++
+		queuedCount++
+		publicACMELogCertificate(log.Info(), cert, trigger, publicACMEStageQueued).
+			Str("reason", decision.Reason).
+			Msg("ACME certificate renewal queued")
+		go m.issueCertificate(ctx, cert.ID, trigger)
 	}
+	publicACMELogOptionalTime(
+		publicACMELog(log.Info(), trigger, publicACMEStageSchedulerScan).
+			Int("certificates_scanned", len(certs)).
+			Int("enabled_acme_certificates", enabledACMECount).
+			Int("due_certificates", dueCount).
+			Int("queued_certificates", queuedCount),
+		"next_renewal_at",
+		earliestNextAttempt,
+	).Msg("ACME renewal scheduler scan completed")
 }
 
 func publicACMECertificateDue(cert db.PublicTlsCertificate, now time.Time) bool {
-	if normalizePublicTLSCertificateSource(cert.Source) != publicTLSCertificateSourceACME || cert.Enabled == 0 {
-		return false
-	}
-	if cert.LastRenewalAttemptAt.Valid && normalizePublicTLSCertificateStatus(cert.Status) == publicTLSCertificateStatusError &&
-		now.Sub(cert.LastRenewalAttemptAt.Time) < publicACMERetryAfterFailure {
-		return false
-	}
-	if cert.CertPath == "" || cert.KeyPath == "" || !cert.ExpiresAt.Valid {
-		return true
-	}
-	return !cert.ExpiresAt.Time.After(now.Add(publicACMERenewBefore))
+	return publicACMECertificateScheduleDecision(cert, now).Due
 }
 
-func (m *publicACMEManager) issueCertificate(ctx context.Context, certID int64) {
+func publicACMECertificateScheduleDecision(cert db.PublicTlsCertificate, now time.Time) publicACMEScheduleDecision {
+	now = now.UTC()
+	if normalizePublicTLSCertificateSource(cert.Source) != publicTLSCertificateSourceACME || cert.Enabled == 0 {
+		return publicACMEScheduleDecision{Reason: "not_enabled_acme"}
+	}
+	if normalizePublicTLSCertificateStatus(cert.Status) == publicTLSCertificateStatusError {
+		if cert.NextRenewalAt.Valid {
+			nextAttemptAt := sql.NullTime{Time: cert.NextRenewalAt.Time.UTC(), Valid: true}
+			if now.Before(nextAttemptAt.Time) {
+				return publicACMEScheduleDecision{Reason: "waiting_for_retry", NextAttemptAt: nextAttemptAt}
+			}
+			return publicACMEScheduleDecision{Due: true, Reason: "retry_due", NextAttemptAt: nextAttemptAt}
+		}
+		if cert.LastRenewalAttemptAt.Valid {
+			nextAttemptAt := sql.NullTime{Time: cert.LastRenewalAttemptAt.Time.UTC().Add(publicACMERetryAfterFailure), Valid: true}
+			if now.Before(nextAttemptAt.Time) {
+				return publicACMEScheduleDecision{Reason: "waiting_for_retry", NextAttemptAt: nextAttemptAt}
+			}
+			return publicACMEScheduleDecision{Due: true, Reason: "retry_due", NextAttemptAt: nextAttemptAt}
+		}
+		return publicACMEScheduleDecision{Due: true, Reason: "retry_due"}
+	}
+	if cert.CertPath == "" || cert.KeyPath == "" {
+		return publicACMEScheduleDecision{Due: true, Reason: "missing_certificate_material"}
+	}
+	if !cert.ExpiresAt.Valid {
+		return publicACMEScheduleDecision{Due: true, Reason: "missing_expiry"}
+	}
+	expiresAt := cert.ExpiresAt.Time.UTC()
+	nextAttemptAt := sql.NullTime{Time: expiresAt.Add(-publicACMERenewBefore), Valid: true}
+	if !expiresAt.After(now) {
+		return publicACMEScheduleDecision{Due: true, Reason: "expired", NextAttemptAt: nextAttemptAt}
+	}
+	if !expiresAt.After(now.Add(publicACMERenewBefore)) {
+		return publicACMEScheduleDecision{Due: true, Reason: "renewal_window", NextAttemptAt: nextAttemptAt}
+	}
+	return publicACMEScheduleDecision{Reason: "scheduled", NextAttemptAt: nextAttemptAt}
+}
+
+func (m *publicACMEManager) issueCertificate(ctx context.Context, certID int64, trigger string) {
+	attemptAt := time.Now().UTC()
 	if !m.beginIssue(certID) {
+		publicACMELog(log.Info(), trigger, publicACMEStageDuplicateInFlight).
+			Int64("cert_id", certID).
+			Time("attempt_at", attemptAt).
+			Msg("ACME certificate renewal skipped because another attempt is in flight")
 		return
 	}
 	defer m.endIssue(certID)
 
 	cert, err := m.app.DB.GetPublicTlsCertificate(ctx, certID)
 	if err != nil {
-		log.Warn().Err(err).Int64("cert_id", certID).Msg("Failed to load ACME certificate")
+		publicACMELog(log.Warn().Err(err), trigger, publicACMEStageLoadCertificate).
+			Int64("cert_id", certID).
+			Time("attempt_at", attemptAt).
+			Msg("Failed to load ACME certificate")
 		return
 	}
 	if normalizePublicTLSCertificateSource(cert.Source) != publicTLSCertificateSourceACME || cert.Enabled == 0 {
 		return
 	}
-	now := time.Now().UTC()
-	cert, err = m.app.DB.UpdatePublicTlsCertificateStatus(ctx, db.UpdatePublicTlsCertificateStatusParams{
+	publicACMELogCertificate(log.Info(), cert, trigger, publicACMEStageIssueCertificate).
+		Time("attempt_at", attemptAt).
+		Msg("ACME certificate renewal started")
+	cert, err = m.app.DB.UpdatePublicTlsCertificateRenewalStatus(ctx, db.UpdatePublicTlsCertificateRenewalStatusParams{
 		ID:                   cert.ID,
 		Status:               publicTLSCertificateStatusRenewing,
 		LastError:            "",
-		LastRenewalAttemptAt: sql.NullTime{Time: now, Valid: true},
+		NextRenewalAt:        sql.NullTime{},
+		LastRenewalAttemptAt: sql.NullTime{Time: attemptAt, Valid: true},
 	})
 	if err != nil {
-		log.Warn().Err(err).Int64("cert_id", certID).Msg("Failed to mark ACME certificate renewing")
+		publicACMELogCertificate(log.Warn().Err(err), cert, trigger, publicACMEStageMarkRenewing).
+			Time("attempt_at", attemptAt).
+			Msg("Failed to mark ACME certificate renewing")
 		return
 	}
 
 	issueCfg, err := m.issueConfig(ctx, cert)
 	if err != nil {
-		m.markIssueFailed(ctx, cert, err)
+		m.markIssueFailed(ctx, cert, trigger, attemptAt, publicACMEStageWrap(publicACMEStageIssueConfig, err))
 		return
 	}
+	issueCfg.Trigger = trigger
+	issueCfg.AttemptAt = attemptAt
 	result, err := m.issuer.Issue(ctx, m, issueCfg)
 	if err != nil {
-		m.markIssueFailed(ctx, cert, err)
+		m.markIssueFailed(ctx, cert, trigger, attemptAt, publicACMEStageWrap(publicACMEStageIssueCertificate, err))
 		return
 	}
 	if result.Leaf == nil {
 		result.Leaf, err = parseLeafCertificate(result.CertPEM)
 		if err != nil {
-			m.markIssueFailed(ctx, cert, err)
+			m.markIssueFailed(ctx, cert, trigger, attemptAt, publicACMEStageWrap(publicACMEStageParseCertificate, err))
 			return
 		}
 	}
 
 	certPath, keyPath, err := m.config().WritePublicTLSCertificateFiles(cert.ListenerID, cert.ID, result.CertPEM, result.KeyPEM)
 	if err != nil {
-		m.markIssueFailed(ctx, cert, err)
+		m.markIssueFailed(ctx, cert, trigger, attemptAt, publicACMEStageWrap(publicACMEStageWriteCertificate, err))
 		return
 	}
 	expiresAt := result.Leaf.NotAfter.UTC()
-	issuedAt := now
+	issuedAt := attemptAt
 	if !result.Leaf.NotBefore.IsZero() {
 		issuedAt = result.Leaf.NotBefore.UTC()
 	}
 	nextRenewalAt := expiresAt.Add(-publicACMERenewBefore)
-	if nextRenewalAt.Before(now) {
-		nextRenewalAt = now.Add(publicACMERetryAfterFailure)
+	if nextRenewalAt.Before(attemptAt) {
+		nextRenewalAt = attemptAt.Add(publicACMERetryAfterFailure)
 	}
 	updated, err := m.app.DB.UpdatePublicTlsCertificateIssueState(ctx, db.UpdatePublicTlsCertificateIssueStateParams{
 		ID:                   cert.ID,
@@ -266,14 +484,23 @@ func (m *publicACMEManager) issueCertificate(ctx context.Context, certID int64) 
 		IssuedAt:             sql.NullTime{Time: issuedAt, Valid: true},
 		ExpiresAt:            sql.NullTime{Time: expiresAt, Valid: true},
 		NextRenewalAt:        sql.NullTime{Time: nextRenewalAt, Valid: true},
-		LastRenewalAttemptAt: sql.NullTime{Time: now, Valid: true},
+		LastRenewalAttemptAt: sql.NullTime{Time: attemptAt, Valid: true},
 	})
 	if err != nil {
-		m.markIssueFailed(ctx, cert, err)
+		m.markIssueFailed(ctx, cert, trigger, attemptAt, publicACMEStageWrap(publicACMEStageRecordSuccess, err))
 		return
 	}
+	duration := time.Since(attemptAt)
+	publicACMELogCertificate(log.Info(), updated, trigger, publicACMEStageRecordSuccess).
+		Time("attempt_at", attemptAt).
+		Dur("duration", duration).
+		Time("expires_at", expiresAt).
+		Time("next_renewal_at", nextRenewalAt).
+		Msg("ACME certificate renewal succeeded")
 	if err := m.app.refreshPublicProxySnapshot(ctx); err != nil {
-		log.Warn().Err(err).Int64("cert_id", cert.ID).Msg("Failed to refresh public proxy after ACME issue")
+		publicACMELogCertificate(log.Warn().Err(err), updated, trigger, publicACMEStageRefreshProxySnapshot).
+			Time("attempt_at", attemptAt).
+			Msg("Failed to refresh public proxy after ACME issue")
 	}
 	_, _ = m.app.restartTLSListenerIfActive(ctx, updated.ListenerID)
 }
@@ -319,19 +546,30 @@ func (m *publicACMEManager) issueConfig(ctx context.Context, cert db.PublicTlsCe
 	return cfg, nil
 }
 
-func (m *publicACMEManager) markIssueFailed(ctx context.Context, cert db.PublicTlsCertificate, issueErr error) {
+func (m *publicACMEManager) markIssueFailed(ctx context.Context, cert db.PublicTlsCertificate, trigger string, attemptAt time.Time, issueErr error) {
 	if issueErr == nil {
 		return
 	}
 	now := time.Now().UTC()
-	_, err := m.app.DB.UpdatePublicTlsCertificateStatus(ctx, db.UpdatePublicTlsCertificateStatusParams{
+	retryAt := now.Add(publicACMERetryAfterFailure)
+	_, err := m.app.DB.UpdatePublicTlsCertificateRenewalStatus(ctx, db.UpdatePublicTlsCertificateRenewalStatusParams{
 		ID:                   cert.ID,
 		Status:               publicTLSCertificateStatusError,
 		LastError:            issueErr.Error(),
-		LastRenewalAttemptAt: sql.NullTime{Time: now, Valid: true},
+		NextRenewalAt:        sql.NullTime{Time: retryAt, Valid: true},
+		LastRenewalAttemptAt: sql.NullTime{Time: attemptAt, Valid: true},
 	})
+	stage := publicACMEErrorStage(issueErr, publicACMEStageIssueCertificate)
+	publicACMELogCertificate(log.Warn().Err(issueErr), cert, trigger, stage).
+		Time("attempt_at", attemptAt).
+		Dur("duration", now.Sub(attemptAt)).
+		Time("retry_at", retryAt).
+		Msg("ACME certificate renewal failed")
 	if err != nil {
-		log.Warn().Err(err).Int64("cert_id", cert.ID).Msg("Failed to record ACME certificate issue error")
+		publicACMELogCertificate(log.Warn().Err(err), cert, trigger, publicACMEStageRecordFailure).
+			Time("attempt_at", attemptAt).
+			Time("retry_at", retryAt).
+			Msg("Failed to record ACME certificate issue error")
 	}
 }
 
@@ -347,85 +585,134 @@ type publicRealACMEIssuer struct {
 }
 
 func (i publicRealACMEIssuer) Issue(ctx context.Context, store publicACMEChallengeStore, cfg publicACMEIssueConfig) (publicACMEIssueResult, error) {
-	accountKey, err := loadOrCreateACMEAccountKey(i.cfg, cfg.CA, cfg.Email)
+	accountKey, accountKeyCreated, err := loadOrCreateACMEAccountKey(i.cfg, cfg.CA, cfg.Email)
 	if err != nil {
-		return publicACMEIssueResult{}, err
+		return publicACMEIssueResult{}, publicACMEStageWrap(publicACMEStageAccountKey, err)
 	}
+	accountKeyState := "loaded"
+	if accountKeyCreated {
+		accountKeyState = "created"
+	}
+	publicACMELogIssueConfig(log.Info(), cfg, publicACMEStageAccountKey).
+		Str("account_key_state", accountKeyState).
+		Msg("ACME account key ready")
 	client := &acme.Client{
 		Key:          accountKey,
 		DirectoryURL: acmeDirectoryURL(cfg.CA),
 	}
 	if _, err := client.GetReg(ctx, ""); err != nil {
+		publicACMELogIssueConfig(log.Info(), cfg, publicACMEStageAccountRegistration).
+			Msg("Registering ACME account")
 		if _, registerErr := client.Register(ctx, &acme.Account{Contact: []string{"mailto:" + cfg.Email}}, acme.AcceptTOS); registerErr != nil {
-			return publicACMEIssueResult{}, fmt.Errorf("register ACME account: %w", registerErr)
+			return publicACMEIssueResult{}, publicACMEStageWrap(publicACMEStageAccountRegistration, fmt.Errorf("register ACME account: %w", registerErr))
 		}
+		publicACMELogIssueConfig(log.Info(), cfg, publicACMEStageAccountRegistration).
+			Msg("ACME account registered")
+	} else {
+		publicACMELogIssueConfig(log.Info(), cfg, publicACMEStageAccountRegistration).
+			Msg("ACME account ready")
 	}
 
 	order, err := client.AuthorizeOrder(ctx, acme.DomainIDs(cfg.Domain))
 	if err != nil {
-		return publicACMEIssueResult{}, err
+		return publicACMEIssueResult{}, publicACMEStageWrap(publicACMEStageOrderCreate, err)
 	}
+	publicACMELogIssueConfig(log.Info(), cfg, publicACMEStageOrderCreate).
+		Int("authorization_count", len(order.AuthzURLs)).
+		Msg("ACME order created")
 	challengeType := acmeChallengeTypeForCA(cfg.ChallengeType)
 	for _, authzURL := range order.AuthzURLs {
 		authz, err := client.GetAuthorization(ctx, authzURL)
 		if err != nil {
-			return publicACMEIssueResult{}, err
+			return publicACMEIssueResult{}, publicACMEStageWrap(publicACMEStageAuthorizationLookup, err)
 		}
+		publicACMELogIssueConfig(log.Info(), cfg, publicACMEStageAuthorizationLookup).
+			Str("authorization_domain", authz.Identifier.Value).
+			Str("authorization_status", authz.Status).
+			Msg("ACME authorization loaded")
 		if authz.Status == acme.StatusValid {
 			continue
 		}
 		challenge := findACMEChallenge(authz, challengeType)
 		if challenge == nil {
-			return publicACMEIssueResult{}, fmt.Errorf("ACME authorization for %q does not offer %s", authz.Identifier.Value, challengeType)
+			return publicACMEIssueResult{}, publicACMEStageWrap(publicACMEStageChallengeSelection, fmt.Errorf("ACME authorization for %q does not offer %s", authz.Identifier.Value, challengeType))
 		}
+		publicACMELogIssueConfig(log.Info(), cfg, publicACMEStageChallengeSelection).
+			Str("authorization_domain", authz.Identifier.Value).
+			Str("acme_challenge_type", challengeType).
+			Msg("ACME challenge selected")
 		cleanup, err := provisionACMEChallenge(ctx, client, store, cfg, authz, challenge)
 		if err != nil {
-			return publicACMEIssueResult{}, err
+			return publicACMEIssueResult{}, publicACMEStageWrap(publicACMEStageChallengeProvision, err)
 		}
+		publicACMELogIssueConfig(log.Info(), cfg, publicACMEStageChallengeProvision).
+			Str("authorization_domain", authz.Identifier.Value).
+			Str("acme_challenge_type", challengeType).
+			Msg("ACME challenge provisioned")
 		if _, err := client.Accept(ctx, challenge); err != nil {
 			cleanup()
-			return publicACMEIssueResult{}, err
+			publicACMELogIssueConfig(log.Info(), cfg, publicACMEStageChallengeCleanup).
+				Str("authorization_domain", authz.Identifier.Value).
+				Msg("ACME challenge cleanup completed")
+			return publicACMEIssueResult{}, publicACMEStageWrap(publicACMEStageChallengeAccept, err)
 		}
+		publicACMELogIssueConfig(log.Info(), cfg, publicACMEStageChallengeAccept).
+			Str("authorization_domain", authz.Identifier.Value).
+			Msg("ACME challenge accepted")
 		_, waitErr := client.WaitAuthorization(ctx, authz.URI)
 		cleanup()
+		publicACMELogIssueConfig(log.Info(), cfg, publicACMEStageChallengeCleanup).
+			Str("authorization_domain", authz.Identifier.Value).
+			Msg("ACME challenge cleanup completed")
 		if waitErr != nil {
-			return publicACMEIssueResult{}, waitErr
+			return publicACMEIssueResult{}, publicACMEStageWrap(publicACMEStageAuthorizationWait, waitErr)
 		}
+		publicACMELogIssueConfig(log.Info(), cfg, publicACMEStageAuthorizationWait).
+			Str("authorization_domain", authz.Identifier.Value).
+			Msg("ACME authorization validated")
 	}
 	order, err = client.WaitOrder(ctx, order.URI)
 	if err != nil {
-		return publicACMEIssueResult{}, err
+		return publicACMEIssueResult{}, publicACMEStageWrap(publicACMEStageOrderWait, err)
 	}
+	publicACMELogIssueConfig(log.Info(), cfg, publicACMEStageOrderWait).
+		Str("order_status", order.Status).
+		Msg("ACME order ready")
 
 	certKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return publicACMEIssueResult{}, err
+		return publicACMEIssueResult{}, publicACMEStageWrap(publicACMEStageCSRCreate, err)
 	}
 	csr, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
 		Subject:  pkix.Name{CommonName: strings.TrimPrefix(cfg.Domain, "*.")},
 		DNSNames: []string{cfg.Domain},
 	}, certKey)
 	if err != nil {
-		return publicACMEIssueResult{}, err
+		return publicACMEIssueResult{}, publicACMEStageWrap(publicACMEStageCSRCreate, err)
 	}
+	publicACMELogIssueConfig(log.Info(), cfg, publicACMEStageCSRCreate).
+		Msg("ACME certificate signing request created")
 	derChain, _, err := client.CreateOrderCert(ctx, order.FinalizeURL, csr, true)
 	if err != nil {
-		return publicACMEIssueResult{}, err
+		return publicACMEIssueResult{}, publicACMEStageWrap(publicACMEStageFinalizeCertificate, err)
 	}
 	if len(derChain) == 0 {
-		return publicACMEIssueResult{}, errors.New("ACME CA returned no certificate")
+		return publicACMEIssueResult{}, publicACMEStageWrap(publicACMEStageFinalizeCertificate, errors.New("ACME CA returned no certificate"))
 	}
+	publicACMELogIssueConfig(log.Info(), cfg, publicACMEStageFinalizeCertificate).
+		Int("certificate_chain_length", len(derChain)).
+		Msg("ACME certificate finalized")
 	certPEM := make([]byte, 0)
 	for _, der := range derChain {
 		certPEM = append(certPEM, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})...)
 	}
 	keyDER, err := x509.MarshalPKCS8PrivateKey(certKey)
 	if err != nil {
-		return publicACMEIssueResult{}, err
+		return publicACMEIssueResult{}, publicACMEStageWrap(publicACMEStageMarshalKey, err)
 	}
 	leaf, err := x509.ParseCertificate(derChain[0])
 	if err != nil {
-		return publicACMEIssueResult{}, err
+		return publicACMEIssueResult{}, publicACMEStageWrap(publicACMEStageParseCertificate, err)
 	}
 	return publicACMEIssueResult{
 		CertPEM: certPEM,
@@ -492,30 +779,31 @@ func acmeDirectoryURL(ca string) string {
 	return publicACMEProductionDirectory
 }
 
-func loadOrCreateACMEAccountKey(cfg *config.Config, ca string, email string) (*ecdsa.PrivateKey, error) {
+func loadOrCreateACMEAccountKey(cfg *config.Config, ca string, email string) (*ecdsa.PrivateKey, bool, error) {
 	path := acmeAccountKeyPath(cfg, ca, email)
 	pemBytes, err := os.ReadFile(path)
 	if err == nil {
-		return parseACMEAccountKey(pemBytes)
+		key, err := parseACMEAccountKey(pemBytes)
+		return key, false, err
 	}
 	if !errors.Is(err, os.ErrNotExist) {
-		return nil, err
+		return nil, false, err
 	}
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	keyDER, err := x509.MarshalECPrivateKey(key)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0600); err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return key, nil
+	return key, true, nil
 }
 
 func parseACMEAccountKey(pemBytes []byte) (*ecdsa.PrivateKey, error) {

--- a/internal/server/public_acme_test.go
+++ b/internal/server/public_acme_test.go
@@ -1,15 +1,22 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
+	"database/sql"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 
 	p2pstreamv1 "p2pstream/gen/proto/p2pstream/v1"
 	"p2pstream/internal/config"
@@ -36,9 +43,13 @@ func (i fakeACMEIssuer) Issue(context.Context, publicACMEChallengeStore, publicA
 func TestPublicACMEManagerIssuesCertificateWithFakeIssuer(t *testing.T) {
 	database := newServerTestDB(t)
 	listener := seedServerHTTPSListener(t, database)
-	certPEM, keyPEM, err := generateSelfSignedCertificatePEM(24 * time.Hour)
+	certPEM, keyPEM, err := generateSelfSignedCertificatePEM(90 * 24 * time.Hour)
 	if err != nil {
 		t.Fatalf("generate cert: %v", err)
+	}
+	leaf, err := parseLeafCertificate(certPEM)
+	if err != nil {
+		t.Fatalf("parse generated cert: %v", err)
 	}
 
 	configDir := t.TempDir()
@@ -58,7 +69,9 @@ func TestPublicACMEManagerIssuesCertificateWithFakeIssuer(t *testing.T) {
 		t.Fatalf("create ACME cert: %v", err)
 	}
 
-	app.PublicACME.issueCertificate(context.Background(), cert.ID)
+	logs := captureACMELogs(t, func() {
+		app.PublicACME.issueCertificate(context.Background(), cert.ID, publicACMETriggerManual)
+	})
 
 	updated, err := database.GetPublicTlsCertificate(context.Background(), cert.ID)
 	if err != nil {
@@ -67,8 +80,22 @@ func TestPublicACMEManagerIssuesCertificateWithFakeIssuer(t *testing.T) {
 	if updated.Status != publicTLSCertificateStatusReady || updated.CertPath == "" || updated.KeyPath == "" || !updated.ExpiresAt.Valid {
 		t.Fatalf("unexpected issued cert row: %+v", updated)
 	}
+	if !updated.NextRenewalAt.Valid || !updated.NextRenewalAt.Time.Equal(leaf.NotAfter.UTC().Add(-publicACMERenewBefore)) {
+		t.Fatalf("next renewal = %+v, want %s", updated.NextRenewalAt, leaf.NotAfter.UTC().Add(-publicACMERenewBefore))
+	}
 	assertServerFileBytes(t, updated.CertPath, certPEM)
 	assertServerFileBytes(t, updated.KeyPath, keyPEM)
+
+	entry := findACMELogEntry(t, logs, "ACME certificate renewal succeeded")
+	if entry["component"] != publicACMELogComponent ||
+		entry["stage"] != publicACMEStageRecordSuccess ||
+		entry["trigger"] != publicACMETriggerManual ||
+		entry["hostname"] != "acme.example.com" {
+		t.Fatalf("unexpected success log entry: %+v", entry)
+	}
+	if _, ok := entry["next_renewal_at"]; !ok {
+		t.Fatalf("success log missing next_renewal_at: %+v", entry)
+	}
 }
 
 func TestPublicACMEManagerFailureKeepsExistingCertificateFiles(t *testing.T) {
@@ -93,7 +120,9 @@ func TestPublicACMEManagerFailureKeepsExistingCertificateFiles(t *testing.T) {
 		t.Fatalf("create ACME cert: %v", err)
 	}
 
-	app.PublicACME.issueCertificate(context.Background(), cert.ID)
+	logs := captureACMELogs(t, func() {
+		app.PublicACME.issueCertificate(context.Background(), cert.ID, publicACMETriggerScheduledScan)
+	})
 
 	updated, err := database.GetPublicTlsCertificate(context.Background(), cert.ID)
 	if err != nil {
@@ -101,6 +130,47 @@ func TestPublicACMEManagerFailureKeepsExistingCertificateFiles(t *testing.T) {
 	}
 	if updated.Status != publicTLSCertificateStatusError || updated.CertPath != cert.CertPath || updated.KeyPath != cert.KeyPath || updated.LastError == "" {
 		t.Fatalf("unexpected failed cert row: %+v", updated)
+	}
+	if !strings.Contains(updated.LastError, publicACMEStageIssueCertificate+": issuer failed") {
+		t.Fatalf("last error = %q, want staged issuer failure", updated.LastError)
+	}
+	if !updated.NextRenewalAt.Valid || !updated.LastRenewalAttemptAt.Valid || !updated.NextRenewalAt.Time.After(updated.LastRenewalAttemptAt.Time) {
+		t.Fatalf("expected retry schedule after failed attempt: %+v", updated)
+	}
+
+	entry := findACMELogEntry(t, logs, "ACME certificate renewal failed")
+	if entry["component"] != publicACMELogComponent ||
+		entry["stage"] != publicACMEStageIssueCertificate ||
+		entry["trigger"] != publicACMETriggerScheduledScan ||
+		entry["hostname"] != "acme.example.com" {
+		t.Fatalf("unexpected failure log entry: %+v", entry)
+	}
+	if _, ok := entry["retry_at"]; !ok {
+		t.Fatalf("failure log missing retry_at: %+v", entry)
+	}
+}
+
+func TestPublicACMECertificateScheduleDecisionUsesRetryTime(t *testing.T) {
+	now := time.Date(2026, 6, 20, 10, 0, 0, 0, time.UTC)
+	cert := db.PublicTlsCertificate{
+		ID:              1,
+		ListenerID:      2,
+		HostnamePattern: "acme.example.com",
+		Enabled:         1,
+		Source:          publicTLSCertificateSourceACME,
+		Status:          publicTLSCertificateStatusError,
+		NextRenewalAt:   sqlNullTime(now.Add(30 * time.Minute)),
+	}
+
+	decision := publicACMECertificateScheduleDecision(cert, now)
+	if decision.Due || decision.Reason != "waiting_for_retry" || !decision.NextAttemptAt.Valid || !decision.NextAttemptAt.Time.Equal(now.Add(30*time.Minute)) {
+		t.Fatalf("decision before retry = %+v", decision)
+	}
+
+	cert.NextRenewalAt = sqlNullTime(now.Add(-time.Minute))
+	decision = publicACMECertificateScheduleDecision(cert, now)
+	if !decision.Due || decision.Reason != "retry_due" {
+		t.Fatalf("decision after retry = %+v", decision)
 	}
 }
 
@@ -397,4 +467,48 @@ func assertServerFileBytes(t *testing.T, path string, want []byte) {
 	if string(got) != string(want) {
 		t.Fatalf("file %s contents mismatch", path)
 	}
+}
+
+func sqlNullTime(value time.Time) sql.NullTime {
+	return sql.NullTime{Time: value, Valid: true}
+}
+
+func captureACMELogs(t *testing.T, fn func()) []map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	previousLogger := log.Logger
+	previousLevel := zerolog.GlobalLevel()
+	log.Logger = zerolog.New(&buf)
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	t.Cleanup(func() {
+		log.Logger = previousLogger
+		zerolog.SetGlobalLevel(previousLevel)
+	})
+
+	fn()
+
+	rawLines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	entries := make([]map[string]any, 0, len(rawLines))
+	for _, line := range rawLines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("parse log line %q: %v", line, err)
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func findACMELogEntry(t *testing.T, entries []map[string]any, message string) map[string]any {
+	t.Helper()
+	for _, entry := range entries {
+		if entry["message"] == message {
+			return entry
+		}
+	}
+	t.Fatalf("missing log entry %q in %+v", message, entries)
+	return nil
 }

--- a/internal/server/public_config.go
+++ b/internal/server/public_config.go
@@ -790,7 +790,7 @@ func (a *App) CreatePublicTlsCertificate(
 		return nil, err
 	}
 	_, _ = a.restartTLSListenerIfActive(ctx, cert.ListenerID)
-	a.queuePublicACMECertificateIssue(cert)
+	a.queuePublicACMECertificateIssue(cert, publicACMETriggerConfigChange)
 	return connect.NewResponse(&p2pstreamv1.CreatePublicTlsCertificateResponse{TlsCertificate: publicTLSCertificateToProto(cert)}), nil
 }
 
@@ -853,7 +853,7 @@ func (a *App) UpdatePublicTlsCertificate(
 		_, _ = a.restartTLSListenerIfActive(ctx, existing.ListenerID)
 	}
 	_, _ = a.restartTLSListenerIfActive(ctx, cert.ListenerID)
-	a.queuePublicACMECertificateIssue(cert)
+	a.queuePublicACMECertificateIssue(cert, publicACMETriggerConfigChange)
 	return connect.NewResponse(&p2pstreamv1.UpdatePublicTlsCertificateResponse{TlsCertificate: publicTLSCertificateToProto(cert)}), nil
 }
 
@@ -892,16 +892,17 @@ func (a *App) RenewPublicTlsCertificate(
 	if normalizePublicTLSCertificateSource(cert.Source) != publicTLSCertificateSourceACME {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("only ACME certificates can be renewed"))
 	}
-	cert, err = a.DB.UpdatePublicTlsCertificateStatus(ctx, db.UpdatePublicTlsCertificateStatusParams{
+	cert, err = a.DB.UpdatePublicTlsCertificateRenewalStatus(ctx, db.UpdatePublicTlsCertificateRenewalStatusParams{
 		ID:                   cert.ID,
 		Status:               publicTLSCertificateStatusRenewing,
 		LastError:            "",
+		NextRenewalAt:        sql.NullTime{},
 		LastRenewalAttemptAt: sql.NullTime{Time: time.Now().UTC(), Valid: true},
 	})
 	if err != nil {
 		return nil, publicDBError(err)
 	}
-	a.queuePublicACMECertificateIssue(cert)
+	a.queuePublicACMECertificateIssue(cert, publicACMETriggerManual)
 	return connect.NewResponse(&p2pstreamv1.RenewPublicTlsCertificateResponse{TlsCertificate: publicTLSCertificateToProto(cert)}), nil
 }
 
@@ -2285,11 +2286,11 @@ func validateACMEHostPattern(pattern string, challengeType string) error {
 	return nil
 }
 
-func (a *App) queuePublicACMECertificateIssue(cert db.PublicTlsCertificate) {
+func (a *App) queuePublicACMECertificateIssue(cert db.PublicTlsCertificate, trigger string) {
 	if normalizePublicTLSCertificateSource(cert.Source) != publicTLSCertificateSourceACME || cert.Enabled == 0 || a.PublicACME == nil {
 		return
 	}
-	a.PublicACME.QueueIssue(cert.ID)
+	a.PublicACME.QueueCertificate(cert, trigger)
 }
 
 func normalizePublicName(name string) (string, error) {

--- a/sql/query.sql
+++ b/sql/query.sql
@@ -1694,6 +1694,16 @@ SET status = ?,
 WHERE id = ?
 RETURNING id, listener_id, hostname_pattern, cert_path, key_path, enabled, source, acme_challenge_type, acme_ca, acme_email, dns_credential_id, status, last_error, issued_at, expires_at, next_renewal_at, last_renewal_attempt_at, created_at, updated_at;
 
+-- name: UpdatePublicTlsCertificateRenewalStatus :one
+UPDATE public_tls_certificates
+SET status = ?,
+    last_error = ?,
+    next_renewal_at = ?,
+    last_renewal_attempt_at = ?,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = ?
+RETURNING id, listener_id, hostname_pattern, cert_path, key_path, enabled, source, acme_challenge_type, acme_ca, acme_email, dns_credential_id, status, last_error, issued_at, expires_at, next_renewal_at, last_renewal_attempt_at, created_at, updated_at;
+
 -- name: DeletePublicTlsCertificate :exec
 DELETE FROM public_tls_certificates
 WHERE id = ?;

--- a/web/management/src/lib/publicProxyLabels.test.ts
+++ b/web/management/src/lib/publicProxyLabels.test.ts
@@ -20,6 +20,7 @@ import {
   healthTraceSourceLabel,
   healthTraceTargetLabel,
   healthTraceTransitionSummary,
+  tlsCertificateLastAttemptSummary,
   tlsCertificateRenewalSummary,
   tlsCertificateValiditySummary,
 } from "@/lib/publicProxyLabels";
@@ -44,14 +45,44 @@ describe("publicProxyLabels", () => {
     expect(tlsCertificateValiditySummary(cert)).toBe(`Valid until ${formatUnixMillis(cert.expiresAtUnixMillis)}`);
   });
 
-  test("formats ACME renewal separately from validity", () => {
+  test("formats ready ACME next renewal separately from validity", () => {
     const cert = tlsCertificate({
       source: PublicTlsCertificateSource.ACME,
       nextRenewalAtUnixMillis: BigInt(Date.UTC(2026, 11, 1)),
     });
 
-    expect(tlsCertificateRenewalSummary(cert)).toBe(`Renews ${formatUnixMillis(cert.nextRenewalAtUnixMillis)}`);
+    expect(tlsCertificateRenewalSummary(cert)).toBe(`Next renewal ${formatUnixMillis(cert.nextRenewalAtUnixMillis)}`);
     expect(tlsCertificateRenewalSummary(tlsCertificate())).toBe("");
+  });
+
+  test("formats in-progress ACME renewal state", () => {
+    const cert = tlsCertificate({
+      source: PublicTlsCertificateSource.ACME,
+      status: PublicTlsCertificateStatus.RENEWING,
+      lastRenewalAttemptAtUnixMillis: BigInt(Date.UTC(2026, 5, 20, 8, 30)),
+    });
+
+    expect(tlsCertificateRenewalSummary(cert)).toBe(`Renewal started ${formatUnixMillis(cert.lastRenewalAttemptAtUnixMillis)}`);
+  });
+
+  test("formats errored ACME retry schedule", () => {
+    const cert = tlsCertificate({
+      source: PublicTlsCertificateSource.ACME,
+      status: PublicTlsCertificateStatus.ERROR,
+      nextRenewalAtUnixMillis: BigInt(Date.UTC(2026, 5, 20, 9, 30)),
+    });
+
+    expect(tlsCertificateRenewalSummary(cert)).toBe(`Retry scheduled ${formatUnixMillis(cert.nextRenewalAtUnixMillis)}`);
+  });
+
+  test("formats ACME last attempt separately", () => {
+    const cert = tlsCertificate({
+      source: PublicTlsCertificateSource.ACME,
+      lastRenewalAttemptAtUnixMillis: BigInt(Date.UTC(2026, 5, 20, 8, 30)),
+    });
+
+    expect(tlsCertificateLastAttemptSummary(cert)).toBe(`Last attempt ${formatUnixMillis(cert.lastRenewalAttemptAtUnixMillis)}`);
+    expect(tlsCertificateLastAttemptSummary(tlsCertificate())).toBe("");
   });
 
   test("formats health trace labels and summaries", () => {

--- a/web/management/src/lib/publicProxyLabels.ts
+++ b/web/management/src/lib/publicProxyLabels.ts
@@ -532,8 +532,24 @@ export function tlsCertificateValiditySummary(cert: PublicTlsCertificate): strin
 
 export function tlsCertificateRenewalSummary(cert: PublicTlsCertificate): string {
   if (cert.source !== PublicTlsCertificateSource.ACME) return "";
+  if (cert.status === PublicTlsCertificateStatus.RENEWING) {
+    const attempt = formatUnixMillis(cert.lastRenewalAttemptAtUnixMillis);
+    return attempt ? `Renewal started ${attempt}` : "Renewal in progress";
+  }
+  if (cert.status === PublicTlsCertificateStatus.ERROR) {
+    const retry = formatUnixMillis(cert.nextRenewalAtUnixMillis);
+    return retry ? `Retry scheduled ${retry}` : "Retry not scheduled yet";
+  }
   const renewal = formatUnixMillis(cert.nextRenewalAtUnixMillis);
-  return renewal ? `Renews ${renewal}` : "";
+  if (renewal) return `Next renewal ${renewal}`;
+  if (cert.status === PublicTlsCertificateStatus.PENDING) return "Initial issuance pending";
+  return "Next renewal not scheduled yet";
+}
+
+export function tlsCertificateLastAttemptSummary(cert: PublicTlsCertificate): string {
+  if (cert.source !== PublicTlsCertificateSource.ACME) return "";
+  const attempt = formatUnixMillis(cert.lastRenewalAttemptAtUnixMillis);
+  return attempt ? `Last attempt ${attempt}` : "";
 }
 
 export function tlsMethodForCertificate(cert: PublicTlsCertificate): TlsMethod {

--- a/web/management/src/views/TlsConfig.vue
+++ b/web/management/src/views/TlsConfig.vue
@@ -17,6 +17,7 @@ import {
   dnsCredentialName,
   isDefaultSelfSignedCertificate,
   listenerName,
+  tlsCertificateLastAttemptSummary,
   tlsCertificateSummary,
   tlsCertificateRenewalSummary,
   tlsCertificateValiditySummary,
@@ -411,10 +412,11 @@ watch(tlsDnsCredentials, () => {
             <p class="truncate text-xs text-[var(--app-text-muted)]">{{ tlsCertificateSummary(cert) }}</p>
             <p v-if="tlsCertificateValiditySummary(cert)" class="truncate text-xs text-[var(--app-text-muted)]">{{ tlsCertificateValiditySummary(cert) }}</p>
             <p v-if="tlsCertificateRenewalSummary(cert)" class="truncate text-xs text-[var(--app-text-muted)]">{{ tlsCertificateRenewalSummary(cert) }}</p>
+            <p v-if="tlsCertificateLastAttemptSummary(cert)" class="truncate text-xs text-[var(--app-text-muted)]">{{ tlsCertificateLastAttemptSummary(cert) }}</p>
             <p v-if="cert.source === PublicTlsCertificateSource.ACME && cert.dnsCredentialId" class="truncate text-xs text-[var(--app-text-muted)]">
               Cloudflare / {{ dnsCredentialName(cert.dnsCredentialId, tlsDnsCredentials) }}
             </p>
-            <p v-if="cert.lastError" class="truncate text-xs text-red-400">{{ cert.lastError }}</p>
+            <p v-if="cert.lastError" class="whitespace-pre-wrap break-words text-xs text-red-400">Last error: {{ cert.lastError }}</p>
           </div>
           <div class="flex gap-2">
             <DisabledHint


### PR DESCRIPTION
## Summary
- add structured ACME issuance and renewal logs with stage, trigger, attempt, retry, and next-renewal fields
- store failed renewal retry time in next_renewal_at and clear it while renewals are running
- improve TLS UI renewal/last-attempt/error labels and document operational log fields

## Tests
- make generate
- go test ./...
- go vet ./...
- cd web/management && bun test src/lib/*.test.ts
- cd web/management && bun run typecheck
- cd web/management && bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced troubleshooting guide with detailed ACME certificate diagnostics.
  * Expanded reference documentation covering ACME renewal timing, retry behavior, and logging.

* **New Features**
  * Improved TLS certificate renewal status display with granular messages (renewing, retry scheduled, next renewal).
  * Added last renewal attempt timestamp to certificate management interface.
  * Enhanced error message formatting for better readability.

* **Refactor**
  * Updated ACME renewal scheduling system with explicit trigger tracking and automatic retry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->