### PR TITLE
security: reject forwarding header key parts

### DIFF
--- a/docs/operations/security-hardening.md
+++ b/docs/operations/security-hardening.md
@@ -67,7 +67,7 @@ Review:
 | --- | --- |
 | Browser UI returns `404` | `MANAGEMENT_UI_DISABLED=true` intentionally disables only the browser UI. |
 | Agents fail after restore | Restore the old management CA or update agent CA material. |
-| Everyone hits one rate-limit bucket | A front proxy may hide client IPs; change key parts. |
+| Everyone hits one rate-limit bucket | A front proxy may hide client IPs; place p2pstream at the edge, use `REMOTE_IP` when possible, or use only trusted application headers. Do not key on client-supplied forwarding headers. |
 | WAF does not stop network saturation | WAF is HTTP-layer only; use upstream DDoS/network protection. |
 
 ## Next Steps

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -186,7 +186,7 @@ The target response-header timeout limits only the wait for first upstream heade
 
 | Cause | Fix |
 | --- | --- |
-| p2pstream sees one proxy IP | Add better key parts or place p2pstream at the edge. |
+| p2pstream sees one proxy IP | Place p2pstream at the edge, use `REMOTE_IP` when it reflects the client, or add host/path/method/application-header key parts. Do not key on client-supplied forwarding headers. |
 | Rule too broad | Add host/path/method matchers. |
 | Priority conflict | Move specific rules to lower priority numbers. |
 
@@ -198,7 +198,7 @@ The target response-header timeout limits only the wait for first upstream heade
 | Priority conflict | Lower priority numbers win. Adjust priorities or matches. |
 | Captcha provider unavailable | Confirm the provider is enabled and site key/secret key match upstream configuration. |
 | Waiting room stays active | Check trigger thresholds, active request counts, server CPU, and agent CPU in the dashboard. Use `0` to disable an automatic signal. |
-| All clients share one queue identity | Add key parts that identify visitors better than remote IP when behind another proxy. |
+| All clients share one queue identity | Use `REMOTE_IP` when p2pstream sees the client address, or use trusted application-header key parts. Avoid client-controlled forwarding headers; trusted-proxy parsing is not available yet. |
 | Large form or upload must be retried | Captcha and waiting-room admission use `303` redirects and do not replay request bodies. |
 
 ## Trace Stream Reconnects

--- a/docs/reference/rate-limits.md
+++ b/docs/reference/rate-limits.md
@@ -65,6 +65,19 @@ Key sources:
 - cookie,
 - query parameter.
 
+`REMOTE_IP` is the only built-in client-IP identity source. It uses the peer address seen by p2pstream. `HEADER` key parts remain supported for application headers such as `X-Plan`, but they cannot use forwarding or client-IP headers such as `Forwarded`, `X-Forwarded-For`, `X-Real-IP`, `X-Forwarded-Host`, `X-Forwarded-Proto`, `X-Forwarded-Port`, or common client-IP variants. Behind another reverse proxy, place p2pstream where it sees the real client address or use only trusted application headers; trusted-proxy parsing is not available yet.
+
+Before upgrading from an older version that allowed arbitrary header key parts, inspect stored rules:
+
+```sql
+SELECT id, name, key_parts_json
+FROM public_rate_limit_rules
+WHERE lower(key_parts_json) LIKE '%forwarded%'
+   OR lower(key_parts_json) LIKE '%x-real-ip%'
+   OR lower(key_parts_json) LIKE '%client-ip%'
+   OR lower(key_parts_json) LIKE '%connecting-ip%';
+```
+
 <figure class="doc-screenshot">
   <img src="../assets/new/traffic_policies_waf_and_ratelimits.png" alt="p2pstream Traffic Policy rate limits section showing rule priority, match summaries, algorithms, budgets, and enabled state">
   <figcaption>The Rate Limits section shows the active budgets beside nearby WAF controls, making priority and match breadth easier to audit.</figcaption>

