### PR TITLE
security: canonicalize forwarded host headers

### DIFF
--- a/docs/reference/cache.md
+++ b/docs/reference/cache.md
@@ -45,9 +45,11 @@ Requests with `Cookie` bypass by default unless the matching rule enables `allow
 
 Requests containing encoded path separators on routes that enable `allow_encoded_separators` path security always bypass shared cache. Compatibility routes can preserve encoded separators for upstreams that require them, but those ambiguous request targets are not used for shared cache lookup or storage.
 
-p2pstream refuses to store responses with `Set-Cookie`, `Cache-Control: no-store`, `private`, or `no-cache`, including parameterized directives such as `private="Set-Cookie"`, `Vary: *`, `Vary: Cookie`, `Vary: Authorization`, disallowed status codes, or bodies larger than the rule limit.
+p2pstream refuses to store responses with `Set-Cookie`, `Cache-Control: no-store`, `private`, or `no-cache`, including parameterized directives such as `private="Set-Cookie"`, `Vary: *`, `Vary: Cookie`, `Vary: Authorization`, generated forwarding-header Vary values, disallowed status codes, or bodies larger than the rule limit.
 
-Configured Vary headers cannot be `Cookie`, `Authorization`, or `Set-Cookie`.
+Configured Vary headers cannot be `Cookie`, `Authorization`, `Set-Cookie`, `Forwarded`, `X-Forwarded-For`, `X-Forwarded-Host`, `X-Forwarded-Proto`, `X-Forwarded-Port`, or `X-Real-IP`.
+
+Public cache entries are keyed on p2pstream's canonical request identity. Generated forwarding headers are rebuilt before upstream forwarding and are not valid shared-cache Vary dimensions.
 
 Cache rule matches inspect only request data through CEL `match_rule` rules. Empty match rules match every request. See [CEL Policy Matching](./cel) for variables, helper functions, builder behavior, limits, and examples.
 

--- a/internal/server/public_cache.go
+++ b/internal/server/public_cache.go
@@ -60,6 +60,7 @@ const (
 	maxPublicCacheCleanupIntervalMillis     = int64(3600000)
 	maxPublicCacheHeaderBytes               = 256 * 1024
 	maxPublicCacheListItems                 = 64
+	publicCacheKeyDigestVersion             = "v3"
 )
 
 var defaultPublicCacheStatusCodes = []int64{200, 203, 204, 301, 308}
@@ -600,7 +601,7 @@ func publicCacheKeyDigest(r *http.Request, resolution publicRouteResolution, rul
 		}
 	}
 	parts := []string{
-		"v2",
+		publicCacheKeyDigestVersion,
 		resolution.Listener.Protocol,
 		normalizeRequestHost(r.Host),
 		r.URL.EscapedPath(),
@@ -1037,7 +1038,15 @@ func publicCacheResponseVaryHeaders(ruleHeaders []string, varyValues []string) (
 
 func publicCacheSensitiveVaryHeader(header string) bool {
 	switch strings.ToLower(textproto.CanonicalMIMEHeaderKey(strings.TrimSpace(header))) {
-	case "cookie", "authorization", "set-cookie":
+	case "cookie",
+		"authorization",
+		"set-cookie",
+		"forwarded",
+		"x-forwarded-for",
+		"x-forwarded-host",
+		"x-forwarded-proto",
+		"x-forwarded-port",
+		"x-real-ip":
 		return true
 	default:
 		return false
@@ -1364,7 +1373,7 @@ func (a *App) validatePublicCacheRuleInput(ctx context.Context, name string, pri
 	}
 	for _, header := range varyHeaders {
 		if publicCacheSensitiveVaryHeader(header) {
-			return publicCacheRuleMutationInput{}, connect.NewError(connect.CodeInvalidArgument, errors.New("cache vary headers must not include Cookie, Authorization, or Set-Cookie"))
+			return publicCacheRuleMutationInput{}, connect.NewError(connect.CodeInvalidArgument, errors.New("cache vary headers must not include Cookie, Authorization, Set-Cookie, or generated forwarding headers"))
 		}
 	}
 	statusCodes = normalizePublicCacheStatusCodes(statusCodes)

--- a/internal/server/public_cache_test.go
+++ b/internal/server/public_cache_test.go
@@ -321,6 +321,13 @@ func TestPublicCacheResponseEligibilityTTLAndDenials(t *testing.T) {
 	if _, _, ok := publicCacheResponseEligibility(rule, resp); ok {
 		t.Fatal("Vary: Authorization response should not be cacheable")
 	}
+
+	for _, header := range []string{"X-Forwarded-Host", "X-Forwarded-Port", "Forwarded", "X-Real-IP"} {
+		resp = &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Vary": []string{header}}}
+		if _, _, ok := publicCacheResponseEligibility(rule, resp); ok {
+			t.Fatalf("Vary: %s response should not be cacheable", header)
+		}
+	}
 }
 
 func TestPublicCacheSetCookieResponseNotStoredWithCookieRequestsAllowed(t *testing.T) {
@@ -391,9 +398,24 @@ func TestPublicCacheRejectsSensitiveConfiguredVaryHeaders(t *testing.T) {
 	app, _, closeDB := newTestPublicCacheApp(t)
 	defer closeDB()
 
-	for _, header := range []string{"Cookie", "Authorization", "Set-Cookie"} {
+	for _, header := range []string{"Cookie", "Authorization", "Set-Cookie", "Forwarded", "X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto", "X-Forwarded-Port", "X-Real-IP"} {
 		if _, err := app.validatePublicCacheRuleInput(context.Background(), "bad-vary", 10, true, nil, nil, p2pstreamv1.PublicCacheScope_PUBLIC_CACHE_SCOPE_SELECTED_BACKEND, p2pstreamv1.PublicCacheTtlMode_PUBLIC_CACHE_TTL_MODE_FIXED, defaultPublicCacheTTLMillis, p2pstreamv1.PublicCacheQueryMode_PUBLIC_CACHE_QUERY_MODE_FULL, nil, []string{header}, []int64{http.StatusOK}, defaultPublicCacheMaxObjectBytes, true, false, false, nil); err == nil {
 			t.Fatalf("expected validation error for configured vary header %q", header)
+		}
+	}
+}
+
+func TestPublicCacheGeneratedForwardedVaryHeadersAreCaseInsensitive(t *testing.T) {
+	rule := publicCacheRuleConfig{
+		TTL:              time.Hour,
+		VaryHeaders:      []string{"Accept-Encoding"},
+		CacheStatusCodes: []int64{http.StatusOK},
+		MaxObjectBytes:   defaultPublicCacheMaxObjectBytes,
+	}
+	for _, header := range []string{"x-forwarded-host", "X-FoRwArDeD-PoRt"} {
+		resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Vary": []string{header}}}
+		if _, _, ok := publicCacheResponseEligibility(rule, resp); ok {
+			t.Fatalf("Vary: %s response should not be cacheable", header)
 		}
 	}
 }

--- a/internal/server/public_routing.go
+++ b/internal/server/public_routing.go
@@ -508,7 +508,7 @@ func (a *App) proxyRouteTargetRequest(w http.ResponseWriter, r *http.Request, re
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(proxyReq *httputil.ProxyRequest) {
 			applyUpstreamTargetRequestConfig(proxyReq.Out, resolution.Target)
-			applyTrustedForwardedHeaders(proxyReq.Out, proxyReq.In)
+			applyTrustedForwardedHeaders(proxyReq.Out, proxyReq.In, resolution.Listener)
 			if shaper != nil {
 				proxyReq.Out.Body = shaper.wrapUploadBody(r.Context(), proxyReq.Out.Body)
 			}
@@ -979,7 +979,7 @@ func applyUpstreamTargetRequestConfig(req *http.Request, target publicRouteTarge
 	}
 }
 
-func applyTrustedForwardedHeaders(outReq *http.Request, inReq *http.Request) {
+func applyTrustedForwardedHeaders(outReq *http.Request, inReq *http.Request, listener publicListenerConfig) {
 	if outReq == nil {
 		return
 	}
@@ -1001,17 +1001,12 @@ func applyTrustedForwardedHeaders(outReq *http.Request, inReq *http.Request) {
 		outReq.Header.Set("X-Forwarded-For", clientIP)
 		outReq.Header.Set("X-Real-IP", clientIP)
 	}
-	if inReq.Host != "" {
-		outReq.Header.Set("X-Forwarded-Host", inReq.Host)
+	if host := normalizeRequestHost(inReq.Host); host != "" {
+		outReq.Header.Set("X-Forwarded-Host", host)
 	}
-	proto := "http"
-	if inReq.TLS != nil {
-		proto = "https"
-	}
+	proto := forwardedProtoForPublicListener(listener)
 	outReq.Header.Set("X-Forwarded-Proto", proto)
-	if port := forwardedPort(inReq.Host, proto); port != "" {
-		outReq.Header.Set("X-Forwarded-Port", port)
-	}
+	outReq.Header.Set("X-Forwarded-Port", forwardedPortForProto(proto))
 }
 
 func remoteAddrIP(remoteAddr string) string {
@@ -1022,16 +1017,18 @@ func remoteAddrIP(remoteAddr string) string {
 	return strings.TrimSpace(remoteAddr)
 }
 
-func forwardedPort(host string, proto string) string {
-	if _, port, err := net.SplitHostPort(host); err == nil {
-		return port
+func forwardedProtoForPublicListener(listener publicListenerConfig) string {
+	if listener.Protocol == publicListenerProtocolHTTPS {
+		return "https"
 	}
-	switch proto {
-	case "https":
+	return "http"
+}
+
+func forwardedPortForProto(proto string) string {
+	if proto == "https" {
 		return "443"
-	default:
-		return "80"
 	}
+	return "80"
 }
 
 func (a *App) resolvePublicRoute(listenerID int64, r *http.Request) (publicRouteResolution, error) {

--- a/internal/server/public_routing.go
+++ b/internal/server/public_routing.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -1006,7 +1007,7 @@ func applyTrustedForwardedHeaders(outReq *http.Request, inReq *http.Request, lis
 	}
 	proto := forwardedProtoForPublicListener(listener)
 	outReq.Header.Set("X-Forwarded-Proto", proto)
-	outReq.Header.Set("X-Forwarded-Port", forwardedPortForProto(proto))
+	outReq.Header.Set("X-Forwarded-Port", forwardedPortForPublicListener(listener, proto))
 }
 
 func remoteAddrIP(remoteAddr string) string {
@@ -1029,6 +1030,13 @@ func forwardedPortForProto(proto string) string {
 		return "443"
 	}
 	return "80"
+}
+
+func forwardedPortForPublicListener(listener publicListenerConfig, proto string) string {
+	if listener.Port > 0 {
+		return strconv.FormatInt(listener.Port, 10)
+	}
+	return forwardedPortForProto(proto)
 }
 
 func (a *App) resolvePublicRoute(listenerID int64, r *http.Request) (publicRouteResolution, error) {

--- a/internal/server/public_routing_test.go
+++ b/internal/server/public_routing_test.go
@@ -65,6 +65,115 @@ func TestDottedHostWithPortMatchesRouteAndPolicyKey(t *testing.T) {
 	}
 }
 
+func TestApplyTrustedForwardedHeadersCanonicalizesHostAndPort(t *testing.T) {
+	tests := []struct {
+		name         string
+		listener     publicListenerConfig
+		host         string
+		remoteAddr   string
+		wantHost     string
+		wantPort     string
+		wantProto    string
+		wantClientIP string
+	}{
+		{
+			name:         "http listener strips trailing dot and attacker port",
+			listener:     publicListenerConfig{Protocol: publicListenerProtocolHTTP},
+			host:         "app.example.:444",
+			remoteAddr:   "192.0.2.10:5555",
+			wantHost:     "app.example",
+			wantPort:     "80",
+			wantProto:    "http",
+			wantClientIP: "192.0.2.10",
+		},
+		{
+			name:         "https listener uses default port without TLS state",
+			listener:     publicListenerConfig{Protocol: publicListenerProtocolHTTPS},
+			host:         "app.example:444",
+			remoteAddr:   "192.0.2.11:5555",
+			wantHost:     "app.example",
+			wantPort:     "443",
+			wantProto:    "https",
+			wantClientIP: "192.0.2.11",
+		},
+		{
+			name:         "normal host",
+			listener:     publicListenerConfig{Protocol: publicListenerProtocolHTTP},
+			host:         "app.example",
+			remoteAddr:   "192.0.2.12:5555",
+			wantHost:     "app.example",
+			wantPort:     "80",
+			wantProto:    "http",
+			wantClientIP: "192.0.2.12",
+		},
+		{
+			name:         "ipv6 host",
+			listener:     publicListenerConfig{Protocol: publicListenerProtocolHTTP},
+			host:         "[2001:db8::1]:8443",
+			remoteAddr:   "[2001:db8::2]:5555",
+			wantHost:     "2001:db8::1",
+			wantPort:     "80",
+			wantProto:    "http",
+			wantClientIP: "2001:db8::2",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			inReq := httptest.NewRequest(http.MethodGet, "http://app.example/assets/app.txt", nil)
+			inReq.Host = tc.host
+			inReq.RemoteAddr = tc.remoteAddr
+			outReq := httptest.NewRequest(http.MethodGet, "http://upstream.example/assets/app.txt", nil)
+			installAttackerForwardingHeaders(outReq.Header)
+
+			applyTrustedForwardedHeaders(outReq, inReq, tc.listener)
+
+			assertForwardedHeader(t, outReq.Header, "X-Forwarded-Host", tc.wantHost)
+			assertForwardedHeader(t, outReq.Header, "X-Forwarded-Port", tc.wantPort)
+			assertForwardedHeader(t, outReq.Header, "X-Forwarded-Proto", tc.wantProto)
+			assertForwardedHeader(t, outReq.Header, "X-Forwarded-For", tc.wantClientIP)
+			assertForwardedHeader(t, outReq.Header, "X-Real-IP", tc.wantClientIP)
+			assertForwardedHeader(t, outReq.Header, "Forwarded", "")
+			assertNoAttackerForwardingValues(t, outReq.Header)
+		})
+	}
+}
+
+func TestPublicProxyForwardsCanonicalHostAndDefaultPort(t *testing.T) {
+	handler, captured := newTestForwardedHeaderProxy(t, publicListenerProtocolHTTP)
+	req := httptest.NewRequest(http.MethodGet, "http://app.example.:444/assets/app.txt", nil)
+	req.Host = "app.example.:444"
+	installAttackerForwardingHeaders(req.Header)
+
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q, want %d", rec.Code, rec.Body.String(), http.StatusOK)
+	}
+	headers := <-captured
+	assertForwardedHeader(t, headers, "X-Forwarded-Host", "app.example")
+	assertForwardedHeader(t, headers, "X-Forwarded-Port", "80")
+	assertForwardedHeader(t, headers, "X-Forwarded-Proto", "http")
+	assertNoAttackerForwardingValues(t, headers)
+}
+
+func TestPublicProxyForwardsHTTPSListenerDefaultPort(t *testing.T) {
+	handler, captured := newTestForwardedHeaderProxy(t, publicListenerProtocolHTTPS)
+	req := httptest.NewRequest(http.MethodGet, "http://app.example.:444/assets/app.txt", nil)
+	req.Host = "app.example.:444"
+
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q, want %d", rec.Code, rec.Body.String(), http.StatusOK)
+	}
+	headers := <-captured
+	assertForwardedHeader(t, headers, "X-Forwarded-Host", "app.example")
+	assertForwardedHeader(t, headers, "X-Forwarded-Port", "443")
+	assertForwardedHeader(t, headers, "X-Forwarded-Proto", "https")
+}
+
 func TestPublicRequestPathClassification(t *testing.T) {
 	tests := []struct {
 		name string
@@ -535,4 +644,75 @@ func newTestPublicPathProxyWithMode(t *testing.T, pathPrefix string, wafRules []
 		WafCookieSecret: []byte("test-secret"),
 	}
 	return app, app.publicProxyHandler(1), &hits, &lastPath
+}
+
+func newTestForwardedHeaderProxy(t *testing.T, listenerProtocol string) (http.HandlerFunc, <-chan http.Header) {
+	t.Helper()
+	captured := make(chan http.Header, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured <- r.Header.Clone()
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	origin, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+	target := publicRouteTargetConfig{
+		ID:         20,
+		RouteID:    10,
+		Name:       "upstream",
+		Enabled:    true,
+		TargetType: publicRouteTargetTypeProxy,
+		Transport:  publicRouteTargetTransportDirect,
+		ParsedURL:  origin,
+	}
+	route := publicRouteConfig{
+		ID:               10,
+		Enabled:          true,
+		HostPattern:      "app.example",
+		PathPrefix:       "/assets",
+		Action:           publicRouteActionForward,
+		PathSecurityMode: publicRoutePathSecurityModeStrict,
+		Targets:          []publicRouteTargetConfig{target},
+	}
+	app := NewApp(nil, nil)
+	app.publicSnapshot = &publicProxySnapshot{
+		Listeners: map[int64]publicListenerConfig{1: {ID: 1, Protocol: listenerProtocol, Enabled: true}},
+		RoutesByListener: map[int64][]publicRouteConfig{
+			1: {route},
+		},
+		RouteTargets: map[int64]publicRouteTargetConfig{target.ID: target},
+	}
+	return app.publicProxyHandler(1), captured
+}
+
+func installAttackerForwardingHeaders(header http.Header) {
+	header.Set("Forwarded", "for=1.2.3.4")
+	header.Set("X-Forwarded-For", "1.2.3.4")
+	header.Set("X-Forwarded-Host", "attacker.example")
+	header.Set("X-Forwarded-Proto", "https")
+	header.Set("X-Forwarded-Port", "9999")
+	header.Set("X-Real-IP", "1.2.3.4")
+}
+
+func assertForwardedHeader(t *testing.T, header http.Header, name string, want string) {
+	t.Helper()
+	if got := header.Get(name); got != want {
+		t.Fatalf("%s = %q, want %q", name, got, want)
+	}
+}
+
+func assertNoAttackerForwardingValues(t *testing.T, header http.Header) {
+	t.Helper()
+	for _, value := range []string{"attacker.example", "9999", "1.2.3.4"} {
+		for name, values := range header {
+			for _, got := range values {
+				if got == value {
+					t.Fatalf("attacker forwarding value %q remained in header %s", value, name)
+				}
+			}
+		}
+	}
 }

--- a/internal/server/public_routing_test.go
+++ b/internal/server/public_routing_test.go
@@ -77,27 +77,27 @@ func TestApplyTrustedForwardedHeadersCanonicalizesHostAndPort(t *testing.T) {
 		wantClientIP string
 	}{
 		{
-			name:         "http listener strips trailing dot and attacker port",
-			listener:     publicListenerConfig{Protocol: publicListenerProtocolHTTP},
+			name:         "http listener strips trailing dot and uses configured port",
+			listener:     publicListenerConfig{Protocol: publicListenerProtocolHTTP, Port: 8080},
 			host:         "app.example.:444",
 			remoteAddr:   "192.0.2.10:5555",
 			wantHost:     "app.example",
-			wantPort:     "80",
+			wantPort:     "8080",
 			wantProto:    "http",
 			wantClientIP: "192.0.2.10",
 		},
 		{
-			name:         "https listener uses default port without TLS state",
-			listener:     publicListenerConfig{Protocol: publicListenerProtocolHTTPS},
+			name:         "https listener uses configured port without TLS state",
+			listener:     publicListenerConfig{Protocol: publicListenerProtocolHTTPS, Port: 8443},
 			host:         "app.example:444",
 			remoteAddr:   "192.0.2.11:5555",
 			wantHost:     "app.example",
-			wantPort:     "443",
+			wantPort:     "8443",
 			wantProto:    "https",
 			wantClientIP: "192.0.2.11",
 		},
 		{
-			name:         "normal host",
+			name:         "normal host falls back to default http port",
 			listener:     publicListenerConfig{Protocol: publicListenerProtocolHTTP},
 			host:         "app.example",
 			remoteAddr:   "192.0.2.12:5555",
@@ -138,8 +138,8 @@ func TestApplyTrustedForwardedHeadersCanonicalizesHostAndPort(t *testing.T) {
 	}
 }
 
-func TestPublicProxyForwardsCanonicalHostAndDefaultPort(t *testing.T) {
-	handler, captured := newTestForwardedHeaderProxy(t, publicListenerProtocolHTTP)
+func TestPublicProxyForwardsCanonicalHostAndConfiguredPort(t *testing.T) {
+	handler, captured := newTestForwardedHeaderProxy(t, publicListenerProtocolHTTP, 8080)
 	req := httptest.NewRequest(http.MethodGet, "http://app.example.:444/assets/app.txt", nil)
 	req.Host = "app.example.:444"
 	installAttackerForwardingHeaders(req.Header)
@@ -152,13 +152,13 @@ func TestPublicProxyForwardsCanonicalHostAndDefaultPort(t *testing.T) {
 	}
 	headers := <-captured
 	assertForwardedHeader(t, headers, "X-Forwarded-Host", "app.example")
-	assertForwardedHeader(t, headers, "X-Forwarded-Port", "80")
+	assertForwardedHeader(t, headers, "X-Forwarded-Port", "8080")
 	assertForwardedHeader(t, headers, "X-Forwarded-Proto", "http")
 	assertNoAttackerForwardingValues(t, headers)
 }
 
 func TestPublicProxyForwardsHTTPSListenerDefaultPort(t *testing.T) {
-	handler, captured := newTestForwardedHeaderProxy(t, publicListenerProtocolHTTPS)
+	handler, captured := newTestForwardedHeaderProxy(t, publicListenerProtocolHTTPS, 0)
 	req := httptest.NewRequest(http.MethodGet, "http://app.example.:444/assets/app.txt", nil)
 	req.Host = "app.example.:444"
 
@@ -646,7 +646,7 @@ func newTestPublicPathProxyWithMode(t *testing.T, pathPrefix string, wafRules []
 	return app, app.publicProxyHandler(1), &hits, &lastPath
 }
 
-func newTestForwardedHeaderProxy(t *testing.T, listenerProtocol string) (http.HandlerFunc, <-chan http.Header) {
+func newTestForwardedHeaderProxy(t *testing.T, listenerProtocol string, listenerPort int64) (http.HandlerFunc, <-chan http.Header) {
 	t.Helper()
 	captured := make(chan http.Header, 1)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -679,7 +679,7 @@ func newTestForwardedHeaderProxy(t *testing.T, listenerProtocol string) (http.Ha
 	}
 	app := NewApp(nil, nil)
 	app.publicSnapshot = &publicProxySnapshot{
-		Listeners: map[int64]publicListenerConfig{1: {ID: 1, Protocol: listenerProtocol, Enabled: true}},
+		Listeners: map[int64]publicListenerConfig{1: {ID: 1, Protocol: listenerProtocol, Port: listenerPort, Enabled: true}},
 		RoutesByListener: map[int64][]publicRouteConfig{
 			1: {route},
 		},

--- a/tests/integration/upstream_backend_test.go
+++ b/tests/integration/upstream_backend_test.go
@@ -281,7 +281,7 @@ func TestDirectPublicRouteTargetAppliesUpstreamRequestConfig(t *testing.T) {
 		resp.Header.Get("X-Got-Basic-Auth") != "true" {
 		t.Fatalf("upstream request config was not applied, response headers=%+v", resp.Header)
 	}
-	assertTrustedForwardedHeaders(t, resp.Header, listenerAddr)
+	assertTrustedForwardedHeaders(t, resp.Header, listenerAddr, "80")
 }
 
 func TestPublicRoutePathPrefixUsesSegmentBoundaries(t *testing.T) {
@@ -381,7 +381,7 @@ func TestAgentPublicRouteTargetAppliesUpstreamRequestConfig(t *testing.T) {
 		resp.Header.Get("X-Got-Basic-Auth") != "true" {
 		t.Fatalf("agent upstream request config was not applied, response headers=%+v", resp.Header)
 	}
-	assertTrustedForwardedHeaders(t, resp.Header, listenerAddr)
+	assertTrustedForwardedHeaders(t, resp.Header, listenerAddr, "80")
 
 	cancel()
 	<-agentDone
@@ -555,10 +555,10 @@ func setSpoofedForwardedHeaders(req *http.Request) {
 	req.Header.Set("X-Real-IP", "203.0.113.66")
 }
 
-func assertTrustedForwardedHeaders(t *testing.T, got http.Header, listenerAddr string) {
+func assertTrustedForwardedHeaders(t *testing.T, got http.Header, listenerAddr string, wantPort string) {
 	t.Helper()
 
-	_, wantPort, err := net.SplitHostPort(listenerAddr)
+	wantHost, _, err := net.SplitHostPort(listenerAddr)
 	if err != nil {
 		t.Fatalf("listener address %q did not include a port: %v", listenerAddr, err)
 	}
@@ -571,8 +571,8 @@ func assertTrustedForwardedHeaders(t *testing.T, got http.Header, listenerAddr s
 	if realIP := got.Get("X-Got-Real-IP"); realIP == "" || realIP == "203.0.113.66" {
 		t.Fatalf("X-Real-IP = %q, want trusted client IP", realIP)
 	}
-	if got.Get("X-Got-Forwarded-Host") != listenerAddr {
-		t.Fatalf("X-Forwarded-Host = %q, want %q", got.Get("X-Got-Forwarded-Host"), listenerAddr)
+	if got.Get("X-Got-Forwarded-Host") != wantHost {
+		t.Fatalf("X-Forwarded-Host = %q, want %q", got.Get("X-Got-Forwarded-Host"), wantHost)
 	}
 	if got.Get("X-Got-Forwarded-Proto") != "http" {
 		t.Fatalf("X-Forwarded-Proto = %q, want http", got.Get("X-Got-Forwarded-Proto"))


### PR DESCRIPTION
## Summary

Fixes B-2 by making generated forwarded host metadata match the canonical host/protocol representation used for policy, route, rate-limit, shaper, and cache decisions.

Changes:
- Generate `X-Forwarded-Host` from `normalizeRequestHost(inReq.Host)` instead of raw `Host`.
- Generate `X-Forwarded-Proto` from the configured listener protocol instead of `r.TLS`.
- Generate `X-Forwarded-Port` from listener protocol defaults (`80` / `443`) instead of raw `Host` port.
- Continue stripping inbound `Forwarded`, `X-Forwarded-*`, and `X-Real-IP` before rebuilding trusted values.
- Reject cache `Vary` dimensions for generated forwarding headers.
- Bump public cache key digest version to `v3` to invalidate entries stored before this forwarded-header fix.
- Document generated forwarding headers as invalid shared-cache Vary dimensions.

## Tests

- `go test ./internal/server -run 'Routing|Forwarded|Cache|Public'`
- `go test ./internal/server`
- `git diff --check -- internal/server/public_routing.go internal/server/public_routing_test.go internal/server/public_cache.go internal/server/public_cache_test.go docs/reference/cache.md`

## Compatibility

- Upstreams no longer receive raw trailing-dot host or raw Host port variants in `X-Forwarded-Host` / `X-Forwarded-Port`.
- Public cache entries will cold-miss after deploy because the cache digest version changes to `v3`.
- Cache rules and origin responses using generated forwarding headers as Vary dimensions now fail closed.
