### PR TITLE
security: protect blocked login throttle keys

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -36,7 +36,7 @@ Set these on the server process via `.env` or environment. They control manageme
 | `BOOTSTRAP_AGENT_TOKEN`          | empty                        | Bootstrap agent token. Stored as a hash.                                                     |
 | `OBSERVABILITY_RETENTION_DAYS`   | `30`                         | Retention window for recorded observability data.                                            |
 | `OBSERVABILITY_MAX_ROWS`         | `1000000`                    | Maximum retained proxy request events and agent stat rows. Set `0` to disable this cap.       |
-| `LOGIN_THROTTLE_MAX_KEYS`        | `50000`                      | Maximum in-memory login throttle keys before oldest-key eviction.                            |
+| `LOGIN_THROTTLE_MAX_KEYS`        | `50000`                      | Maximum in-memory login throttle keys; active blocks are retained until expiry.              |
 
 ### Agent Variables
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -38,6 +38,8 @@ Set these on the server process via `.env` or environment. They control manageme
 | `OBSERVABILITY_MAX_ROWS`         | `1000000`                    | Maximum retained proxy request events and agent stat rows. Set `0` to disable this cap.       |
 | `LOGIN_THROTTLE_MAX_KEYS`        | `50000`                      | Maximum in-memory login throttle keys; active blocks are retained until expiry.              |
 
+If every login throttle slot is occupied by an active block, new failed-login keys are not tracked until a blocked key expires or a login succeeds for an existing key.
+
 ### Agent Variables
 
 Set these on each agent host via `/etc/p2pstream/agent.env` or the generated installer environment. The agent installer writes these automatically from the setup dialog.

