### PR TITLE
security: serialize agent token rotation with tunnel registration

### DIFF
--- a/internal/server/agent_registry.go
+++ b/internal/server/agent_registry.go
@@ -172,6 +172,9 @@ func (a *App) RotateAgentToken(
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
+	unlock := a.lockAgentAuth(req.Msg.Id)
+	defer unlock()
+
 	agent, err := a.DB.UpdateAgentToken(ctx, db.UpdateAgentTokenParams{
 		ID:        req.Msg.Id,
 		TokenHash: tokenHash,

--- a/internal/server/agent_registry_test.go
+++ b/internal/server/agent_registry_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -319,6 +321,124 @@ func TestRotateAgentTokenClosesTunnelConnection(t *testing.T) {
 	waitForAgentHubConnection(t, app, agent.ID, true)
 }
 
+func TestAgentTunnelRechecksTokenBeforeRegisteringAfterRotation(t *testing.T) {
+	database := newAgentRegistryTestDB(t)
+	app := NewApp(&config.Config{ManagementUIDisabled: true}, database)
+	header := createTestAdminSession(t, app)
+	agent := createAgentRegistryTestAgent(t, database, "agent-tunnel-reauth-rotation", "Reauth Rotation", "old-token")
+	mux := http.NewServeMux()
+	app.RegisterManagementRoutes(mux)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	initialAuthDone := make(chan struct{})
+	releaseFinalAuth := make(chan struct{})
+	var hookOnce sync.Once
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() {
+		close(releaseFinalAuth)
+	})
+	app.agentTunnelBeforeFinalAuth = func(row db.Agent) {
+		if row.ID != agent.ID {
+			return
+		}
+		hookOnce.Do(func() {
+			close(initialAuthDone)
+			<-releaseFinalAuth
+		})
+	}
+
+	type dialResult struct {
+		session *yamux.Session
+		conn    net.Conn
+		err     error
+	}
+	dialDone := make(chan dialResult, 1)
+	go func() {
+		session, conn, err := dialAgentRegistryTestTunnel(server.URL, agent.PublicID, "old-token")
+		dialDone <- dialResult{session: session, conn: conn, err: err}
+	}()
+
+	select {
+	case <-initialAuthDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for tunnel initial auth")
+	}
+
+	rotateResp := rotateAgentTokenForTest(t, app, header, agent.ID)
+	releaseOnce.Do(func() {
+		close(releaseFinalAuth)
+	})
+
+	var result dialResult
+	select {
+	case result = <-dialDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for old-token tunnel result")
+	}
+	if result.session != nil {
+		result.session.Close()
+	}
+	if result.conn != nil {
+		result.conn.Close()
+	}
+	if result.err == nil {
+		t.Fatal("old-token tunnel registered after rotation")
+	}
+	if !strings.Contains(result.err.Error(), "401") {
+		t.Fatalf("old-token tunnel error = %v, want status 401", result.err)
+	}
+	if got := app.AgentHub.connectedByID(agent.ID); got != nil {
+		t.Fatalf("old-token tunnel registered in hub = %#v", got)
+	}
+
+	newSession, newConn, err := dialAgentRegistryTestTunnel(server.URL, agent.PublicID, rotateResp.Msg.Token)
+	if err != nil {
+		t.Fatalf("new token did not connect after rotation: %v", err)
+	}
+	defer newConn.Close()
+	defer newSession.Close()
+	waitForAgentHubConnection(t, app, agent.ID, true)
+}
+
+func TestAgentTunnelFinalAuthLockReleasedAfterHijackFailure(t *testing.T) {
+	database := newAgentRegistryTestDB(t)
+	app := NewApp(&config.Config{ManagementUIDisabled: true}, database)
+	header := createTestAdminSession(t, app)
+	agent := createAgentRegistryTestAgent(t, database, "agent-tunnel-hijack-failure", "Hijack Failure", "token")
+
+	req := httptest.NewRequest(http.MethodGet, tunnel.BootstrapPath, nil)
+	req.Header.Set("X-P2PStream-Agent-ID", agent.PublicID)
+	req.Header.Set("Authorization", "Bearer token")
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", tunnel.UpgradeToken)
+	req.Header.Set(tunnel.TunnelVersionHeader, "1")
+	rw := &failingHijackResponseWriter{}
+
+	app.agentTunnelHandler(rw, req)
+
+	if got := app.AgentHub.connectedByID(agent.ID); got != nil {
+		t.Fatalf("agent registered after hijack failure = %#v", got)
+	}
+
+	rotateDone := make(chan error, 1)
+	go func() {
+		rotateReq := connect.NewRequest(&p2pstreamv1.RotateAgentTokenRequest{Id: agent.ID})
+		rotateReq.Header().Set("Cookie", header.Get("Cookie"))
+		_, err := app.RotateAgentToken(context.Background(), rotateReq)
+		rotateDone <- err
+	}()
+
+	select {
+	case err := <-rotateDone:
+		if err != nil {
+			t.Fatalf("rotate token after hijack failure: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("rotation blocked after failed tunnel hijack")
+	}
+}
+
 func TestAgentTunnelRejectsMissingUpgrade(t *testing.T) {
 	database := newAgentRegistryTestDB(t)
 	app := NewApp(&config.Config{ManagementUIDisabled: true}, database)
@@ -544,4 +664,29 @@ func waitForConnectionDisconnected(t *testing.T, database *db.DB, connID int64) 
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("connection %d disconnected_at was not set", connID)
+}
+
+type failingHijackResponseWriter struct {
+	header http.Header
+	status int
+	body   strings.Builder
+}
+
+func (w *failingHijackResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+	return w.header
+}
+
+func (w *failingHijackResponseWriter) WriteHeader(status int) {
+	w.status = status
+}
+
+func (w *failingHijackResponseWriter) Write(p []byte) (int, error) {
+	return w.body.Write(p)
+}
+
+func (w *failingHijackResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return nil, nil, errors.New("hijack failed")
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -53,6 +53,7 @@ type App struct {
 	AgentTransports    *agentTransportPool
 	DashboardCache     *dashboardResponseCache
 	LoginThrottle      *loginThrottle
+	agentAuthLocks     *agentAuthLockMap
 
 	ProxyIsRunning atomic.Bool
 	ProxyLastError atomic.Pointer[string]
@@ -74,6 +75,40 @@ type App struct {
 
 	observabilityMu          sync.Mutex
 	observabilityLastCleanup time.Time
+
+	agentTunnelBeforeFinalAuth func(db.Agent)
+}
+
+type agentAuthLockMap struct {
+	mu    sync.Mutex
+	locks map[int64]*sync.Mutex
+}
+
+func newAgentAuthLockMap() *agentAuthLockMap {
+	return &agentAuthLockMap{locks: make(map[int64]*sync.Mutex)}
+}
+
+func (m *agentAuthLockMap) lock(agentID int64) func() {
+	if m == nil {
+		return func() {}
+	}
+	m.mu.Lock()
+	lock := m.locks[agentID]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		m.locks[agentID] = lock
+	}
+	m.mu.Unlock()
+
+	lock.Lock()
+	return lock.Unlock
+}
+
+func (a *App) lockAgentAuth(agentID int64) func() {
+	if a == nil || a.agentAuthLocks == nil {
+		return func() {}
+	}
+	return a.agentAuthLocks.lock(agentID)
 }
 
 func NewApp(cfg *config.Config, database *db.DB) *App {
@@ -95,6 +130,7 @@ func NewApp(cfg *config.Config, database *db.DB) *App {
 		AgentTransports:     newAgentTransportPool(),
 		DashboardCache:      newDashboardResponseCache(),
 		LoginThrottle:       newLoginThrottle(cfg.LoginThrottleMaxKeys),
+		agentAuthLocks:      newAgentAuthLockMap(),
 		latestAgentStats:    make(map[int64]stats.AgentStats),
 		proxyState:          p2pstreamv1.ProxyState_PROXY_STATE_STOPPED,
 		publicListenerState: make(map[int64]*publicListenerRuntime),
@@ -272,7 +308,9 @@ func (a *App) statusResponse() *p2pstreamv1.GetStatusResponse {
 }
 
 func (a *App) agentTunnelHandler(w http.ResponseWriter, r *http.Request) {
-	agentRow, err := a.authenticateAgent(r.Context(), r.Header.Get("X-P2PStream-Agent-ID"), r.Header.Get("Authorization"))
+	publicID := r.Header.Get("X-P2PStream-Agent-ID")
+	authorization := r.Header.Get("Authorization")
+	agentRow, err := a.authenticateAgent(r.Context(), publicID, authorization)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return
@@ -295,6 +333,31 @@ func (a *App) agentTunnelHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "agent tunnel requires HTTP/1.1 hijack support", http.StatusInternalServerError)
 		return
 	}
+
+	if a.agentTunnelBeforeFinalAuth != nil {
+		a.agentTunnelBeforeFinalAuth(agentRow)
+	}
+
+	unlock := a.lockAgentAuth(agentRow.ID)
+	locked := true
+	unlockAgentAuth := func() {
+		if locked {
+			locked = false
+			unlock()
+		}
+	}
+	defer unlockAgentAuth()
+
+	finalAgentRow, err := a.authenticateAgent(r.Context(), publicID, authorization)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	if finalAgentRow.ID != agentRow.ID {
+		http.Error(w, "agent identity changed", http.StatusUnauthorized)
+		return
+	}
+	agentRow = finalAgentRow
 
 	if existing := a.AgentHub.connectedByID(agentRow.ID); existing != nil {
 		log.Warn().Str("agent", agentRow.PublicID).Msg("Rejecting duplicate agent connection")
@@ -364,6 +427,8 @@ func (a *App) agentTunnelHandler(w http.ResponseWriter, r *http.Request) {
 		log.Warn().Err(err).Str("agent", agent.PublicID).Msg("Rejecting duplicate agent connection")
 		return
 	}
+	unlockAgentAuth()
+
 	cleanupAgent := func() {
 		a.AgentHub.disconnect(agent)
 		if a.TargetHealth != nil {


### PR DESCRIPTION
## Summary
- add per-agent in-process serialization for final tunnel auth/registration and token rotation
- re-authenticate tunnel requests under the per-agent lock immediately before registration
- keep rotation revocation and transport closure under the same lock
- add regression tests for old-token in-flight registration and lock release after hijack failure

## Tests
- go test ./internal/server -run 'Agent|Tunnel|Rotate'\n- go test ./internal/server\n- git diff --check -- internal/server/server.go internal/server/agent_registry.go internal/server/agent_registry_test.go\n\n## Notes\n- This is an in-process lock. Multi-process deployments sharing one DB still need a future DB-backed token generation or transactional registration design.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added concurrent access protection during agent token rotation to improve reliability and security.
  * Enhanced tunnel connection verification and re-authentication during setup.

* **Tests**
  * Added test coverage for token validation in tunnel scenarios.
  * Added test coverage for error handling during tunnel establishment failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->