### PR TITLE
security: limit reserved WAF endpoints

### DIFF
--- a/internal/server/public_waf.go
+++ b/internal/server/public_waf.go
@@ -172,16 +172,17 @@ type publicWafRuleMutationInput struct {
 }
 
 type publicWAF struct {
-	mu                   sync.Mutex
-	rules                map[int64]*publicWafRuleRuntime
-	cookieSecret         atomic.Value // stores immutable []byte
-	proxyActiveRequests  atomic.Int64
-	captchaHTTPClient    *http.Client
-	captchaVerifyLimiter *publicWafCaptchaVerifyLimiter
-	captchaVerifySlots   chan struct{}
-	cpuSampler           *sysmetrics.ProcessCPUSampler
-	lastCPUSampleAt      time.Time
-	lastCPUPercent       float64
+	mu                      sync.Mutex
+	rules                   map[int64]*publicWafRuleRuntime
+	cookieSecret            atomic.Value // stores immutable []byte
+	proxyActiveRequests     atomic.Int64
+	captchaHTTPClient       *http.Client
+	captchaVerifyLimiter    *publicWafCaptchaVerifyLimiter
+	reservedEndpointLimiter *publicWafReservedEndpointLimiter
+	captchaVerifySlots      chan struct{}
+	cpuSampler              *sysmetrics.ProcessCPUSampler
+	lastCPUSampleAt         time.Time
+	lastCPUPercent          float64
 }
 
 type publicWafRuleRuntime struct {
@@ -216,11 +217,12 @@ type publicWafDecision struct {
 
 func newPublicWAF() *publicWAF {
 	return &publicWAF{
-		rules:                make(map[int64]*publicWafRuleRuntime),
-		captchaHTTPClient:    &http.Client{Timeout: publicWafChallengeTimeoutSeconds * time.Second},
-		captchaVerifyLimiter: newPublicWafCaptchaVerifyLimiter(),
-		captchaVerifySlots:   make(chan struct{}, publicWafCaptchaVerifyMaxConcurrentCalls),
-		cpuSampler:           sysmetrics.NewProcessCPUSampler(),
+		rules:                   make(map[int64]*publicWafRuleRuntime),
+		captchaHTTPClient:       &http.Client{Timeout: publicWafChallengeTimeoutSeconds * time.Second},
+		captchaVerifyLimiter:    newPublicWafCaptchaVerifyLimiter(),
+		reservedEndpointLimiter: newPublicWafReservedEndpointLimiter(),
+		captchaVerifySlots:      make(chan struct{}, publicWafCaptchaVerifyMaxConcurrentCalls),
+		cpuSampler:              sysmetrics.NewProcessCPUSampler(),
 	}
 }
 

--- a/internal/server/public_waf_captcha.go
+++ b/internal/server/public_waf_captcha.go
@@ -49,6 +49,12 @@ const (
 	publicWafCaptchaVerifyIdleTTL            = 15 * time.Minute
 	publicWafCaptchaVerifyPruneInterval      = time.Minute
 	publicWafCaptchaVerifyMaxConcurrentCalls = 32
+	publicWafReservedEndpointWindow          = time.Minute
+	publicWafReservedEndpointIPLimit         = 60
+	publicWafReservedEndpointPathLimit       = 1200
+	publicWafReservedEndpointMaxKeys         = publicWafCaptchaVerifyMaxKeys
+	publicWafReservedEndpointIdleTTL         = publicWafCaptchaVerifyIdleTTL
+	publicWafReservedEndpointPruneInterval   = publicWafCaptchaVerifyPruneInterval
 )
 
 var publicWafCaptchaVerifyEndpoints = map[string]string{
@@ -70,6 +76,9 @@ func (a *App) servePublicWAFReserved(w http.ResponseWriter, r *http.Request, lis
 	if !isPublicWAFReservedPath(r.URL.Path) {
 		return publicWafDecision{}, false
 	}
+	if decision, limited := a.rateLimitPublicWAFReservedEndpoint(w, r, listenerID); limited {
+		return decision, true
+	}
 	switch r.URL.Path {
 	case publicWafCaptchaVerifyPath:
 		return a.servePublicWAFCaptchaVerify(w, r, listenerID), true
@@ -79,6 +88,42 @@ func (a *App) servePublicWAFReserved(w http.ResponseWriter, r *http.Request, lis
 		http.NotFound(w, r)
 		return publicWafDecision{StatusCode: http.StatusNotFound, ErrorKind: "waf_reserved_not_found"}, true
 	}
+}
+
+func (a *App) rateLimitPublicWAFReservedEndpoint(w http.ResponseWriter, r *http.Request, listenerID int64) (publicWafDecision, bool) {
+	if a == nil || a.PublicWAF == nil || a.PublicWAF.reservedEndpointLimiter == nil {
+		return publicWafDecision{}, false
+	}
+	path := ""
+	if r != nil && r.URL != nil {
+		path = r.URL.Path
+	}
+	retryAfter, allowed := a.PublicWAF.reservedEndpointLimiter.allow(listenerID, path, remoteIPForRateLimit(r), time.Now())
+	if allowed {
+		return publicWafDecision{}, false
+	}
+	decision := publicWafReservedRateLimitDecision(listenerID, path, retryAfter)
+	w.Header().Set("Retry-After", captchaRetryAfterSeconds(retryAfter))
+	http.Error(w, "WAF reserved endpoint rate limit exceeded", http.StatusTooManyRequests)
+	return decision, true
+}
+
+func publicWafReservedRateLimitDecision(listenerID int64, path string, retryAfter time.Duration) publicWafDecision {
+	decision := publicWafDecision{
+		Listener:   publicListenerConfig{ID: listenerID},
+		StatusCode: http.StatusTooManyRequests,
+		ErrorKind:  "waf_reserved_rate_limited",
+		RetryAfter: retryAfter,
+	}
+	switch path {
+	case publicWafCaptchaVerifyPath:
+		decision.Action = publicWafActionCaptcha
+		decision.ChallengeKind = publicWafActionCaptcha
+	case publicWafWaitingRoomPath, publicWafWaitingRoomStatusPath:
+		decision.Action = publicWafActionWaitingRoom
+		decision.ChallengeKind = publicWafActionWaitingRoom
+	}
+	return decision
 }
 
 func (a *App) servePublicWAFCaptchaVerify(w http.ResponseWriter, r *http.Request, listenerID int64) publicWafDecision {

--- a/internal/server/public_waf_captcha_limiter.go
+++ b/internal/server/public_waf_captcha_limiter.go
@@ -8,18 +8,28 @@ import (
 
 type publicWafCaptchaVerifyLimiter struct {
 	mu        sync.Mutex
-	keys      map[string]*publicWafCaptchaVerifyBucket
+	keys      map[string]*publicWafFixedWindowBucket
 	lastPrune time.Time
 }
 
-type publicWafCaptchaVerifyBucket struct {
+type publicWafReservedEndpointLimiter struct {
+	mu        sync.Mutex
+	keys      map[string]*publicWafFixedWindowBucket
+	lastPrune time.Time
+}
+
+type publicWafFixedWindowBucket struct {
 	windowStart int64
 	count       int64
 	lastSeenAt  time.Time
 }
 
 func newPublicWafCaptchaVerifyLimiter() *publicWafCaptchaVerifyLimiter {
-	return &publicWafCaptchaVerifyLimiter{keys: make(map[string]*publicWafCaptchaVerifyBucket)}
+	return &publicWafCaptchaVerifyLimiter{keys: make(map[string]*publicWafFixedWindowBucket)}
+}
+
+func newPublicWafReservedEndpointLimiter() *publicWafReservedEndpointLimiter {
+	return &publicWafReservedEndpointLimiter{keys: make(map[string]*publicWafFixedWindowBucket)}
 }
 
 func (l *publicWafCaptchaVerifyLimiter) allow(listenerID int64, ruleID int64, remoteIP string, now time.Time) (time.Duration, bool) {
@@ -35,8 +45,8 @@ func (l *publicWafCaptchaVerifyLimiter) allow(listenerID int64, ruleID int64, re
 	ipBucket := l.bucketLocked(ipKey, now)
 	ruleBucket := l.bucketLocked(ruleKey, now)
 
-	ipRetryAfter, ipAllowed := ipBucket.canAllow(publicWafCaptchaVerifyIPLimit, now)
-	ruleRetryAfter, ruleAllowed := ruleBucket.canAllow(publicWafCaptchaVerifyRuleLimit, now)
+	ipRetryAfter, ipAllowed := ipBucket.canAllow(publicWafCaptchaVerifyIPLimit, publicWafCaptchaVerifyWindow, now)
+	ruleRetryAfter, ruleAllowed := ruleBucket.canAllow(publicWafCaptchaVerifyRuleLimit, publicWafCaptchaVerifyWindow, now)
 	if !ipAllowed || !ruleAllowed {
 		return maxDuration(ipRetryAfter, ruleRetryAfter), false
 	}
@@ -48,32 +58,32 @@ func (l *publicWafCaptchaVerifyLimiter) allow(listenerID int64, ruleID int64, re
 	return 0, true
 }
 
-func (l *publicWafCaptchaVerifyLimiter) bucketLocked(key string, now time.Time) *publicWafCaptchaVerifyBucket {
+func (l *publicWafCaptchaVerifyLimiter) bucketLocked(key string, now time.Time) *publicWafFixedWindowBucket {
 	bucket := l.keys[key]
 	if bucket == nil {
 		if len(l.keys) >= publicWafCaptchaVerifyMaxKeys {
 			l.evictOldestLocked()
 		}
-		bucket = &publicWafCaptchaVerifyBucket{}
+		bucket = &publicWafFixedWindowBucket{}
 		l.keys[key] = bucket
 	}
-	bucket.rollWindow(now)
+	bucket.rollWindow(publicWafCaptchaVerifyWindow, now)
 	bucket.lastSeenAt = now
 	return bucket
 }
 
-func (b *publicWafCaptchaVerifyBucket) canAllow(limit int64, now time.Time) (time.Duration, bool) {
-	b.rollWindow(now)
+func (b *publicWafFixedWindowBucket) canAllow(limit int64, window time.Duration, now time.Time) (time.Duration, bool) {
+	b.rollWindow(window, now)
 	if b.count < limit {
 		return 0, true
 	}
-	windowEnd := b.windowStart + publicWafCaptchaVerifyWindow.Milliseconds()
+	windowEnd := b.windowStart + window.Milliseconds()
 	retryAfter := time.Duration(maxInt64(1, windowEnd-now.UnixMilli())) * time.Millisecond
 	return retryAfter, false
 }
 
-func (b *publicWafCaptchaVerifyBucket) rollWindow(now time.Time) {
-	windowMs := publicWafCaptchaVerifyWindow.Milliseconds()
+func (b *publicWafFixedWindowBucket) rollWindow(window time.Duration, now time.Time) {
+	windowMs := window.Milliseconds()
 	windowStart := (now.UnixMilli() / windowMs) * windowMs
 	if b.windowStart != windowStart {
 		b.windowStart = windowStart
@@ -94,6 +104,76 @@ func (l *publicWafCaptchaVerifyLimiter) pruneLocked(now time.Time) {
 }
 
 func (l *publicWafCaptchaVerifyLimiter) evictOldestLocked() {
+	var oldestKey string
+	var oldestTime time.Time
+	for key, bucket := range l.keys {
+		if bucket == nil {
+			delete(l.keys, key)
+			return
+		}
+		if oldestKey == "" || bucket.lastSeenAt.Before(oldestTime) {
+			oldestKey = key
+			oldestTime = bucket.lastSeenAt
+		}
+	}
+	if oldestKey != "" {
+		delete(l.keys, oldestKey)
+	}
+}
+
+func (l *publicWafReservedEndpointLimiter) allow(listenerID int64, path string, remoteIP string, now time.Time) (time.Duration, bool) {
+	if l == nil {
+		return 0, true
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.pruneLocked(now)
+	ipKey := fmt.Sprintf("reserved:ip:%d:%s:%s", listenerID, path, remoteIP)
+	pathKey := fmt.Sprintf("reserved:path:%d:%s", listenerID, path)
+	ipBucket := l.bucketLocked(ipKey, now)
+	pathBucket := l.bucketLocked(pathKey, now)
+
+	ipRetryAfter, ipAllowed := ipBucket.canAllow(publicWafReservedEndpointIPLimit, publicWafReservedEndpointWindow, now)
+	pathRetryAfter, pathAllowed := pathBucket.canAllow(publicWafReservedEndpointPathLimit, publicWafReservedEndpointWindow, now)
+	if !ipAllowed || !pathAllowed {
+		return maxDuration(ipRetryAfter, pathRetryAfter), false
+	}
+
+	ipBucket.count++
+	ipBucket.lastSeenAt = now
+	pathBucket.count++
+	pathBucket.lastSeenAt = now
+	return 0, true
+}
+
+func (l *publicWafReservedEndpointLimiter) bucketLocked(key string, now time.Time) *publicWafFixedWindowBucket {
+	bucket := l.keys[key]
+	if bucket == nil {
+		if len(l.keys) >= publicWafReservedEndpointMaxKeys {
+			l.evictOldestLocked()
+		}
+		bucket = &publicWafFixedWindowBucket{}
+		l.keys[key] = bucket
+	}
+	bucket.rollWindow(publicWafReservedEndpointWindow, now)
+	bucket.lastSeenAt = now
+	return bucket
+}
+
+func (l *publicWafReservedEndpointLimiter) pruneLocked(now time.Time) {
+	if !l.lastPrune.IsZero() && now.Sub(l.lastPrune) < publicWafReservedEndpointPruneInterval {
+		return
+	}
+	l.lastPrune = now
+	for key, bucket := range l.keys {
+		if bucket == nil || bucket.lastSeenAt.IsZero() || now.Sub(bucket.lastSeenAt) > publicWafReservedEndpointIdleTTL {
+			delete(l.keys, key)
+		}
+	}
+}
+
+func (l *publicWafReservedEndpointLimiter) evictOldestLocked() {
 	var oldestKey string
 	var oldestTime time.Time
 	for key, bucket := range l.keys {

--- a/internal/server/public_waf_captcha_limiter.go
+++ b/internal/server/public_waf_captcha_limiter.go
@@ -130,20 +130,28 @@ func (l *publicWafReservedEndpointLimiter) allow(listenerID int64, path string, 
 
 	l.pruneLocked(now)
 	ipKey := fmt.Sprintf("reserved:ip:%d:%s:%s", listenerID, path, remoteIP)
-	pathKey := fmt.Sprintf("reserved:path:%d:%s", listenerID, path)
 	ipBucket := l.bucketLocked(ipKey, now)
-	pathBucket := l.bucketLocked(pathKey, now)
 
 	ipRetryAfter, ipAllowed := ipBucket.canAllow(publicWafReservedEndpointIPLimit, publicWafReservedEndpointWindow, now)
-	pathRetryAfter, pathAllowed := pathBucket.canAllow(publicWafReservedEndpointPathLimit, publicWafReservedEndpointWindow, now)
-	if !ipAllowed || !pathAllowed {
-		return maxDuration(ipRetryAfter, pathRetryAfter), false
+	if !ipAllowed {
+		return ipRetryAfter, false
+	}
+	var pathBucket *publicWafFixedWindowBucket
+	if path != publicWafWaitingRoomStatusPath {
+		pathKey := fmt.Sprintf("reserved:path:%d:%s", listenerID, path)
+		pathBucket = l.bucketLocked(pathKey, now)
+		pathRetryAfter, pathAllowed := pathBucket.canAllow(publicWafReservedEndpointPathLimit, publicWafReservedEndpointWindow, now)
+		if !pathAllowed {
+			return pathRetryAfter, false
+		}
 	}
 
 	ipBucket.count++
 	ipBucket.lastSeenAt = now
-	pathBucket.count++
-	pathBucket.lastSeenAt = now
+	if pathBucket != nil {
+		pathBucket.count++
+		pathBucket.lastSeenAt = now
+	}
 	return 0, true
 }
 

--- a/internal/server/public_waf_test.go
+++ b/internal/server/public_waf_test.go
@@ -460,6 +460,117 @@ func TestPublicWafCaptchaVerifyThrottlesBeforeProviderCall(t *testing.T) {
 	}
 }
 
+func TestPublicWafReservedCaptchaVerifyRateLimitedBeforeProviderCall(t *testing.T) {
+	app, handler, rule, calls := newTestCaptchaVerifyApp(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"success":false}`))
+	})
+	app.PublicWAF.captchaVerifyLimiter = nil
+	challenge := testCaptchaChallenge(t, app, rule, "example.com", "/private")
+	form := captchaVerifyForm(rule.ID, "/private", challenge, "bad-token")
+
+	for i := 0; i < publicWafReservedEndpointIPLimit; i++ {
+		resp := httptest.NewRecorder()
+		handler(resp, newCaptchaVerifyRequest("example.com", form))
+		if resp.Code != http.StatusForbidden {
+			t.Fatalf("attempt %d status = %d, want %d", i+1, resp.Code, http.StatusForbidden)
+		}
+	}
+	if got := calls.Load(); got != publicWafReservedEndpointIPLimit {
+		t.Fatalf("provider calls = %d, want %d", got, publicWafReservedEndpointIPLimit)
+	}
+
+	resp := httptest.NewRecorder()
+	handler(resp, newCaptchaVerifyRequest("example.com", form))
+	if resp.Code != http.StatusTooManyRequests {
+		t.Fatalf("throttled status = %d, want %d", resp.Code, http.StatusTooManyRequests)
+	}
+	if retryAfter := resp.Header().Get("Retry-After"); retryAfter == "" {
+		t.Fatal("missing Retry-After on reserved endpoint rate limit")
+	}
+	if got := calls.Load(); got != publicWafReservedEndpointIPLimit {
+		t.Fatalf("provider calls after reserved throttle = %d, want %d", got, publicWafReservedEndpointIPLimit)
+	}
+}
+
+func TestPublicWafReservedCaptchaVerifyMalformedRequestsRateLimitedBeforeParse(t *testing.T) {
+	_, handler, _, calls := newTestCaptchaVerifyApp(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"success":false}`))
+	})
+
+	for i := 0; i < publicWafReservedEndpointIPLimit; i++ {
+		resp := httptest.NewRecorder()
+		req := malformedCaptchaVerifyRequest("example.com")
+		handler(resp, req)
+		if resp.Code != http.StatusBadRequest {
+			t.Fatalf("attempt %d status = %d, want %d", i+1, resp.Code, http.StatusBadRequest)
+		}
+	}
+
+	resp := httptest.NewRecorder()
+	handler(resp, malformedCaptchaVerifyRequest("example.com"))
+	if resp.Code != http.StatusTooManyRequests {
+		t.Fatalf("throttled status = %d, want %d", resp.Code, http.StatusTooManyRequests)
+	}
+	if retryAfter := resp.Header().Get("Retry-After"); retryAfter == "" {
+		t.Fatal("missing Retry-After on malformed reserved endpoint rate limit")
+	}
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("provider calls = %d, want 0", got)
+	}
+}
+
+func TestPublicWafReservedLimiterUsesRemoteAddrNotForwardedFor(t *testing.T) {
+	_, handler, _, _ := newTestCaptchaVerifyApp(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"success":false}`))
+	})
+
+	for i := 0; i < publicWafReservedEndpointIPLimit; i++ {
+		resp := httptest.NewRecorder()
+		req := malformedCaptchaVerifyRequest("example.com")
+		req.Header.Set("X-Forwarded-For", "203.0.113."+strconv.Itoa(i+1))
+		handler(resp, req)
+		if resp.Code != http.StatusBadRequest {
+			t.Fatalf("attempt %d status = %d, want %d", i+1, resp.Code, http.StatusBadRequest)
+		}
+	}
+
+	resp := httptest.NewRecorder()
+	req := malformedCaptchaVerifyRequest("example.com")
+	req.Header.Set("X-Forwarded-For", "203.0.113.200")
+	handler(resp, req)
+	if resp.Code != http.StatusTooManyRequests {
+		t.Fatalf("throttled status = %d, want %d", resp.Code, http.StatusTooManyRequests)
+	}
+}
+
+func TestPublicWafReservedWaitingRoomStatusRateLimited(t *testing.T) {
+	app := NewApp(nil, nil)
+	rule := testWafRule(1, publicWafActionWaitingRoom)
+	snap := testWafSnapshot(rule, nil)
+	app.proxyMu.Lock()
+	app.publicSnapshot = snap
+	app.proxyMu.Unlock()
+	app.PublicWAF.reconcile(snap)
+	handler := app.publicProxyHandler(1)
+
+	for i := 0; i < publicWafReservedEndpointIPLimit; i++ {
+		resp := httptest.NewRecorder()
+		handler(resp, newWaitingRoomStatusRequest("example.com", rule.ID))
+		if resp.Code != http.StatusServiceUnavailable {
+			t.Fatalf("attempt %d status = %d, want %d", i+1, resp.Code, http.StatusServiceUnavailable)
+		}
+	}
+
+	resp := httptest.NewRecorder()
+	handler(resp, newWaitingRoomStatusRequest("example.com", rule.ID))
+	if resp.Code != http.StatusTooManyRequests {
+		t.Fatalf("throttled status = %d, want %d", resp.Code, http.StatusTooManyRequests)
+	}
+	if retryAfter := resp.Header().Get("Retry-After"); retryAfter == "" {
+		t.Fatal("missing Retry-After on waiting-room reserved endpoint rate limit")
+	}
+}
+
 func TestPublicWafCaptchaVerifySuccessSetsCookieAndRedirects(t *testing.T) {
 	app, handler, rule, _ := newTestCaptchaVerifyApp(t, func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
@@ -1332,6 +1443,19 @@ func captchaVerifyForm(ruleID int64, returnTo string, challenge string, token st
 func newCaptchaVerifyRequest(host string, form url.Values) *http.Request {
 	req := httptest.NewRequest(http.MethodPost, "http://"+host+publicWafCaptchaVerifyPath, strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.RemoteAddr = "198.51.100.9:12345"
+	return req
+}
+
+func malformedCaptchaVerifyRequest(host string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "http://"+host+publicWafCaptchaVerifyPath, strings.NewReader("%"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.RemoteAddr = "198.51.100.9:12345"
+	return req
+}
+
+func newWaitingRoomStatusRequest(host string, ruleID int64) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "http://"+host+publicWafWaitingRoomStatusPath+"?rule_id="+strconv.FormatInt(ruleID, 10), nil)
 	req.RemoteAddr = "198.51.100.9:12345"
 	return req
 }

--- a/internal/server/public_waf_test.go
+++ b/internal/server/public_waf_test.go
@@ -571,6 +571,32 @@ func TestPublicWafReservedWaitingRoomStatusRateLimited(t *testing.T) {
 	}
 }
 
+func TestPublicWafReservedWaitingRoomStatusSkipsAggregatePathLimit(t *testing.T) {
+	limiter := newPublicWafReservedEndpointLimiter()
+	now := time.Unix(100, 0)
+	for i := 0; i < publicWafReservedEndpointPathLimit+1; i++ {
+		retryAfter, allowed := limiter.allow(1, publicWafWaitingRoomStatusPath, "client-"+strconv.Itoa(i), now)
+		if !allowed {
+			t.Fatalf("status poll %d was aggregate limited with retryAfter=%v", i+1, retryAfter)
+		}
+	}
+
+	entryLimiter := newPublicWafReservedEndpointLimiter()
+	for i := 0; i < publicWafReservedEndpointPathLimit; i++ {
+		retryAfter, allowed := entryLimiter.allow(1, publicWafWaitingRoomPath, "client-"+strconv.Itoa(i), now)
+		if !allowed {
+			t.Fatalf("entry request %d was limited early with retryAfter=%v", i+1, retryAfter)
+		}
+	}
+	retryAfter, allowed := entryLimiter.allow(1, publicWafWaitingRoomPath, "client-over-limit", now)
+	if allowed {
+		t.Fatal("waiting-room entry path was not aggregate limited")
+	}
+	if retryAfter <= 0 {
+		t.Fatalf("entry path retryAfter = %v, want positive duration", retryAfter)
+	}
+}
+
 func TestPublicWafCaptchaVerifySuccessSetsCookieAndRedirects(t *testing.T) {
 	app, handler, rule, _ := newTestCaptchaVerifyApp(t, func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {


### PR DESCRIPTION
## Summary
- add a built-in fixed-window limiter for exact WAF reserved endpoints before endpoint-specific parsing/handling
- limit captcha verify and waiting-room reserved endpoints by listener/path and RemoteAddr-derived client IP
- keep the existing captcha provider verification limiter in place
- add regression tests for provider-call limiting, malformed submissions, RemoteAddr keying, and waiting-room status polling

## Tests
- go test ./internal/server -run 'Waf|WAF|Captcha|Waiting|ACME|Public'\n- go test ./internal/server\n- git diff --check -- internal/server/public_waf.go internal/server/public_waf_captcha.go internal/server/public_waf_captcha_limiter.go internal/server/public_waf_test.go\n\n## Notes\n- This remediates A-1 from the static audit.\n- All static audit findings now have code remediations; runtime-confirmation follow-ups remain for deployed upstream behavior and operational validation.\n