--- a/internal/server/login_throttle.go
+++ b/internal/server/login_throttle.go
@@ -87,6 +87,7 @@ func (t *loginThrottle) evictOldestUnlockedEntryLocked(now time.Time) bool {
 	var oldestKey string
 	var oldestStart time.Time
 	for key, entry := range t.entries {
+		// recordFailure prunes before eviction; keep these checks defensive for callers that do not.
 		if entry == nil {
 			delete(t.entries, key)
 			return true

--- a/internal/server/login_throttle.go
+++ b/internal/server/login_throttle.go
@@ -59,10 +59,12 @@ func (t *loginThrottle) recordFailure(key string, now time.Time) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	entry := t.entries[key]
-	if entry == nil || now.Sub(entry.windowStart) > loginThrottleWindow {
+	if entry == nil || (!loginThrottleEntryBlocked(entry, now) && loginThrottleEntryExpired(entry, now)) {
 		t.pruneLocked(now)
 		if len(t.entries) >= t.maxEntries {
-			t.evictOldestLocked()
+			if !t.evictOldestUnlockedEntryLocked(now) {
+				return
+			}
 		}
 		entry = &loginThrottleEntry{windowStart: now}
 		t.entries[key] = entry
@@ -75,19 +77,26 @@ func (t *loginThrottle) recordFailure(key string, now time.Time) {
 
 func (t *loginThrottle) pruneLocked(now time.Time) {
 	for key, entry := range t.entries {
-		if entry == nil || now.Sub(entry.windowStart) > loginThrottleWindow {
+		if entry == nil || (!loginThrottleEntryBlocked(entry, now) && loginThrottleEntryExpired(entry, now)) {
 			delete(t.entries, key)
 		}
 	}
 }
 
-func (t *loginThrottle) evictOldestLocked() {
+func (t *loginThrottle) evictOldestUnlockedEntryLocked(now time.Time) bool {
 	var oldestKey string
 	var oldestStart time.Time
 	for key, entry := range t.entries {
 		if entry == nil {
 			delete(t.entries, key)
-			return
+			return true
+		}
+		if !loginThrottleEntryBlocked(entry, now) && loginThrottleEntryExpired(entry, now) {
+			delete(t.entries, key)
+			return true
+		}
+		if loginThrottleEntryBlocked(entry, now) {
+			continue
 		}
 		if oldestKey == "" || entry.windowStart.Before(oldestStart) {
 			oldestKey = key
@@ -96,7 +105,17 @@ func (t *loginThrottle) evictOldestLocked() {
 	}
 	if oldestKey != "" {
 		delete(t.entries, oldestKey)
+		return true
 	}
+	return false
+}
+
+func loginThrottleEntryBlocked(entry *loginThrottleEntry, now time.Time) bool {
+	return entry != nil && !entry.blockedUntil.IsZero() && now.Before(entry.blockedUntil)
+}
+
+func loginThrottleEntryExpired(entry *loginThrottleEntry, now time.Time) bool {
+	return entry == nil || now.Sub(entry.windowStart) > loginThrottleWindow
 }
 
 func (t *loginThrottle) recordSuccess(key string) {

--- a/internal/server/login_throttle_test.go
+++ b/internal/server/login_throttle_test.go
@@ -24,6 +24,80 @@ func TestLoginThrottleCapsEntries(t *testing.T) {
 	}
 }
 
+func TestLoginThrottleDoesNotEvictBlockedKey(t *testing.T) {
+	throttle := newLoginThrottle(3)
+	now := time.Unix(1, 0)
+	adminKey := loginThrottleKey("198.51.100.10:1234", "admin")
+	blockLoginThrottleKey(throttle, adminKey, now)
+
+	for i := 0; i < 10; i++ {
+		throttle.recordFailure(loginThrottleKey("198.51.100.10:1234", "filler"+strconv.Itoa(i)), now.Add(time.Duration(i+1)*time.Millisecond))
+	}
+
+	if retryAfter := throttle.retryAfter(adminKey, now.Add(time.Second)); retryAfter <= 0 {
+		t.Fatalf("admin retryAfter = %v, want active block", retryAfter)
+	}
+	throttle.mu.Lock()
+	defer throttle.mu.Unlock()
+	if got := len(throttle.entries); got > 3 {
+		t.Fatalf("entries = %d, want capped at 3", got)
+	}
+	if _, ok := throttle.entries[adminKey]; !ok {
+		t.Fatal("blocked admin key was evicted")
+	}
+}
+
+func TestLoginThrottleDropsNewKeyWhenAllEntriesBlocked(t *testing.T) {
+	throttle := newLoginThrottle(2)
+	now := time.Unix(1, 0)
+	firstKey := loginThrottleKey("198.51.100.10:1234", "admin")
+	secondKey := loginThrottleKey("198.51.100.10:1234", "operator")
+	thirdKey := loginThrottleKey("198.51.100.10:1234", "filler")
+
+	blockLoginThrottleKey(throttle, firstKey, now)
+	blockLoginThrottleKey(throttle, secondKey, now.Add(time.Millisecond))
+	throttle.recordFailure(thirdKey, now.Add(2*time.Millisecond))
+
+	if retryAfter := throttle.retryAfter(firstKey, now.Add(time.Second)); retryAfter <= 0 {
+		t.Fatalf("first retryAfter = %v, want active block", retryAfter)
+	}
+	if retryAfter := throttle.retryAfter(secondKey, now.Add(time.Second)); retryAfter <= 0 {
+		t.Fatalf("second retryAfter = %v, want active block", retryAfter)
+	}
+	throttle.mu.Lock()
+	defer throttle.mu.Unlock()
+	if got := len(throttle.entries); got != 2 {
+		t.Fatalf("entries = %d, want 2", got)
+	}
+	if _, ok := throttle.entries[thirdKey]; ok {
+		t.Fatal("new filler key was inserted by evicting an active block")
+	}
+}
+
+func TestLoginThrottleEvictsOldestNonBlockedKey(t *testing.T) {
+	throttle := newLoginThrottle(2)
+	now := time.Unix(1, 0)
+	oldKey := loginThrottleKey("198.51.100.10:1234", "old")
+	freshKey := loginThrottleKey("198.51.100.10:1234", "fresh")
+	newKey := loginThrottleKey("198.51.100.10:1234", "new")
+
+	throttle.recordFailure(oldKey, now)
+	throttle.recordFailure(freshKey, now.Add(time.Second))
+	throttle.recordFailure(newKey, now.Add(2*time.Second))
+
+	throttle.mu.Lock()
+	defer throttle.mu.Unlock()
+	if _, ok := throttle.entries[oldKey]; ok {
+		t.Fatal("oldest non-blocked key was not evicted")
+	}
+	if _, ok := throttle.entries[freshKey]; !ok {
+		t.Fatal("fresh non-blocked key was evicted")
+	}
+	if _, ok := throttle.entries[newKey]; !ok {
+		t.Fatal("new key was not inserted")
+	}
+}
+
 func TestLoginThrottlePrunesExpiredBeforeEviction(t *testing.T) {
 	throttle := newLoginThrottle(2)
 	old := time.Unix(1, 0)
@@ -40,5 +114,54 @@ func TestLoginThrottlePrunesExpiredBeforeEviction(t *testing.T) {
 	}
 	if got := len(throttle.entries); got > 2 {
 		t.Fatalf("entries = %d, want at most 2", got)
+	}
+}
+
+func TestLoginThrottlePrunesExpiredBlockedKey(t *testing.T) {
+	throttle := newLoginThrottle(1)
+	old := time.Unix(1, 0)
+	blockedKey := loginThrottleKey("198.51.100.10:1234", "admin")
+	newKey := loginThrottleKey("198.51.100.10:1234", "new")
+	blockLoginThrottleKey(throttle, blockedKey, old)
+
+	now := old.Add(loginThrottleWindow + loginThrottleBlock + time.Second)
+	throttle.recordFailure(newKey, now)
+
+	throttle.mu.Lock()
+	defer throttle.mu.Unlock()
+	if _, ok := throttle.entries[blockedKey]; ok {
+		t.Fatal("expired blocked key was not pruned")
+	}
+	if _, ok := throttle.entries[newKey]; !ok {
+		t.Fatal("new key was not inserted after pruning expired block")
+	}
+	if got := len(throttle.entries); got != 1 {
+		t.Fatalf("entries = %d, want 1", got)
+	}
+}
+
+func TestLoginThrottleRecordSuccessClearsKey(t *testing.T) {
+	throttle := newLoginThrottle(3)
+	now := time.Unix(1, 0)
+	key := loginThrottleKey("198.51.100.10:1234", "admin")
+	blockLoginThrottleKey(throttle, key, now)
+
+	if retryAfter := throttle.retryAfter(key, now.Add(time.Second)); retryAfter <= 0 {
+		t.Fatalf("retryAfter before success = %v, want active block", retryAfter)
+	}
+	throttle.recordSuccess(key)
+	if retryAfter := throttle.retryAfter(key, now.Add(time.Second)); retryAfter != 0 {
+		t.Fatalf("retryAfter after success = %v, want 0", retryAfter)
+	}
+	throttle.mu.Lock()
+	defer throttle.mu.Unlock()
+	if _, ok := throttle.entries[key]; ok {
+		t.Fatal("successful login did not clear throttle key")
+	}
+}
+
+func blockLoginThrottleKey(throttle *loginThrottle, key string, now time.Time) {
+	for i := 0; i < loginThrottleMaxFailures; i++ {
+		throttle.recordFailure(key, now)
 	}
 }


### PR DESCRIPTION
## Summary
- keep actively blocked login throttle entries non-evictable until `blockedUntil` expires
- evict nil, expired, or oldest non-blocked entries first when the throttle map is full
- drop new unique failure keys if every stored entry is actively blocked, preserving bounded memory
- add regression tests for blocked-key flooding, all-blocked capacity, expired blocks, and success clearing

## Tests
- go test ./internal/server -run 'Login|Throttle|Auth'\n- go test ./internal/server\n- git diff --check -- internal/server/login_throttle.go internal/server/login_throttle_test.go docs/reference/configuration.md\n\n## Notes\n- This remediates I-2 from the static audit.\n- Operational behavior change: when all stored throttle keys are active blocks, some new unique username failures are not recorded so existing blocks remain durable and memory stays bounded.\n