### PR TITLE
security: reject dynamic CEL regex patterns

### DIFF
--- a/docs/reference/cel.md
+++ b/docs/reference/cel.md
@@ -120,6 +120,7 @@ Header and query conditions check all repeated values. Internally migrated legac
 | CEL evaluation cost limit | `20000` |
 
 Expressions must compile and evaluate to bool. Regex literals are validated when p2pstream can see them statically.
+Regex arguments to `.matches()` must be string literals; dynamic regex patterns from request fields such as headers, cookies, or query parameters are rejected during policy validation and stored rule loading.
 
 For routes that allow encoded path separators, CEL still receives the decoded `path`. Use route-scoped compatibility sparingly and avoid CEL authorization logic that depends on slash boundaries that an upstream interprets differently.
 
@@ -128,6 +129,7 @@ Literal arguments receive targeted validation:
 - `cidr(remote_ip, "...")` requires a valid CIDR prefix.
 - `path_prefix(path, "...")` requires a prefix starting with `/`.
 - `host_match(host, "...")` requires a non-empty host pattern.
+- `value.matches("...")` requires a string-literal regex no larger than the condition value limit.
 
 ## Examples
 
@@ -153,6 +155,12 @@ Bot user-agent match:
 
 ```text
 headers["user-agent"].exists(v, v.matches("(?i)(bot|crawler)"))
+```
+
+Invalid dynamic regex source:
+
+```text
+path.matches(headers["x-re"][0])
 ```
 
 Cookie absence:
@@ -202,7 +210,7 @@ p2pstream may perform an internal route-only path security match before WAF, rat
 | Rule matches every request | Check whether `match_rule` is empty or the builder has no conditions. Empty matches mean any request. |
 | Header rule does not match | Use lowercase header names such as `headers["x-plan"]`; p2pstream lowercases header keys. |
 | Header or query value rule does not match | Use `.exists(v, ...)` because headers and query parameters are lists. |
-| Regex is rejected | Compile the regex separately and escape backslashes correctly inside the CEL string. |
+| Regex is rejected | Use a string-literal regex, keep it within the value-size limit, compile it separately, and escape backslashes correctly inside the CEL string. |
 | Path prefix is rejected | Prefix values for `path_prefix` and builder path-prefix conditions must start with `/`. |
 | CIDR is rejected or never matches | Use a valid CIDR prefix and confirm p2pstream sees the expected client IP. |
 | Route or target data is missing | CEL only sees request data. Use feature-specific route/target filters where available. |

--- a/internal/server/public_policy_match.go
+++ b/internal/server/public_policy_match.go
@@ -267,12 +267,22 @@ func validatePublicPolicyMatchCELAst(checked *cel.Ast) error {
 				}
 			}
 		case "matches":
-			if call.IsMemberFunction() && len(args) == 1 {
-				if value, ok := publicPolicyMatchStringLiteral(args[0]); ok {
-					if _, err := regexp.Compile(value); err != nil {
-						validationErr = fmt.Errorf("policy match regex value is invalid")
-					}
-				}
+			if !call.IsMemberFunction() || len(args) != 1 {
+				validationErr = fmt.Errorf("policy match regex call is invalid")
+				return
+			}
+			value, ok := publicPolicyMatchStringLiteral(args[0])
+			if !ok {
+				validationErr = fmt.Errorf("policy match regex argument must be a string literal")
+				return
+			}
+			if len(value) > maxPublicPolicyMatchValueBytes {
+				validationErr = fmt.Errorf("policy match regex value is too large")
+				return
+			}
+			if _, err := regexp.Compile(value); err != nil {
+				validationErr = fmt.Errorf("policy match regex value is invalid")
+				return
 			}
 		}
 	})

--- a/internal/server/public_policy_match.go
+++ b/internal/server/public_policy_match.go
@@ -267,11 +267,17 @@ func validatePublicPolicyMatchCELAst(checked *cel.Ast) error {
 				}
 			}
 		case "matches":