--- a/docs/reference/traffic-shaping.md
+++ b/docs/reference/traffic-shaping.md
@@ -25,6 +25,19 @@ Traffic-shaper path matching and `path` key parts use p2pstream's decoded reques
 
 Key parts still identify the per-key budget. They can use remote IP, host, method, path, protocol, header, cookie, and query parameter values.
 
+For `per_key` shaping, `REMOTE_IP` is the only built-in client-IP identity source. `HEADER` key parts remain supported for application headers such as `X-Plan`, but forwarding or client-IP headers such as `Forwarded`, `X-Forwarded-For`, `X-Real-IP`, `X-Forwarded-Host`, `X-Forwarded-Proto`, and `X-Forwarded-Port` are rejected. `per_request` shaping ignores key parts.
+
+Before upgrading from an older version that allowed arbitrary header key parts, inspect stored per-key shapers:
+
+```sql
+SELECT id, name, key_parts_json
+FROM public_traffic_shaper_rules
+WHERE lower(key_parts_json) LIKE '%forwarded%'
+   OR lower(key_parts_json) LIKE '%x-real-ip%'
+   OR lower(key_parts_json) LIKE '%client-ip%'
+   OR lower(key_parts_json) LIKE '%connecting-ip%';
+```
+
 Byte rates and exempt bytes must be non-negative. Use realistic rates so operational debugging remains clear.
 
 <figure class="doc-screenshot">

--- a/docs/reference/waf.md
+++ b/docs/reference/waf.md
@@ -88,6 +88,19 @@ WAF path matching uses p2pstream's decoded request path. On routes that allow en
 
 WAF key parts reuse rate-limit key sources: remote IP, host, method, path, protocol, header, cookie, and query parameter.
 
+`REMOTE_IP` is the only built-in client-IP identity source. It uses the peer address seen by p2pstream. `HEADER` key parts remain supported for application headers such as `X-Plan`, but they cannot use forwarding or client-IP headers such as `Forwarded`, `X-Forwarded-For`, `X-Real-IP`, `X-Forwarded-Host`, `X-Forwarded-Proto`, `X-Forwarded-Port`, or common client-IP variants. Behind another reverse proxy, place p2pstream where it sees the real client address or use only trusted application headers; trusted-proxy parsing is not available yet.
+
+Before upgrading from an older version that allowed arbitrary header key parts, inspect stored WAF rules:
+
+```sql
+SELECT id, name, key_parts_json
+FROM public_waf_rules
+WHERE lower(key_parts_json) LIKE '%forwarded%'
+   OR lower(key_parts_json) LIKE '%x-real-ip%'
+   OR lower(key_parts_json) LIKE '%client-ip%'
+   OR lower(key_parts_json) LIKE '%connecting-ip%';
+```
+
 Automatic trigger thresholds accept `0` to disable individual signals. CPU percentages are 0 to 100.
 
 <figure class="doc-screenshot">

--- a/internal/server/public_traffic_shaper.go
+++ b/internal/server/public_traffic_shaper.go
@@ -496,7 +496,7 @@ func validatePublicTrafficShaperRuleInput(
 	}
 	keyPartConfig := []publicRateLimitKeyPartConfig(nil)
 	if scope == publicTrafficShaperBudgetScopePerKey {
-		keyPartConfig, err = validateRateLimitKeyParts(keyParts)
+		keyPartConfig, err = validateRateLimitClientIdentityKeyParts(keyParts)
 		if err != nil {
 			return publicTrafficShaperRuleMutationInput{}, trafficShaperValidationError(err)
 		}
@@ -566,8 +566,12 @@ func publicTrafficShaperRuleRowToConfig(row db.PublicTrafficShaperRule) (publicT
 	}
 	if rule.BudgetScope == publicTrafficShaperBudgetScopePerRequest {
 		rule.KeyParts = nil
-	} else if len(rule.KeyParts) == 0 {
-		rule.KeyParts = []publicRateLimitKeyPartConfig{{Source: publicRateLimitKeySourceRemoteIP}}
+	} else {
+		keyParts, err := validateStoredRateLimitClientIdentityKeyParts(rule.KeyParts)
+		if err != nil {
+			return publicTrafficShaperRuleConfig{}, trafficShaperValidationError(err)
+		}
+		rule.KeyParts = keyParts
 	}
 	rule.Fingerprint = publicTrafficShaperRuleFingerprint(rule)
 	return rule, nil

--- a/internal/server/public_traffic_shaper_test.go
+++ b/internal/server/public_traffic_shaper_test.go
@@ -245,6 +245,115 @@ func TestPublicTrafficShaperValidationAndDBRoundTrip(t *testing.T) {
 	}
 }
 
