### PR TITLE
security: bind WAF cookies to request scope

### DIFF
--- a/internal/server/public_waf.go
+++ b/internal/server/public_waf.go
@@ -53,7 +53,7 @@ const (
 	defaultWafTriggerMinimumRequestRate  = int64(50)
 	defaultWafTriggerSpikeMultiplier     = 4.0
 	defaultWafTriggerProxyActiveRequests = int64(100)
-	defaultWafTriggerRouteTargetActive       = int64(100)
+	defaultWafTriggerRouteTargetActive   = int64(100)
 	defaultWafTriggerAgentActive         = int64(50)
 	defaultWafTriggerServerCPU           = 85.0
 	defaultWafTriggerAgentCPU            = 85.0
@@ -84,16 +84,16 @@ type publicWafCaptchaProviderConfig struct {
 }
 
 type publicWafTriggerConfig struct {
-	RequestWindowMillis    int64
-	MinimumRequestRate     int64
-	TrafficSpikeMultiplier float64
-	ProxyActiveRequests    int64
-	RouteTargetActiveRequests  int64
-	AgentActiveRequests    int64
-	ServerCPUPercent       float64
-	AgentCPUPercent        float64
-	MinimumActiveMillis    int64
-	QuietPeriodMillis      int64
+	RequestWindowMillis       int64
+	MinimumRequestRate        int64
+	TrafficSpikeMultiplier    float64
+	ProxyActiveRequests       int64
+	RouteTargetActiveRequests int64
+	AgentActiveRequests       int64
+	ServerCPUPercent          float64
+	AgentCPUPercent           float64
+	MinimumActiveMillis       int64
+	QuietPeriodMillis         int64
 }
 
 type publicWafWaitingRoomConfig struct {
@@ -155,7 +155,7 @@ type publicWafRuleMutationInput struct {
 	TriggerMinimumRequestRate            int64
 	TriggerTrafficSpikeMultiplier        float64
 	TriggerProxyActiveRequests           int64
-	TriggerRouteTargetActiveRequests         int64
+	TriggerRouteTargetActiveRequests     int64
 	TriggerAgentActiveRequests           int64
 	TriggerServerCpuPercent              float64
 	TriggerAgentCpuPercent               float64
@@ -324,7 +324,7 @@ func (w *publicWAF) evaluate(snap *publicProxySnapshot, listener publicListenerC
 		}
 		switch rule.Action {
 		case publicWafActionCaptcha:
-			if w.validRuleCookieLocked(r, rule.ID, publicWafCaptchaCookieKind, now) {
+			if w.validRuleCookieLocked(r, rule, listener, publicWafCaptchaCookieKind, now) {
 				return publicWafDecision{}, true
 			}
 			provider, ok := snap.WafCaptchaProviders[rule.CaptchaProviderID]
@@ -616,16 +616,16 @@ func publicWafRuleRowToConfig(row db.PublicWafRule) (publicWafRuleConfig, error)
 			PageBody:                  row.WaitingRoomPageBody,
 		},
 		Triggers: publicWafTriggerConfig{
-			RequestWindowMillis:    row.TriggerRequestWindowMillis,
-			MinimumRequestRate:     row.TriggerMinimumRequestRate,
-			TrafficSpikeMultiplier: row.TriggerTrafficSpikeMultiplier,
-			ProxyActiveRequests:    row.TriggerProxyActiveRequests,
-			RouteTargetActiveRequests:  row.TriggerRouteTargetActiveRequests,
-			AgentActiveRequests:    row.TriggerAgentActiveRequests,
-			ServerCPUPercent:       row.TriggerServerCpuPercent,
-			AgentCPUPercent:        row.TriggerAgentCpuPercent,
-			MinimumActiveMillis:    row.TriggerMinimumActiveMillis,
-			QuietPeriodMillis:      row.TriggerQuietPeriodMillis,
+			RequestWindowMillis:       row.TriggerRequestWindowMillis,
+			MinimumRequestRate:        row.TriggerMinimumRequestRate,
+			TrafficSpikeMultiplier:    row.TriggerTrafficSpikeMultiplier,
+			ProxyActiveRequests:       row.TriggerProxyActiveRequests,
+			RouteTargetActiveRequests: row.TriggerRouteTargetActiveRequests,
+			AgentActiveRequests:       row.TriggerAgentActiveRequests,
+			ServerCPUPercent:          row.TriggerServerCpuPercent,
+			AgentCPUPercent:           row.TriggerAgentCpuPercent,
+			MinimumActiveMillis:       row.TriggerMinimumActiveMillis,
+			QuietPeriodMillis:         row.TriggerQuietPeriodMillis,
 		},
 		BlockResponseStatusCode:   int(row.BlockResponseStatusCode),
 		BlockResponseBody:         row.BlockResponseBody,
@@ -825,16 +825,16 @@ func publicWafWaitingRoomToProto(cfg publicWafWaitingRoomConfig) *p2pstreamv1.Pu
 
 func publicWafTriggersToProto(cfg publicWafTriggerConfig) *p2pstreamv1.PublicWafTriggerConfig {
 	return &p2pstreamv1.PublicWafTriggerConfig{
-		RequestWindowMillis:    cfg.RequestWindowMillis,
-		MinimumRequestRate:     cfg.MinimumRequestRate,
-		TrafficSpikeMultiplier: cfg.TrafficSpikeMultiplier,
-		ProxyActiveRequests:    cfg.ProxyActiveRequests,
-		RouteTargetActiveRequests:  cfg.RouteTargetActiveRequests,
-		AgentActiveRequests:    cfg.AgentActiveRequests,
-		ServerCpuPercent:       cfg.ServerCPUPercent,
-		AgentCpuPercent:        cfg.AgentCPUPercent,
-		MinimumActiveMillis:    cfg.MinimumActiveMillis,
-		QuietPeriodMillis:      cfg.QuietPeriodMillis,
+		RequestWindowMillis:       cfg.RequestWindowMillis,
+		MinimumRequestRate:        cfg.MinimumRequestRate,
+		TrafficSpikeMultiplier:    cfg.TrafficSpikeMultiplier,
+		ProxyActiveRequests:       cfg.ProxyActiveRequests,
+		RouteTargetActiveRequests: cfg.RouteTargetActiveRequests,
+		AgentActiveRequests:       cfg.AgentActiveRequests,
+		ServerCpuPercent:          cfg.ServerCPUPercent,
+		AgentCpuPercent:           cfg.AgentCPUPercent,
+		MinimumActiveMillis:       cfg.MinimumActiveMillis,
+		QuietPeriodMillis:         cfg.QuietPeriodMillis,
 	}
 }
 
@@ -1019,7 +1019,7 @@ func (a *App) validatePublicWafRuleInput(
 		TriggerMinimumRequestRate:            triggerConfig.MinimumRequestRate,
 		TriggerTrafficSpikeMultiplier:        triggerConfig.TrafficSpikeMultiplier,
 		TriggerProxyActiveRequests:           triggerConfig.ProxyActiveRequests,
-		TriggerRouteTargetActiveRequests:         triggerConfig.RouteTargetActiveRequests,
+		TriggerRouteTargetActiveRequests:     triggerConfig.RouteTargetActiveRequests,
 		TriggerAgentActiveRequests:           triggerConfig.AgentActiveRequests,
 		TriggerServerCpuPercent:              triggerConfig.ServerCPUPercent,
 		TriggerAgentCpuPercent:               triggerConfig.AgentCPUPercent,
@@ -1089,16 +1089,16 @@ func validatePublicWafWaitingRoom(cfg *p2pstreamv1.PublicWafWaitingRoomConfig) (
 
 func validatePublicWafTriggers(cfg *p2pstreamv1.PublicWafTriggerConfig) (publicWafTriggerConfig, error) {
 	resp := publicWafTriggerConfig{
-		RequestWindowMillis:    int64(defaultWafTriggerRequestWindow / time.Millisecond),
-		MinimumRequestRate:     defaultWafTriggerMinimumRequestRate,
-		TrafficSpikeMultiplier: defaultWafTriggerSpikeMultiplier,
-		ProxyActiveRequests:    defaultWafTriggerProxyActiveRequests,
-		RouteTargetActiveRequests:  defaultWafTriggerRouteTargetActive,
-		AgentActiveRequests:    defaultWafTriggerAgentActive,
-		ServerCPUPercent:       defaultWafTriggerServerCPU,
-		AgentCPUPercent:        defaultWafTriggerAgentCPU,
-		MinimumActiveMillis:    int64(defaultWafTriggerMinimumActive / time.Millisecond),
-		QuietPeriodMillis:      int64(defaultWafTriggerQuietPeriod / time.Millisecond),
+		RequestWindowMillis:       int64(defaultWafTriggerRequestWindow / time.Millisecond),
+		MinimumRequestRate:        defaultWafTriggerMinimumRequestRate,
+		TrafficSpikeMultiplier:    defaultWafTriggerSpikeMultiplier,
+		ProxyActiveRequests:       defaultWafTriggerProxyActiveRequests,
+		RouteTargetActiveRequests: defaultWafTriggerRouteTargetActive,
+		AgentActiveRequests:       defaultWafTriggerAgentActive,
+		ServerCPUPercent:          defaultWafTriggerServerCPU,
+		AgentCPUPercent:           defaultWafTriggerAgentCPU,
+		MinimumActiveMillis:       int64(defaultWafTriggerMinimumActive / time.Millisecond),
+		QuietPeriodMillis:         int64(defaultWafTriggerQuietPeriod / time.Millisecond),
 	}
 	if cfg != nil {
 		resp.RequestWindowMillis = valueOrDefault(cfg.RequestWindowMillis, resp.RequestWindowMillis)
@@ -1429,7 +1429,7 @@ func wafCreateParams(input publicWafRuleMutationInput) db.CreatePublicWafRulePar
 		TriggerMinimumRequestRate:            input.TriggerMinimumRequestRate,
 		TriggerTrafficSpikeMultiplier:        input.TriggerTrafficSpikeMultiplier,
 		TriggerProxyActiveRequests:           input.TriggerProxyActiveRequests,
-		TriggerRouteTargetActiveRequests:         input.TriggerRouteTargetActiveRequests,
+		TriggerRouteTargetActiveRequests:     input.TriggerRouteTargetActiveRequests,
 		TriggerAgentActiveRequests:           input.TriggerAgentActiveRequests,
 		TriggerServerCpuPercent:              input.TriggerServerCpuPercent,
 		TriggerAgentCpuPercent:               input.TriggerAgentCpuPercent,
@@ -1469,7 +1469,7 @@ func wafUpdateParams(id int64, input publicWafRuleMutationInput) db.UpdatePublic
 		TriggerMinimumRequestRate:            input.TriggerMinimumRequestRate,
 		TriggerTrafficSpikeMultiplier:        input.TriggerTrafficSpikeMultiplier,
 		TriggerProxyActiveRequests:           input.TriggerProxyActiveRequests,
-		TriggerRouteTargetActiveRequests:         input.TriggerRouteTargetActiveRequests,
+		TriggerRouteTargetActiveRequests:     input.TriggerRouteTargetActiveRequests,
 		TriggerAgentActiveRequests:           input.TriggerAgentActiveRequests,
 		TriggerServerCpuPercent:              input.TriggerServerCpuPercent,
 		TriggerAgentCpuPercent:               input.TriggerAgentCpuPercent,

--- a/internal/server/public_waf_captcha.go
+++ b/internal/server/public_waf_captcha.go
@@ -21,10 +21,12 @@ import (
 
 type publicWafCookiePayload struct {
 	RuleID          int64  `json:"rule_id"`
+	ListenerID      int64  `json:"listener_id"`
+	RuleFingerprint string `json:"rule_fingerprint"`
+	Host            string `json:"host"`
 	Kind            string `json:"kind"`
 	SessionID       string `json:"session_id,omitempty"`
 	ExpiresUnixMs   int64  `json:"expires_unix_ms"`
-	OriginalPathKey string `json:"original_path_key,omitempty"`
 }
 
 type publicWafCaptchaChallengePayload struct {
@@ -161,7 +163,7 @@ func (a *App) servePublicWAFCaptchaVerify(w http.ResponseWriter, r *http.Request
 		writeCaptchaChallenge(w, r, decision)
 		return decision
 	}
-	cookie := a.PublicWAF.signedRuleCookie(rule.ID, publicWafCaptchaCookieKind, "", rule.CaptchaPassTTL, now, decision.Listener, r)
+	cookie := a.PublicWAF.signedRuleCookie(rule, decision.Listener, r, publicWafCaptchaCookieKind, "", rule.CaptchaPassTTL, now)
 	http.SetCookie(w, cookie)
 	redirectTo := sanitizeWAFReturnTo(returnTo)
 	redirectTo = strings.ReplaceAll(redirectTo, `\`, "/")
@@ -482,14 +484,25 @@ func captchaRetryAfterSeconds(d time.Duration) string {
 	return strconv.FormatInt(int64((d+time.Second-time.Nanosecond)/time.Second), 10)
 }
 
-func (w *publicWAF) validRuleCookieLocked(r *http.Request, ruleID int64, kind string, now time.Time) bool {
-	name := wafCookieName(ruleID, kind)
+func (w *publicWAF) validRuleCookieLocked(r *http.Request, rule publicWafRuleConfig, listener publicListenerConfig, kind string, now time.Time) bool {
+	name := wafCookieName(rule.ID, kind)
 	cookie, err := r.Cookie(name)
 	if err != nil {
 		return false
 	}
 	payload, ok := w.verifyCookieValueLocked(cookie.Value, now)
-	return ok && payload.RuleID == ruleID && payload.Kind == kind
+	return ok && publicWafCookieMatchesRequest(payload, r, rule, listener, kind)
+}
+
+func publicWafCookieMatchesRequest(payload publicWafCookiePayload, r *http.Request, rule publicWafRuleConfig, listener publicListenerConfig, kind string) bool {
+	return rule.ID > 0 &&
+		listener.ID > 0 &&
+		rule.Fingerprint != "" &&
+		payload.RuleID == rule.ID &&
+		payload.ListenerID == listener.ID &&
+		payload.RuleFingerprint == rule.Fingerprint &&
+		payload.Host == publicWafChallengeRequestHost(r) &&
+		payload.Kind == kind
 }
 
 func publicWafCookieSecure(listener publicListenerConfig, r *http.Request) bool {
@@ -499,18 +512,21 @@ func publicWafCookieSecure(listener publicListenerConfig, r *http.Request) bool 
 	return r != nil && r.TLS != nil
 }
 
-func (w *publicWAF) signedRuleCookie(ruleID int64, kind string, sessionID string, ttl time.Duration, now time.Time, listener publicListenerConfig, r *http.Request) *http.Cookie {
+func (w *publicWAF) signedRuleCookie(rule publicWafRuleConfig, listener publicListenerConfig, r *http.Request, kind string, sessionID string, ttl time.Duration, now time.Time) *http.Cookie {
 	if ttl <= 0 {
 		ttl = defaultWafCaptchaPassTTL
 	}
 	payload := publicWafCookiePayload{
-		RuleID:        ruleID,
-		Kind:          kind,
-		SessionID:     sessionID,
-		ExpiresUnixMs: now.Add(ttl).UnixMilli(),
+		RuleID:          rule.ID,
+		ListenerID:      listener.ID,
+		RuleFingerprint: rule.Fingerprint,
+		Host:            publicWafChallengeRequestHost(r),
+		Kind:            kind,
+		SessionID:       sessionID,
+		ExpiresUnixMs:   now.Add(ttl).UnixMilli(),
 	}
 	return &http.Cookie{
-		Name:     wafCookieName(ruleID, kind),
+		Name:     wafCookieName(rule.ID, kind),
 		Value:    w.signCookieValue(payload),
 		Path:     "/",
 		Expires:  now.Add(ttl),
@@ -561,13 +577,13 @@ func (w *publicWAF) verifyCookieValueLocked(value string, now time.Time) (public
 	return payload, true
 }
 
-func (w *publicWAF) queueCookiePayloadLocked(r *http.Request, ruleID int64, now time.Time) (publicWafCookiePayload, bool) {
-	cookie, err := r.Cookie(wafCookieName(ruleID, publicWafQueueCookieKind))
+func (w *publicWAF) queueCookiePayloadLocked(r *http.Request, rule publicWafRuleConfig, listener publicListenerConfig, now time.Time) (publicWafCookiePayload, bool) {
+	cookie, err := r.Cookie(wafCookieName(rule.ID, publicWafQueueCookieKind))
 	if err != nil {
 		return publicWafCookiePayload{}, false
 	}
 	payload, ok := w.verifyCookieValueLocked(cookie.Value, now)
-	if !ok || payload.RuleID != ruleID || payload.Kind != publicWafQueueCookieKind || payload.SessionID == "" {
+	if !ok || !publicWafCookieMatchesRequest(payload, r, rule, listener, publicWafQueueCookieKind) || payload.SessionID == "" {
 		return publicWafCookiePayload{}, false
 	}
 	return payload, true

--- a/internal/server/public_waf_test.go
+++ b/internal/server/public_waf_test.go
@@ -586,7 +586,7 @@ func TestPublicWafWaitingRoomStatusSanitizesUnsafeReturnRedirect(t *testing.T) {
 	app.PublicWAF.reconcile(snap)
 
 	req := httptest.NewRequest(http.MethodGet, "http://example.com"+publicWafWaitingRoomStatusPath+"?rule_id=1&return_to=%2F%2Fevil.example%2Fprivate", nil)
-	req.AddCookie(app.PublicWAF.signedRuleCookie(rule.ID, publicWafAdmissionCookieKind, "session", time.Minute, time.Now(), snap.Listeners[1], req))
+	req.AddCookie(app.PublicWAF.signedRuleCookie(rule, snap.Listeners[1], req, publicWafAdmissionCookieKind, "session", time.Minute, time.Now()))
 	resp := httptest.NewRecorder()
 
 	decision := app.servePublicWAFWaitingRoomStatus(resp, req, 1)
@@ -601,7 +601,8 @@ func TestPublicWafWaitingRoomStatusSanitizesUnsafeReturnRedirect(t *testing.T) {
 
 func TestPublicWafCaptchaPassCookieAllowsRequest(t *testing.T) {
 	waf := newPublicWAF()
-	snap := testWafSnapshot(testWafRule(1, publicWafActionCaptcha), nil)
+	rule := testWafRule(1, publicWafActionCaptcha)
+	snap := testWafSnapshot(rule, nil)
 	snap.WafCaptchaProviders[1] = publicWafCaptchaProviderConfig{
 		ID:           1,
 		Name:         "turnstile",
@@ -622,9 +623,121 @@ func TestPublicWafCaptchaPassCookieAllowsRequest(t *testing.T) {
 	}
 
 	req = httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
-	req.AddCookie(waf.signedRuleCookie(1, publicWafCaptchaCookieKind, "", time.Minute, now, snap.Listeners[1], req))
+	req.AddCookie(waf.signedRuleCookie(rule, snap.Listeners[1], req, publicWafCaptchaCookieKind, "", time.Minute, now))
 	if _, allowed := waf.evaluate(snap, snap.Listeners[1], req, now.Add(time.Second), nil); !allowed {
 		t.Fatal("request with valid captcha cookie was not allowed")
+	}
+}
+
+func TestPublicWafCaptchaPassCookieAcceptedForSameScope(t *testing.T) {
+	waf, rule, listener, now, _, cookie := newScopedWafCookieForTest(t, publicWafActionCaptcha, publicWafCaptchaCookieKind, "")
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req.AddCookie(cookie)
+
+	if !waf.validRuleCookieLocked(req, rule, listener, publicWafCaptchaCookieKind, now.Add(time.Second)) {
+		t.Fatal("captcha pass cookie for same listener, host, and rule fingerprint was rejected")
+	}
+}
+
+func TestPublicWafCaptchaPassCookieRejectsDifferentHost(t *testing.T) {
+	waf, rule, listener, now, _, cookie := newScopedWafCookieForTest(t, publicWafActionCaptcha, publicWafCaptchaCookieKind, "")
+	req := httptest.NewRequest(http.MethodGet, "http://other.example/", nil)
+	req.AddCookie(cookie)
+
+	if waf.validRuleCookieLocked(req, rule, listener, publicWafCaptchaCookieKind, now.Add(time.Second)) {
+		t.Fatal("captcha pass cookie for another host was accepted")
+	}
+}
+
+func TestPublicWafCaptchaPassCookieRejectsDifferentListener(t *testing.T) {
+	waf, rule, listener, now, _, cookie := newScopedWafCookieForTest(t, publicWafActionCaptcha, publicWafCaptchaCookieKind, "")
+	otherListener := listener
+	otherListener.ID = 2
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req.AddCookie(cookie)
+
+	if waf.validRuleCookieLocked(req, rule, otherListener, publicWafCaptchaCookieKind, now.Add(time.Second)) {
+		t.Fatal("captcha pass cookie for another listener was accepted")
+	}
+}
+
+func TestPublicWafCaptchaPassCookieRejectsChangedRuleFingerprint(t *testing.T) {
+	waf, rule, listener, now, _, cookie := newScopedWafCookieForTest(t, publicWafActionCaptcha, publicWafCaptchaCookieKind, "")
+	changedRule := rule
+	changedRule.Fingerprint = "changed-" + rule.Fingerprint
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req.AddCookie(cookie)
+
+	if waf.validRuleCookieLocked(req, changedRule, listener, publicWafCaptchaCookieKind, now.Add(time.Second)) {
+		t.Fatal("captcha pass cookie for a changed rule fingerprint was accepted")
+	}
+}
+
+func TestPublicWafWaitingRoomAdmissionRejectsDifferentHost(t *testing.T) {
+	waf, rule, listener, now, _, cookie := newScopedWafCookieForTest(t, publicWafActionWaitingRoom, publicWafAdmissionCookieKind, "session")
+	req := httptest.NewRequest(http.MethodGet, "http://other.example/", nil)
+	req.AddCookie(cookie)
+
+	if waf.validRuleCookieLocked(req, rule, listener, publicWafAdmissionCookieKind, now.Add(time.Second)) {
+		t.Fatal("waiting-room admission cookie for another host was accepted")
+	}
+}
+
+func TestPublicWafWaitingRoomAdmissionRejectsDifferentListener(t *testing.T) {
+	waf, rule, listener, now, _, cookie := newScopedWafCookieForTest(t, publicWafActionWaitingRoom, publicWafAdmissionCookieKind, "session")
+	otherListener := listener
+	otherListener.ID = 2
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req.AddCookie(cookie)
+
+	if waf.validRuleCookieLocked(req, rule, otherListener, publicWafAdmissionCookieKind, now.Add(time.Second)) {
+		t.Fatal("waiting-room admission cookie for another listener was accepted")
+	}
+}
+
+func TestPublicWafWaitingRoomAdmissionRejectsChangedRuleFingerprint(t *testing.T) {
+	waf, rule, listener, now, _, cookie := newScopedWafCookieForTest(t, publicWafActionWaitingRoom, publicWafAdmissionCookieKind, "session")
+	changedRule := rule
+	changedRule.Fingerprint = "changed-" + rule.Fingerprint
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req.AddCookie(cookie)
+
+	if waf.validRuleCookieLocked(req, changedRule, listener, publicWafAdmissionCookieKind, now.Add(time.Second)) {
+		t.Fatal("waiting-room admission cookie for a changed rule fingerprint was accepted")
+	}
+}
+
+func TestPublicWafWaitingRoomQueueCookieRejectsDifferentHost(t *testing.T) {
+	waf, rule, listener, now, _, cookie := newScopedWafCookieForTest(t, publicWafActionWaitingRoom, publicWafQueueCookieKind, "session")
+	req := httptest.NewRequest(http.MethodGet, "http://other.example/", nil)
+	req.AddCookie(cookie)
+
+	if _, ok := waf.queueCookiePayloadLocked(req, rule, listener, now.Add(time.Second)); ok {
+		t.Fatal("waiting-room queue cookie for another host was accepted")
+	}
+}
+
+func TestPublicWafWaitingRoomQueueCookieRejectsDifferentListener(t *testing.T) {
+	waf, rule, listener, now, _, cookie := newScopedWafCookieForTest(t, publicWafActionWaitingRoom, publicWafQueueCookieKind, "session")
+	otherListener := listener
+	otherListener.ID = 2
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req.AddCookie(cookie)
+
+	if _, ok := waf.queueCookiePayloadLocked(req, rule, otherListener, now.Add(time.Second)); ok {
+		t.Fatal("waiting-room queue cookie for another listener was accepted")
+	}
+}
+
+func TestPublicWafWaitingRoomQueueCookieRejectsChangedRuleFingerprint(t *testing.T) {
+	waf, rule, listener, now, _, cookie := newScopedWafCookieForTest(t, publicWafActionWaitingRoom, publicWafQueueCookieKind, "session")
+	changedRule := rule
+	changedRule.Fingerprint = "changed-" + rule.Fingerprint
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req.AddCookie(cookie)
+
+	if _, ok := waf.queueCookiePayloadLocked(req, changedRule, listener, now.Add(time.Second)); ok {
+		t.Fatal("waiting-room queue cookie for a changed rule fingerprint was accepted")
 	}
 }
 
@@ -696,8 +809,8 @@ func TestPublicProxyCaptchaPassStillHitsRateLimit(t *testing.T) {
 		t.Fatalf("request without captcha pass status = %d, want WAF captcha status %d", noPassResp.Code, http.StatusForbidden)
 	}
 
-	passCookie := app.PublicWAF.signedRuleCookie(wafRule.ID, publicWafCaptchaCookieKind, "", time.Minute, time.Now(), snap.Listeners[1], nil)
 	firstReq := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	passCookie := app.PublicWAF.signedRuleCookie(wafRule, snap.Listeners[1], firstReq, publicWafCaptchaCookieKind, "", time.Minute, time.Now())
 	firstReq.AddCookie(passCookie)
 	firstResp := httptest.NewRecorder()
 	handler(firstResp, firstReq)
@@ -717,15 +830,16 @@ func TestPublicProxyCaptchaPassStillHitsRateLimit(t *testing.T) {
 func TestPublicWafSignedCookiesRejectExpiredAndForgedValues(t *testing.T) {
 	waf := newPublicWAF()
 	waf.storeCookieSecret([]byte("test-secret"))
+	rule := testWafRule(7, publicWafActionCaptcha)
+	listener := publicListenerConfig{ID: 1, Protocol: publicListenerProtocolHTTP}
 	now := time.Unix(100, 0)
-	cookie := waf.signedRuleCookie(7, publicWafCaptchaCookieKind, "", time.Minute, now, publicListenerConfig{Protocol: publicListenerProtocolHTTP}, nil)
-
 	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	cookie := waf.signedRuleCookie(rule, listener, req, publicWafCaptchaCookieKind, "", time.Minute, now)
 	req.AddCookie(cookie)
-	if !waf.validRuleCookieLocked(req, 7, publicWafCaptchaCookieKind, now.Add(time.Second)) {
+	if !waf.validRuleCookieLocked(req, rule, listener, publicWafCaptchaCookieKind, now.Add(time.Second)) {
 		t.Fatal("valid signed cookie was rejected")
 	}
-	if waf.validRuleCookieLocked(req, 7, publicWafCaptchaCookieKind, now.Add(2*time.Minute)) {
+	if waf.validRuleCookieLocked(req, rule, listener, publicWafCaptchaCookieKind, now.Add(2*time.Minute)) {
 		t.Fatal("expired signed cookie was accepted")
 	}
 
@@ -733,10 +847,13 @@ func TestPublicWafSignedCookiesRejectExpiredAndForgedValues(t *testing.T) {
 	forged.Value += "x"
 	forgedReq := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
 	forgedReq.AddCookie(&forged)
-	if waf.validRuleCookieLocked(forgedReq, 7, publicWafCaptchaCookieKind, now.Add(time.Second)) {
+	if waf.validRuleCookieLocked(forgedReq, rule, listener, publicWafCaptchaCookieKind, now.Add(time.Second)) {
 		t.Fatal("forged signed cookie was accepted")
 	}
-	if waf.validRuleCookieLocked(req, 8, publicWafCaptchaCookieKind, now.Add(time.Second)) {
+	otherRule := rule
+	otherRule.ID = 8
+	otherRule.Fingerprint = publicWafRuleFingerprint(otherRule)
+	if waf.validRuleCookieLocked(req, otherRule, listener, publicWafCaptchaCookieKind, now.Add(time.Second)) {
 		t.Fatal("cookie signed for another rule was accepted")
 	}
 }
@@ -784,14 +901,14 @@ func TestPublicWafCookieSecretConcurrentReconcileAndSigning(t *testing.T) {
 			}
 			waf.verifyCaptchaChallenge(challenge, now)
 
-			cookie := waf.signedRuleCookie(rule.ID, publicWafCaptchaCookieKind, "", time.Minute, now, listener, req)
+			cookie := waf.signedRuleCookie(rule, listener, req, publicWafCaptchaCookieKind, "", time.Minute, now)
 			if cookie == nil || cookie.Value == "" {
 				errCh <- "empty signed WAF cookie"
 				return
 			}
 			cookieReq := httptest.NewRequest(http.MethodGet, "http://example.com/protected?x=1", nil)
 			cookieReq.AddCookie(cookie)
-			waf.validRuleCookieLocked(cookieReq, rule.ID, publicWafCaptchaCookieKind, now)
+			waf.validRuleCookieLocked(cookieReq, rule, listener, publicWafCaptchaCookieKind, now)
 		}
 	}
 	go signAndVerify()
@@ -1059,16 +1176,16 @@ func TestPublicWafValidationRequiresEnabledCaptchaProvider(t *testing.T) {
 
 func TestPublicWafTriggerValidationPreservesDisabledSignals(t *testing.T) {
 	cfg, err := validatePublicWafTriggers(&p2pstreamv1.PublicWafTriggerConfig{
-		RequestWindowMillis:    10000,
-		MinimumRequestRate:     0,
-		TrafficSpikeMultiplier: 0,
-		ProxyActiveRequests:    0,
-		RouteTargetActiveRequests:  0,
-		AgentActiveRequests:    0,
-		ServerCpuPercent:       0,
-		AgentCpuPercent:        0,
-		MinimumActiveMillis:    30000,
-		QuietPeriodMillis:      60000,
+		RequestWindowMillis:       10000,
+		MinimumRequestRate:        0,
+		TrafficSpikeMultiplier:    0,
+		ProxyActiveRequests:       0,
+		RouteTargetActiveRequests: 0,
+		AgentActiveRequests:       0,
+		ServerCpuPercent:          0,
+		AgentCpuPercent:           0,
+		MinimumActiveMillis:       30000,
+		QuietPeriodMillis:         60000,
 	})
 	if err != nil {
 		t.Fatalf("validate triggers: %v", err)
@@ -1173,6 +1290,18 @@ func testWafSnapshot(rule publicWafRuleConfig, providers map[int64]publicWafCapt
 		snap.WafCaptchaProviders = map[int64]publicWafCaptchaProviderConfig{}
 	}
 	return snap
+}
+
+func newScopedWafCookieForTest(t *testing.T, action string, kind string, sessionID string) (*publicWAF, publicWafRuleConfig, publicListenerConfig, time.Time, *http.Request, *http.Cookie) {
+	t.Helper()
+	waf := newPublicWAF()
+	waf.storeCookieSecret([]byte("test-secret"))
+	rule := testWafRule(1, action)
+	listener := publicListenerConfig{ID: 1, Protocol: publicListenerProtocolHTTP}
+	now := time.Unix(100, 0)
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	cookie := waf.signedRuleCookie(rule, listener, req, kind, sessionID, time.Minute, now)
+	return waf, rule, listener, now, req, cookie
 }
 
 func testWafRule(id int64, action string) publicWafRuleConfig {

--- a/internal/server/public_waf_waiting_room.go
+++ b/internal/server/public_waf_waiting_room.go
@@ -30,11 +30,11 @@ func (rt *publicWaitingRoomRuntime) evaluateLocked(w *publicWAF, rule publicWafR
 	if rt == nil {
 		rt = newPublicWaitingRoomRuntime()
 	}
-	if w.validRuleCookieLocked(r, rule.ID, publicWafAdmissionCookieKind, now) {
+	if w.validRuleCookieLocked(r, rule, listener, publicWafAdmissionCookieKind, now) {
 		return publicWafDecision{}, true
 	}
 	sessionID := ""
-	if payload, ok := w.queueCookiePayloadLocked(r, rule.ID, now); ok {
+	if payload, ok := w.queueCookiePayloadLocked(r, rule, listener, now); ok {
 		sessionID = payload.SessionID
 	}
 	if sessionID == "" {
@@ -67,7 +67,7 @@ func (rt *publicWaitingRoomRuntime) evaluateLocked(w *publicWAF, rule publicWafR
 		rt.queue = append(rt.queue, sessionID)
 	}
 	position := rt.positionLocked(sessionID)
-	queueCookie := w.signedRuleCookie(rule.ID, publicWafQueueCookieKind, sessionID, queueTimeout, now, listener, r)
+	queueCookie := w.signedRuleCookie(rule, listener, r, publicWafQueueCookieKind, sessionID, queueTimeout, now)
 	if rt.canAdmitLocked(rule, now, sessionID) {
 		admissionTTL := time.Duration(rule.WaitingRoom.AdmissionSessionTTLMillis) * time.Millisecond
 		if admissionTTL <= 0 {
@@ -82,7 +82,7 @@ func (rt *publicWaitingRoomRuntime) evaluateLocked(w *publicWAF, rule publicWafR
 			Action:           publicWafActionWaitingRoom,
 			StatusCode:       http.StatusSeeOther,
 			RedirectLocation: sanitizeWAFReturnTo(r.URL.RequestURI()),
-			Cookies:          []*http.Cookie{queueCookie, w.signedRuleCookie(rule.ID, publicWafAdmissionCookieKind, sessionID, admissionTTL, now, listener, r)},
+			Cookies:          []*http.Cookie{queueCookie, w.signedRuleCookie(rule, listener, r, publicWafAdmissionCookieKind, sessionID, admissionTTL, now)},
 			AutomaticActive:  automaticActive,
 			ChallengeKind:    publicWafActionWaitingRoom,
 			QueuePosition:    position,
@@ -287,7 +287,7 @@ func (a *App) servePublicWAFWaitingRoomStatus(w http.ResponseWriter, r *http.Req
 	now := time.Now()
 	a.PublicWAF.mu.Lock()
 	defer a.PublicWAF.mu.Unlock()
-	if a.PublicWAF.validRuleCookieLocked(r, rule.ID, publicWafAdmissionCookieKind, now) {
+	if a.PublicWAF.validRuleCookieLocked(r, rule, listener, publicWafAdmissionCookieKind, now) {
 		redirectTo := sanitizeWAFReturnTo(r.URL.Query().Get("return_to"))
 		redirectTo = strings.ReplaceAll(redirectTo, `\`, "/")
 		redirectURL, err := url.Parse(redirectTo)
@@ -300,7 +300,7 @@ func (a *App) servePublicWAFWaitingRoomStatus(w http.ResponseWriter, r *http.Req
 	}
 	runtime := a.PublicWAF.runtimeLocked(rule)
 	sessionID := ""
-	if payload, ok := a.PublicWAF.queueCookiePayloadLocked(r, rule.ID, now); ok {
+	if payload, ok := a.PublicWAF.queueCookiePayloadLocked(r, rule, listener, now); ok {
 		sessionID = payload.SessionID
 	}
 	position := int64(0)


### PR DESCRIPTION
## Summary
- bind WAF signed cookies to rule ID, listener ID, normalized host, cookie kind, and current rule fingerprint
- apply the scoped cookie verification to captcha pass, waiting-room admission, and waiting-room queue cookies
- add replay regression coverage across host, listener, and rule fingerprint changes

## Compatibility
- existing WAF captcha/admission/queue cookies without the new scope fields will be invalid after deploy
- no DB, proto, or public API migration

## Tests
- go test ./internal/server -run 'Waf|WAF|Waiting|Captcha'
- go test ./internal/server
- git diff --check --cached

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WAF cookie validation to prevent cross-context cookie reuse. CAPTCHA and waiting-room cookies now require matching request context (host, listener, and rule configuration) to be accepted.

* **Tests**
  * Added comprehensive test coverage for WAF cookie scope enforcement across different hosts, listeners, and rule configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->