-			if !call.IsMemberFunction() || len(args) != 1 {
+			var regexArg celast.Expr
+			switch {
+			case call.IsMemberFunction() && len(args) == 1:
+				regexArg = args[0]
+			case !call.IsMemberFunction() && len(args) == 2:
+				regexArg = args[1]
+			default:
 				validationErr = fmt.Errorf("policy match regex call is invalid")
 				return
 			}
-			value, ok := publicPolicyMatchStringLiteral(args[0])
+			value, ok := publicPolicyMatchStringLiteral(regexArg)
 			if !ok {
 				validationErr = fmt.Errorf("policy match regex argument must be a string literal")
 				return

--- a/internal/server/public_policy_match_test.go
+++ b/internal/server/public_policy_match_test.go
@@ -99,6 +99,21 @@ func TestPublicPolicyMatchValidationAcceptsLiteralRegexCEL(t *testing.T) {
 	}
 }
 
+func TestPublicPolicyMatchValidationAcceptsGlobalLiteralRegexCEL(t *testing.T) {
+	config, err := validatePublicPolicyMatch(&p2pstreamv1.PublicPolicyMatchRule{
+		CelExpression: `matches(path, "^/admin/.*$")`,
+	})
+	if err != nil {
+		t.Fatalf("global literal regex CEL should be accepted: %v", err)
+	}
+	if !config.matches(publicListenerConfig{}, httptest.NewRequest(http.MethodGet, "http://example.test/admin/users", nil)) {
+		t.Fatal("global literal regex CEL did not match expected path")
+	}
+	if config.matches(publicListenerConfig{}, httptest.NewRequest(http.MethodGet, "http://example.test/public/users", nil)) {
+		t.Fatal("global literal regex CEL matched unexpected path")
+	}
+}
+
 func TestPublicPolicyMatchBuilderRegexConditionRemainsAccepted(t *testing.T) {
 	config, err := validatePublicPolicyMatch(&p2pstreamv1.PublicPolicyMatchRule{
 		Builder: &p2pstreamv1.PublicPolicyMatchBuilder{
@@ -130,7 +145,6 @@ func TestPublicPolicyMatchValidationRejectsInvalidCEL(t *testing.T) {
 		`unknown_request_field == true`,
 		`method`,
 		`path.matches("[")`,
-		`matches(path, "^/admin")`,
 		`cidr(remote_ip, "not-a-cidr")`,
 		`path_prefix(path, "api")`,
 	} {
@@ -144,6 +158,7 @@ func TestPublicPolicyMatchValidationRejectsDynamicRegexCEL(t *testing.T) {
 	for _, expr := range []string{
 		`path.matches(headers["x-re"][0])`,
 		`path.matches(query["re"][0])`,
+		`matches(path, headers["x-re"][0])`,
 	} {
 		_, err := validatePublicPolicyMatch(&p2pstreamv1.PublicPolicyMatchRule{CelExpression: expr})
 		if err == nil {

--- a/internal/server/public_policy_match_test.go
+++ b/internal/server/public_policy_match_test.go
@@ -84,17 +84,97 @@ func TestPublicPolicyMatchBuilderOnlyRule(t *testing.T) {
 	}
 }
 
+func TestPublicPolicyMatchValidationAcceptsLiteralRegexCEL(t *testing.T) {
+	config, err := validatePublicPolicyMatch(&p2pstreamv1.PublicPolicyMatchRule{
+		CelExpression: `path.matches("^/admin/.*$")`,
+	})
+	if err != nil {
+		t.Fatalf("literal regex CEL should be accepted: %v", err)
+	}
+	if !config.matches(publicListenerConfig{}, httptest.NewRequest(http.MethodGet, "http://example.test/admin/users", nil)) {
+		t.Fatal("literal regex CEL did not match expected path")
+	}
+	if config.matches(publicListenerConfig{}, httptest.NewRequest(http.MethodGet, "http://example.test/public/users", nil)) {
+		t.Fatal("literal regex CEL matched unexpected path")
+	}
+}
+
+func TestPublicPolicyMatchBuilderRegexConditionRemainsAccepted(t *testing.T) {
+	config, err := validatePublicPolicyMatch(&p2pstreamv1.PublicPolicyMatchRule{
+		Builder: &p2pstreamv1.PublicPolicyMatchBuilder{
+			Root: &p2pstreamv1.PublicPolicyMatchGroup{
+				Conditions: []*p2pstreamv1.PublicPolicyMatchCondition{{
+					Field:    p2pstreamv1.PublicPolicyMatchField_PUBLIC_POLICY_MATCH_FIELD_PATH,
+					Operator: p2pstreamv1.PublicPolicyMatchConditionOperator_PUBLIC_POLICY_MATCH_CONDITION_OPERATOR_MATCHES,
+					Values:   []string{`^/assets/.+\.js$`},
+				}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("builder regex condition should be accepted: %v", err)
+	}
+	if config.CELExpression == "" || !strings.Contains(config.CELExpression, `.matches(`) {
+		t.Fatalf("builder regex condition did not generate matches CEL: %q", config.CELExpression)
+	}
+	if !config.matches(publicListenerConfig{}, httptest.NewRequest(http.MethodGet, "http://example.test/assets/app.js", nil)) {
+		t.Fatal("builder regex condition did not match expected path")
+	}
+	if config.matches(publicListenerConfig{}, httptest.NewRequest(http.MethodGet, "http://example.test/assets/app.css", nil)) {
+		t.Fatal("builder regex condition matched unexpected path")
+	}
+}
+
 func TestPublicPolicyMatchValidationRejectsInvalidCEL(t *testing.T) {
 	for _, expr := range []string{
 		`unknown_request_field == true`,
 		`method`,
 		`path.matches("[")`,
+		`matches(path, "^/admin")`,
 		`cidr(remote_ip, "not-a-cidr")`,
 		`path_prefix(path, "api")`,
 	} {
 		if _, err := validatePublicPolicyMatch(&p2pstreamv1.PublicPolicyMatchRule{CelExpression: expr}); err == nil {
 			t.Fatalf("expected invalid expression %q to be rejected", expr)
 		}
+	}
+}
+
+func TestPublicPolicyMatchValidationRejectsDynamicRegexCEL(t *testing.T) {
+	for _, expr := range []string{
+		`path.matches(headers["x-re"][0])`,
+		`path.matches(query["re"][0])`,
+	} {
+		_, err := validatePublicPolicyMatch(&p2pstreamv1.PublicPolicyMatchRule{CelExpression: expr})
+		if err == nil {
+			t.Fatalf("expected dynamic regex expression %q to be rejected", expr)
+		}
+		if !strings.Contains(err.Error(), "policy match regex argument must be a string literal") {
+			t.Fatalf("dynamic regex expression %q rejected with wrong error: %v", expr, err)
+		}
+	}
+}
+
+func TestPublicPolicyMatchValidationRejectsOversizedRegexLiteral(t *testing.T) {
+	value := strings.Repeat("a", maxPublicPolicyMatchValueBytes+1)
+	_, err := validatePublicPolicyMatch(&p2pstreamv1.PublicPolicyMatchRule{
+		CelExpression: `path.matches("` + value + `")`,
+	})
+	if err == nil {
+		t.Fatal("expected oversized regex literal to be rejected")
+	}
+	if !strings.Contains(err.Error(), "policy match regex value is too large") {
+		t.Fatalf("oversized regex literal rejected with wrong error: %v", err)
+	}
+}
+
+func TestPublicPolicyMatchStoredJSONRejectsDynamicRegex(t *testing.T) {
+	_, err := decodePublicPolicyMatchJSON(`{"cel_expression":"path.matches(headers[\"x-re\"][0])"}`)
+	if err == nil {
+		t.Fatal("expected stored dynamic regex CEL to be rejected")
+	}
+	if !strings.Contains(err.Error(), "policy match regex argument must be a string literal") {
+		t.Fatalf("stored dynamic regex rejected with wrong error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- require public policy CEL `.matches()` regex arguments to be string literals
- reject dynamic request-derived regex patterns during validation and stored config decoding
- keep builder-generated and static raw CEL regex rules working, with regex literals bounded by the existing value-size limit
- document dynamic regex sources as unsupported

## Tests

- `go test ./internal/server -run 'Policy|CEL|Waf|RateLimit|TrafficShaper|Cache'`
- `go test ./internal/server`
- `git diff --check -- internal/server/public_policy_match.go internal/server/public_policy_match_test.go docs/reference/cel.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CEL policy documentation with clearer guidance on regex validation rules and usage patterns, including troubleshooting for common regex-related issues.

* **Bug Fixes**
  * Enhanced validation for regex patterns in CEL policies to enforce string literals only and prevent dynamically constructed regex patterns. Added size limit enforcement for regex expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->