+func TestPublicTrafficShaperValidationRejectsUnsafeForwardingHeaderKeyParts(t *testing.T) {
+	for _, header := range []string{"X-Forwarded-For", "x-real-ip"} {
+		_, err := validatePublicTrafficShaperRuleInput(
+			"unsafe-key",
+			100,
+			true,
+			p2pstreamv1.PublicTrafficShaperBudgetScope_PUBLIC_TRAFFIC_SHAPER_BUDGET_SCOPE_PER_KEY,
+			1024,
+			0,
+			0,
+			0,
+			0,
+			[]*p2pstreamv1.PublicRateLimitKeyPart{{
+				Source: p2pstreamv1.PublicRateLimitKeySource_PUBLIC_RATE_LIMIT_KEY_SOURCE_HEADER,
+				Name:   header,
+			}},
+			nil,
+		)
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Fatalf("header %q: expected invalid argument, got %v", header, err)
+		}
+		if !strings.Contains(err.Error(), "traffic shaper header key part must not use forwarding or client IP headers; use REMOTE_IP") {
+			t.Fatalf("header %q: unexpected error %v", header, err)
+		}
+	}
+}
+
+func TestPublicTrafficShaperValidationAllowsApplicationHeaderKeyPart(t *testing.T) {
+	params, err := validatePublicTrafficShaperRuleInput(
+		"safe-key",
+		100,
+		true,
+		p2pstreamv1.PublicTrafficShaperBudgetScope_PUBLIC_TRAFFIC_SHAPER_BUDGET_SCOPE_PER_KEY,
+		1024,
+		0,
+		0,
+		0,
+		0,
+		[]*p2pstreamv1.PublicRateLimitKeyPart{{
+			Source: p2pstreamv1.PublicRateLimitKeySource_PUBLIC_RATE_LIMIT_KEY_SOURCE_HEADER,
+			Name:   "x-plan",
+		}},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("validate application header key part: %v", err)
+	}
+	if !strings.Contains(params.KeyPartsJSON, `"name":"X-Plan"`) {
+		t.Fatalf("key parts json = %q, want canonical X-Plan", params.KeyPartsJSON)
+	}
+}
+
+func TestPublicTrafficShaperPerRequestIgnoresUnsafeKeyParts(t *testing.T) {
+	params, err := validatePublicTrafficShaperRuleInput(
+		"per-request",
+		100,
+		true,
+		p2pstreamv1.PublicTrafficShaperBudgetScope_PUBLIC_TRAFFIC_SHAPER_BUDGET_SCOPE_PER_REQUEST,
+		1024,
+		0,
+		0,
+		0,
+		0,
+		[]*p2pstreamv1.PublicRateLimitKeyPart{{
+			Source: p2pstreamv1.PublicRateLimitKeySource_PUBLIC_RATE_LIMIT_KEY_SOURCE_HEADER,
+			Name:   "X-Forwarded-For",
+		}},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("per-request shaper should ignore unsafe key parts: %v", err)
+	}
+	if params.KeyPartsJSON != "[]" {
+		t.Fatalf("per-request key parts json = %q, want []", params.KeyPartsJSON)
+	}
+}
+
+func TestPublicTrafficShaperStoredPerKeyRejectsUnsafeForwardingHeaderKeyPart(t *testing.T) {
+	_, err := publicTrafficShaperRuleRowToConfig(db.PublicTrafficShaperRule{
+		Name:                   "stored-unsafe",
+		BudgetScope:            publicTrafficShaperBudgetScopePerKey,
+		UploadBytesPerSecond:   1024,
+		DownloadBytesPerSecond: 0,
+		KeyPartsJson:           `[{"source":"header","name":"x-forwarded-for"}]`,
+	})
+	if err == nil {
+		t.Fatal("expected stored per-key unsafe forwarding header key part to be rejected")
+	}
+	if !strings.Contains(err.Error(), "traffic shaper header key part must not use forwarding or client IP headers; use REMOTE_IP") {
+		t.Fatalf("unexpected stored-row error: %v", err)
+	}
+}
+
+func TestPublicTrafficShaperStoredPerRequestIgnoresUnsafeForwardingHeaderKeyPart(t *testing.T) {
+	rule, err := publicTrafficShaperRuleRowToConfig(db.PublicTrafficShaperRule{
+		Name:                   "stored-per-request",
+		BudgetScope:            publicTrafficShaperBudgetScopePerRequest,
+		UploadBytesPerSecond:   1024,
+		DownloadBytesPerSecond: 0,
+		KeyPartsJson:           `[{"source":"header","name":"x-forwarded-for"}]`,
+	})
+	if err != nil {
+		t.Fatalf("stored per-request shaper should ignore unsafe key parts: %v", err)
+	}
+	if rule.KeyParts != nil {
+		t.Fatalf("per-request key parts = %#v, want nil", rule.KeyParts)
+	}
+}
+
 func TestPublicTrafficShaperPrunesIdlePerKeyBuckets(t *testing.T) {
 	shaper := newPublicTrafficShaper()
 	listener := publicListenerConfig{ID: 1, Protocol: publicListenerProtocolHTTP}

--- a/internal/server/public_waf.go
+++ b/internal/server/public_waf.go
@@ -589,6 +589,10 @@ func publicWafRuleRowToConfig(row db.PublicWafRule) (publicWafRuleConfig, error)
 			return publicWafRuleConfig{}, err
 		}
 	}
+	keyParts, err = validateStoredRateLimitClientIdentityKeyParts(keyParts)
+	if err != nil {
+		return publicWafRuleConfig{}, err
+	}
 	var blockHeaders []publicRateLimitResponseHeaderConfig
 	if strings.TrimSpace(row.BlockResponseHeadersJson) != "" {
 		if err := json.Unmarshal([]byte(row.BlockResponseHeadersJson), &blockHeaders); err != nil {
@@ -910,7 +914,7 @@ func (a *App) validatePublicWafRuleInput(
 	if err != nil {
 		return publicWafRuleMutationInput{}, err
 	}
-	keyPartConfig, err := validateRateLimitKeyParts(keyParts)
+	keyPartConfig, err := validateRateLimitClientIdentityKeyParts(keyParts)
 	if err != nil {
 		return publicWafRuleMutationInput{}, err
 	}

--- a/internal/server/public_waf_test.go
+++ b/internal/server/public_waf_test.go
@@ -1174,6 +1174,91 @@ func TestPublicWafValidationRequiresEnabledCaptchaProvider(t *testing.T) {
 	}
 }
 
+func TestPublicWafValidationRejectsUnsafeForwardingHeaderKeyParts(t *testing.T) {
+	app := NewApp(nil, newServerTestDB(t))
+	for _, header := range []string{"X-Forwarded-For", "x-real-ip", "CF-Connecting-IP"} {
+		_, err := app.validatePublicWafRuleInput(
+			context.Background(),
+			"unsafe-key",
+			100,
+			true,
+			p2pstreamv1.PublicWafRuleAction_PUBLIC_WAF_RULE_ACTION_BLOCK,
+			p2pstreamv1.PublicWafActivationMode_PUBLIC_WAF_ACTIVATION_MODE_ALWAYS,
+			[]*p2pstreamv1.PublicRateLimitKeyPart{{
+				Source: p2pstreamv1.PublicRateLimitKeySource_PUBLIC_RATE_LIMIT_KEY_SOURCE_HEADER,
+				Name:   header,
+			}},
+			0,
+			0,
+			nil,
+			nil,
+			0,
+			"",
+			p2pstreamv1.PublicResponseBodyMode_PUBLIC_RESPONSE_BODY_MODE_INLINE,
+			0,
+			0,
+			0,
+			"",
+			nil,
+			nil,
+		)
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Fatalf("header %q: expected invalid argument, got %v", header, err)
+		}
+		if !strings.Contains(err.Error(), "rate limit header key part must not use forwarding or client IP headers; use REMOTE_IP") {
+			t.Fatalf("header %q: unexpected error %v", header, err)
+		}
+	}
+}
+
+func TestPublicWafValidationAllowsApplicationHeaderKeyPart(t *testing.T) {
+	app := NewApp(nil, newServerTestDB(t))
+	params, err := app.validatePublicWafRuleInput(
+		context.Background(),
+		"safe-key",
+		100,
+		true,
+		p2pstreamv1.PublicWafRuleAction_PUBLIC_WAF_RULE_ACTION_BLOCK,
+		p2pstreamv1.PublicWafActivationMode_PUBLIC_WAF_ACTIVATION_MODE_ALWAYS,
+		[]*p2pstreamv1.PublicRateLimitKeyPart{{
+			Source: p2pstreamv1.PublicRateLimitKeySource_PUBLIC_RATE_LIMIT_KEY_SOURCE_HEADER,
+			Name:   "x-plan",
+		}},
+		0,
+		0,
+		nil,
+		nil,
+		0,
+		"",
+		p2pstreamv1.PublicResponseBodyMode_PUBLIC_RESPONSE_BODY_MODE_INLINE,
+		0,
+		0,
+		0,
+		"",
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("validate application header key part: %v", err)
+	}
+	if !strings.Contains(params.KeyPartsJSON, `"name":"X-Plan"`) {
+		t.Fatalf("key parts json = %q, want canonical X-Plan", params.KeyPartsJSON)
+	}
+}
+
+func TestPublicWafStoredRuleRejectsUnsafeForwardingHeaderKeyPart(t *testing.T) {
+	_, err := publicWafRuleRowToConfig(db.PublicWafRule{
+		Name:         "stored-unsafe",
+		KeyPartsJson: `[{"source":"header","name":"x-forwarded-for"}]`,
+	})
+	if err == nil {
+		t.Fatal("expected stored unsafe forwarding header key part to be rejected")
+	}
+	if !strings.Contains(err.Error(), "rate limit header key part must not use forwarding or client IP headers; use REMOTE_IP") {
+		t.Fatalf("unexpected stored-row error: %v", err)
+	}
+}
+
 func TestPublicWafTriggerValidationPreservesDisabledSignals(t *testing.T) {
 	cfg, err := validatePublicWafTriggers(&p2pstreamv1.PublicWafTriggerConfig{
 		RequestWindowMillis:       10000,

--- a/internal/server/rate_limiter.go
+++ b/internal/server/rate_limiter.go
@@ -490,6 +490,10 @@ func publicRateLimitRuleRowToConfig(row db.PublicRateLimitRule) (publicRateLimit
 			return publicRateLimitRuleConfig{}, err
 		}
 	}
+	keyParts, err = validateStoredRateLimitClientIdentityKeyParts(keyParts)
+	if err != nil {
+		return publicRateLimitRuleConfig{}, err
+	}
 	var responseHeaders []publicRateLimitResponseHeaderConfig
 	if strings.TrimSpace(row.ResponseHeadersJson) != "" {
 		if err := json.Unmarshal([]byte(row.ResponseHeadersJson), &responseHeaders); err != nil {
@@ -620,7 +624,7 @@ func validatePublicRateLimitRuleInput(
 	if err != nil {
 		return publicRateLimitRuleMutationInput{}, err
 	}
-	keyPartConfig, err := validateRateLimitKeyParts(keyParts)
+	keyPartConfig, err := validateRateLimitClientIdentityKeyParts(keyParts)
 	if err != nil {
 		return publicRateLimitRuleMutationInput{}, err
 	}
@@ -724,6 +728,106 @@ func validateRateLimitKeyParts(parts []*p2pstreamv1.PublicRateLimitKeyPart) ([]p
 		resp = append(resp, publicRateLimitKeyPartConfig{Source: publicRateLimitKeySourceRemoteIP})
 	}
 	return resp, nil
+}
+
+func validateRateLimitClientIdentityKeyParts(parts []*p2pstreamv1.PublicRateLimitKeyPart) ([]publicRateLimitKeyPartConfig, error) {
+	config, err := validateRateLimitKeyParts(parts)
+	if err != nil {
+		return nil, err
+	}
+	return validateRateLimitClientIdentityKeyPartConfig(config)
+}
+
+func validateStoredRateLimitClientIdentityKeyParts(parts []publicRateLimitKeyPartConfig) ([]publicRateLimitKeyPartConfig, error) {
+	config, err := validateStoredRateLimitKeyParts(parts)
+	if err != nil {
+		return nil, err
+	}
+	return validateRateLimitClientIdentityKeyPartConfig(config)
+}
+
+func validateStoredRateLimitKeyParts(parts []publicRateLimitKeyPartConfig) ([]publicRateLimitKeyPartConfig, error) {
+	if len(parts) == 0 {
+		return []publicRateLimitKeyPartConfig{{Source: publicRateLimitKeySourceRemoteIP}}, nil
+	}
+	if len(parts) > maxRateLimitKeyParts {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("rate limit rule has too many key parts"))
+	}
+	resp := make([]publicRateLimitKeyPartConfig, 0, len(parts))
+	for _, part := range parts {
+		source := strings.TrimSpace(part.Source)
+		name := strings.TrimSpace(part.Name)
+		if !validStoredRateLimitKeySource(source) {
+			return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("rate limit key source is invalid"))
+		}
+		switch source {
+		case publicRateLimitKeySourceHeader:
+			if name == "" {
+				return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("rate limit header key part requires a name"))
+			}
+			name = textproto.CanonicalMIMEHeaderKey(name)
+			if !validHTTPToken(name) {
+				return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("rate limit header key part name is invalid"))
+			}
+		case publicRateLimitKeySourceCookie, publicRateLimitKeySourceQueryParam:
+			if name == "" {
+				return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("rate limit cookie and query key parts require a name"))
+			}
+		default:
+			name = ""
+		}
+		resp = append(resp, publicRateLimitKeyPartConfig{Source: source, Name: name})
+	}
+	if len(resp) == 0 {
+		resp = append(resp, publicRateLimitKeyPartConfig{Source: publicRateLimitKeySourceRemoteIP})
+	}
+	return resp, nil
+}
+
+func validateRateLimitClientIdentityKeyPartConfig(parts []publicRateLimitKeyPartConfig) ([]publicRateLimitKeyPartConfig, error) {
+	for _, part := range parts {
+		if part.Source == publicRateLimitKeySourceHeader && unsafeForwardingKeyPartHeader(part.Name) {
+			return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("rate limit header key part must not use forwarding or client IP headers; use REMOTE_IP"))
+		}
+	}
+	return parts, nil
+}
+
+func validStoredRateLimitKeySource(source string) bool {
+	switch source {
+	case publicRateLimitKeySourceRemoteIP,
+		publicRateLimitKeySourceHost,
+		publicRateLimitKeySourceMethod,
+		publicRateLimitKeySourcePath,
+		publicRateLimitKeySourceProtocol,
+		publicRateLimitKeySourceHeader,
+		publicRateLimitKeySourceCookie,
+		publicRateLimitKeySourceQueryParam:
+		return true
+	default:
+		return false
+	}
+}
+
+func unsafeForwardingKeyPartHeader(name string) bool {
+	normalized := strings.ToLower(textproto.CanonicalMIMEHeaderKey(strings.TrimSpace(name)))
+	switch normalized {
+	case "forwarded",
+		"x-forwarded-for",
+		"x-forwarded-host",
+		"x-forwarded-proto",
+		"x-forwarded-port",
+		"x-real-ip",
+		"client-ip",
+		"true-client-ip",
+		"cf-connecting-ip",
+		"fastly-client-ip",
+		"x-client-ip",
+		"x-cluster-client-ip":
+		return true
+	default:
+		return false
+	}
 }
 
 func validateRateLimitResponseHeaders(headers []*p2pstreamv1.PublicRateLimitResponseHeader) ([]publicRateLimitResponseHeaderConfig, error) {

--- a/internal/server/rate_limiter_test.go
+++ b/internal/server/rate_limiter_test.go
@@ -5,12 +5,14 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"connectrpc.com/connect"
 
 	p2pstreamv1 "p2pstream/gen/proto/p2pstream/v1"
+	"p2pstream/internal/db"
 )
 
 func TestPublicRateLimiterAlgorithms(t *testing.T) {
@@ -215,6 +217,155 @@ func TestPublicRateLimitValidationRejectsUnsafeInput(t *testing.T) {
 	}
 }
 
+func TestUnsafeForwardingKeyPartHeader(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "Forwarded", want: true},
+		{name: "forwarded", want: true},
+		{name: "X-Forwarded-For", want: true},
+		{name: "x-forwarded-for", want: true},
+		{name: "X-Real-IP", want: true},
+		{name: "x-real-ip", want: true},
+		{name: "X-FoRwArDeD-PoRt", want: true},
+		{name: "CF-Connecting-IP", want: true},
+		{name: "X-Plan", want: false},
+		{name: "X-User", want: false},
+	}
+	for _, tt := range tests {
+		if got := unsafeForwardingKeyPartHeader(tt.name); got != tt.want {
+			t.Fatalf("unsafeForwardingKeyPartHeader(%q) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestPublicRateLimitValidationRejectsUnsafeForwardingHeaderKeyParts(t *testing.T) {
+	for _, header := range []string{
+		"Forwarded",
+		"X-Forwarded-For",
+		"X-Forwarded-Host",
+		"X-Forwarded-Proto",
+		"X-Forwarded-Port",
+		"x-real-ip",
+		"Client-IP",
+		"True-Client-IP",
+		"CF-Connecting-IP",
+		"Fastly-Client-IP",
+		"X-Client-IP",
+		"X-Cluster-Client-IP",
+	} {
+		_, err := validatePublicRateLimitRuleInput(
+			"unsafe-key",
+			100,
+			true,
+			p2pstreamv1.PublicRateLimitAlgorithm_PUBLIC_RATE_LIMIT_ALGORITHM_FIXED_WINDOW,
+			10,
+			1000,
+			0,
+			[]*p2pstreamv1.PublicRateLimitKeyPart{{
+				Source: p2pstreamv1.PublicRateLimitKeySource_PUBLIC_RATE_LIMIT_KEY_SOURCE_HEADER,
+				Name:   header,
+			}},
+			429,
+			"",
+			p2pstreamv1.PublicResponseBodyMode_PUBLIC_RESPONSE_BODY_MODE_INLINE,
+			0,
+			"",
+			nil,
+			nil,
+		)
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Fatalf("header %q: expected invalid argument, got %v", header, err)
+		}
+		if !strings.Contains(err.Error(), "rate limit header key part must not use forwarding or client IP headers; use REMOTE_IP") {
+			t.Fatalf("header %q: unexpected error %v", header, err)
+		}
+	}
+}
+
+func TestPublicRateLimitValidationAllowsApplicationHeaderKeyPart(t *testing.T) {
+	params, err := validatePublicRateLimitRuleInput(
+		"safe-key",
+		100,
+		true,
+		p2pstreamv1.PublicRateLimitAlgorithm_PUBLIC_RATE_LIMIT_ALGORITHM_FIXED_WINDOW,
+		10,
+		1000,
+		0,
+		[]*p2pstreamv1.PublicRateLimitKeyPart{{
+			Source: p2pstreamv1.PublicRateLimitKeySource_PUBLIC_RATE_LIMIT_KEY_SOURCE_HEADER,
+			Name:   "x-plan",
+		}},
+		429,
+		"",
+		p2pstreamv1.PublicResponseBodyMode_PUBLIC_RESPONSE_BODY_MODE_INLINE,
+		0,
+		"",
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("validate application header key part: %v", err)
+	}
+	if !strings.Contains(params.KeyPartsJSON, `"name":"X-Plan"`) {
+		t.Fatalf("key parts json = %q, want canonical X-Plan", params.KeyPartsJSON)
+	}
+
+	params, err = validatePublicRateLimitRuleInput(
+		"default-key",
+		100,
+		true,
+		p2pstreamv1.PublicRateLimitAlgorithm_PUBLIC_RATE_LIMIT_ALGORITHM_FIXED_WINDOW,
+		10,
+		1000,
+		0,
+		nil,
+		429,
+		"",
+		p2pstreamv1.PublicResponseBodyMode_PUBLIC_RESPONSE_BODY_MODE_INLINE,
+		0,
+		"",
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("validate default remote IP key part: %v", err)
+	}
+	if !strings.Contains(params.KeyPartsJSON, `"source":"remote_ip"`) {
+		t.Fatalf("key parts json = %q, want remote_ip", params.KeyPartsJSON)
+	}
+}
+
+func TestPublicRateLimitStoredRuleRejectsUnsafeForwardingHeaderKeyPart(t *testing.T) {
+	_, err := publicRateLimitRuleRowToConfig(db.PublicRateLimitRule{
+		Name:         "stored-unsafe",
+		KeyPartsJson: `[{"source":"header","name":"x-forwarded-for"}]`,
+	})
+	if err == nil {
+		t.Fatal("expected stored unsafe forwarding header key part to be rejected")
+	}
+	if !strings.Contains(err.Error(), "rate limit header key part must not use forwarding or client IP headers; use REMOTE_IP") {
+		t.Fatalf("unexpected stored-row error: %v", err)
+	}
+}
+
+func TestPublicRateLimitRemoteIPKeyUsesRemoteAddr(t *testing.T) {
+	rule := testRateLimitRule(publicRateLimitAlgorithmFixedWindow, 10, 1000, 0)
+	rule.KeyParts = []publicRateLimitKeyPartConfig{{Source: publicRateLimitKeySourceRemoteIP}}
+	listener := publicListenerConfig{ID: 1, Protocol: publicListenerProtocolHTTP}
+	req := testRateLimitRequest("GET", "http://example.com/api", "198.51.100.9:1234")
+	req.Header.Set("X-Forwarded-For", "203.0.113.9")
+
+	values := rule.keyValues(listener, req)
+	if !rateLimitTestValuesContain(values, "198.51.100.9") {
+		t.Fatalf("key values = %#v, want remote addr IP", values)
+	}
+	if rateLimitTestValuesContain(values, "203.0.113.9") {
+		t.Fatalf("key values = %#v, used spoofed X-Forwarded-For", values)
+	}
+}
+
 func TestPublicRateLimitResponseUsesGeneratedHeaders(t *testing.T) {
 	rule := testRateLimitRule(publicRateLimitAlgorithmFixedWindow, 1, 1000, 0)
 	rule.ResponseHeaders = []publicRateLimitResponseHeaderConfig{
@@ -325,4 +476,13 @@ func testRateLimitRequest(method string, target string, remoteAddr string) *http
 	req := httptest.NewRequest(method, target, nil)
 	req.RemoteAddr = remoteAddr
 	return req
+}
+
+func rateLimitTestValuesContain(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary

- reject forwarding/client-IP headers as rate-limit key parts on create/update and stored-row load
- apply the same strict validation to per-key traffic shapers while preserving per-request key-part ignore behavior
- keep arbitrary application headers such as `X-Plan` valid as key parts
- document the denylist, preflight SQL, and trusted-proxy follow-up guidance

## Compatibility

Existing rate-limit or per-key traffic-shaper rules using forwarding/client-IP headers now fail validation/load closed. Operators should migrate those key parts to `REMOTE_IP` or trusted application headers. Trusted-proxy parsing remains out of scope.

## Tests

- `go test ./internal/server -run 'RateLimit|TrafficShaper|Policy'`
- `go test ./internal/server`
- `git diff --check -- internal/server/rate_limiter.go internal/server/public_traffic_shaper.go internal/server/rate_limiter_test.go internal/server/public_traffic_shaper_test.go docs/reference/rate-limits.md docs/reference/traffic-shaping.md docs/operations/security-hardening.md docs/operations/troubleshooting.md`
