### PR TITLE
Extract public config service handlers

### DIFF
--- a/internal/server/app_services.go
+++ b/internal/server/app_services.go
@@ -12,6 +12,7 @@ type appServices struct {
 	publicWAF       *publicWAF
 	publicCache     *publicProxyCache
 	publicACME      *publicACMEManager
+	publicConfig    *publicConfigService
 	agentTransports *agentTransportPool
 	dashboardCache  *dashboardResponseCache
 	loginThrottle   *loginThrottle
@@ -37,6 +38,7 @@ func newAppServices(cfg *config.Config, app *App) appServices {
 		}
 	}
 	services.publicACME = newPublicACMEManager(app)
+	services.publicConfig = newPublicConfigService(app, app.DB, services.targetHealth, services.publicACME, appPublicConfigRuntime{app: app})
 	return services
 }
 
@@ -50,6 +52,7 @@ func (a *App) applyServices(services appServices) {
 	a.PublicWAF = services.publicWAF
 	a.PublicCache = services.publicCache
 	a.PublicACME = services.publicACME
+	a.publicConfig = services.publicConfig
 	a.AgentTransports = services.agentTransports
 	a.DashboardCache = services.dashboardCache
 	a.LoginThrottle = services.loginThrottle

--- a/internal/server/app_services.go
+++ b/internal/server/app_services.go
@@ -13,6 +13,7 @@ type appServices struct {
 	publicCache     *publicProxyCache
 	publicACME      *publicACMEManager
 	publicConfig    *publicConfigService
+	proxyRuntime    *proxyRuntime
 	agentTransports *agentTransportPool
 	dashboardCache  *dashboardResponseCache
 	loginThrottle   *loginThrottle
@@ -39,6 +40,7 @@ func newAppServices(cfg *config.Config, app *App) appServices {
 	}
 	services.publicACME = newPublicACMEManager(app)
 	services.publicConfig = newPublicConfigService(app, app.DB, services.targetHealth, appPublicConfigRuntime{app: app})
+	services.proxyRuntime = newProxyRuntime(app)
 	return services
 }
 
@@ -53,6 +55,7 @@ func (a *App) applyServices(services appServices) {
 	a.PublicCache = services.publicCache
 	a.PublicACME = services.publicACME
 	a.publicConfig = services.publicConfig
+	a.proxyRuntime = services.proxyRuntime
 	a.AgentTransports = services.agentTransports
 	a.DashboardCache = services.dashboardCache
 	a.LoginThrottle = services.loginThrottle

--- a/internal/server/app_services.go
+++ b/internal/server/app_services.go
@@ -15,6 +15,7 @@ type appServices struct {
 	publicConfig    *publicConfigService
 	proxyRuntime    *proxyRuntime
 	observability   *observabilityRecorder
+	auth            *authService
 	agentTransports *agentTransportPool
 	dashboardCache  *dashboardResponseCache
 	loginThrottle   *loginThrottle
@@ -43,6 +44,7 @@ func newAppServices(cfg *config.Config, app *App) appServices {
 	services.publicConfig = newPublicConfigService(app, app.DB, services.targetHealth, appPublicConfigRuntime{app: app})
 	services.proxyRuntime = newProxyRuntime(app)
 	services.observability = newObservabilityRecorder(app)
+	services.auth = newAuthService(app, app.DB, services.loginThrottle)
 	return services
 }
 
@@ -59,6 +61,7 @@ func (a *App) applyServices(services appServices) {
 	a.publicConfig = services.publicConfig
 	a.proxyRuntime = services.proxyRuntime
 	a.observabilityRecorder = services.observability
+	a.auth = services.auth
 	a.AgentTransports = services.agentTransports
 	a.DashboardCache = services.dashboardCache
 	a.LoginThrottle = services.loginThrottle

--- a/internal/server/app_services.go
+++ b/internal/server/app_services.go
@@ -14,6 +14,7 @@ type appServices struct {
 	publicACME      *publicACMEManager
 	publicConfig    *publicConfigService
 	proxyRuntime    *proxyRuntime
+	observability   *observabilityRecorder
 	agentTransports *agentTransportPool
 	dashboardCache  *dashboardResponseCache
 	loginThrottle   *loginThrottle
@@ -41,6 +42,7 @@ func newAppServices(cfg *config.Config, app *App) appServices {
 	services.publicACME = newPublicACMEManager(app)
 	services.publicConfig = newPublicConfigService(app, app.DB, services.targetHealth, appPublicConfigRuntime{app: app})
 	services.proxyRuntime = newProxyRuntime(app)
+	services.observability = newObservabilityRecorder(app)
 	return services
 }
 
@@ -56,6 +58,7 @@ func (a *App) applyServices(services appServices) {
 	a.PublicACME = services.publicACME
 	a.publicConfig = services.publicConfig
 	a.proxyRuntime = services.proxyRuntime
+	a.observabilityRecorder = services.observability
 	a.AgentTransports = services.agentTransports
 	a.DashboardCache = services.dashboardCache
 	a.LoginThrottle = services.loginThrottle

--- a/internal/server/app_services.go
+++ b/internal/server/app_services.go
@@ -38,7 +38,7 @@ func newAppServices(cfg *config.Config, app *App) appServices {
 		}
 	}
 	services.publicACME = newPublicACMEManager(app)
-	services.publicConfig = newPublicConfigService(app, app.DB, services.targetHealth, services.publicACME, appPublicConfigRuntime{app: app})
+	services.publicConfig = newPublicConfigService(app, app.DB, services.targetHealth, appPublicConfigRuntime{app: app})
 	return services
 }
 

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -103,6 +103,14 @@ func (a *App) GetSetupState(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.GetSetupStateRequest],
 ) (*connect.Response[p2pstreamv1.GetSetupStateResponse], error) {
+	return a.authService().getSetupStateRPC(ctx, req)
+}
+
+func (s *authService) getSetupStateRPC(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.GetSetupStateRequest],
+) (*connect.Response[p2pstreamv1.GetSetupStateResponse], error) {
+	a := s.app
 	_ = req
 
 	state, err := a.getSetupState(ctx)
@@ -116,6 +124,14 @@ func (a *App) SetupAdmin(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.SetupAdminRequest],
 ) (*connect.Response[p2pstreamv1.SetupAdminResponse], error) {
+	return a.authService().setupAdmin(ctx, req)
+}
+
+func (s *authService) setupAdmin(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.SetupAdminRequest],
+) (*connect.Response[p2pstreamv1.SetupAdminResponse], error) {
+	a := s.app
 	if a.DB == nil {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("database is required for setup"))
 	}
@@ -123,13 +139,13 @@ func (a *App) SetupAdmin(
 	a.setupMu.Lock()
 	defer a.setupMu.Unlock()
 
-	tx, err := a.DB.BeginTx(ctx, nil)
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	defer tx.Rollback()
 
-	qtx := a.DB.WithTx(tx)
+	qtx := s.db.WithTx(tx)
 	count, err := qtx.CountUsers(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
@@ -179,6 +195,11 @@ func (a *App) SetupAdmin(
 }
 
 func (a *App) initializeSetupToken(ctx context.Context) {
+	a.authService().initializeSetupToken(ctx)
+}
+
+func (s *authService) initializeSetupToken(ctx context.Context) {
+	a := s.app
 	if a == nil || a.DB == nil {
 		return
 	}
@@ -186,7 +207,7 @@ func (a *App) initializeSetupToken(ctx context.Context) {
 		a.setupTokenHash = hashSetupToken(token)
 		return
 	}
-	count, err := a.DB.CountUsers(ctx)
+	count, err := s.db.CountUsers(ctx)
 	if err != nil {
 		log.Warn().Err(err).Msg("Failed to inspect setup state for setup token initialization")
 		return
@@ -204,6 +225,11 @@ func (a *App) initializeSetupToken(ctx context.Context) {
 }
 
 func (a *App) LogGeneratedSetupToken(baseURL string) {
+	a.authService().logGeneratedSetupToken(baseURL)
+}
+
+func (s *authService) logGeneratedSetupToken(baseURL string) {
+	a := s.app
 	if a == nil || a.generatedSetupToken == "" {
 		return
 	}
@@ -224,6 +250,11 @@ func setupURLWithToken(baseURL string, token string) string {
 }
 
 func (a *App) validSetupToken(token string) bool {
+	return a.authService().validSetupToken(token)
+}
+
+func (s *authService) validSetupToken(token string) bool {
+	a := s.app
 	token = strings.TrimSpace(token)
 	if a == nil || a.setupTokenHash == "" || token == "" {
 		return false
@@ -250,6 +281,14 @@ func (a *App) Login(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.LoginRequest],
 ) (*connect.Response[p2pstreamv1.LoginResponse], error) {
+	return a.authService().login(ctx, req)
+}
+
+func (s *authService) login(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.LoginRequest],
+) (*connect.Response[p2pstreamv1.LoginResponse], error) {
+	a := s.app
 	if a.DB == nil {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("database is required for login"))
 	}
@@ -257,29 +296,29 @@ func (a *App) Login(
 	username := authutil.NormalizeUsername(req.Msg.Username)
 	throttleKey := loginThrottleKey(req.Peer().Addr, username)
 	now := time.Now()
-	if retryAfter := a.LoginThrottle.retryAfter(throttleKey, now); retryAfter > 0 {
+	if retryAfter := s.throttle.retryAfter(throttleKey, now); retryAfter > 0 {
 		return nil, connect.NewError(connect.CodeResourceExhausted, errors.New("too many failed login attempts; try again later"))
 	}
-	user, err := a.DB.GetUserByUsername(ctx, username)
+	user, err := s.db.GetUserByUsername(ctx, username)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			a.LoginThrottle.recordFailure(throttleKey, now)
+			s.throttle.recordFailure(throttleKey, now)
 			return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("invalid username or password"))
 		}
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	if err := authutil.ComparePasswordHash(user.PasswordHash, req.Msg.Password); err != nil {
-		a.LoginThrottle.recordFailure(throttleKey, now)
+		s.throttle.recordFailure(throttleKey, now)
 		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("invalid username or password"))
 	}
-	a.LoginThrottle.recordSuccess(throttleKey)
+	s.throttle.recordSuccess(throttleKey)
 
 	token, tokenHash, err := newSessionToken()
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	expiresAt := time.Now().Add(sessionDuration)
-	if _, err := a.DB.CreateSession(ctx, db.CreateSessionParams{
+	if _, err := s.db.CreateSession(ctx, db.CreateSessionParams{
 		UserID:    user.ID,
 		TokenHash: tokenHash,
 		ExpiresAt: expiresAt,
@@ -296,11 +335,19 @@ func (a *App) Logout(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.LogoutRequest],
 ) (*connect.Response[p2pstreamv1.LogoutResponse], error) {
-	user, err := a.requireUser(ctx, req.Header())
+	return a.authService().logout(ctx, req)
+}
+
+func (s *authService) logout(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.LogoutRequest],
+) (*connect.Response[p2pstreamv1.LogoutResponse], error) {
+	a := s.app
+	user, err := s.requireUser(ctx, req.Header())
 	if err != nil {
 		return nil, err
 	}
-	if err := a.DB.RevokeSessionByTokenHash(ctx, user.TokenHash); err != nil {
+	if err := s.db.RevokeSessionByTokenHash(ctx, user.TokenHash); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
@@ -313,7 +360,14 @@ func (a *App) GetCurrentUser(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.GetCurrentUserRequest],
 ) (*connect.Response[p2pstreamv1.GetCurrentUserResponse], error) {
-	user, err := a.requireUser(ctx, req.Header())
+	return a.authService().getCurrentUser(ctx, req)
+}
+
+func (s *authService) getCurrentUser(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.GetCurrentUserRequest],
+) (*connect.Response[p2pstreamv1.GetCurrentUserResponse], error) {
+	user, err := s.requireUser(ctx, req.Header())
 	if err != nil {
 		return nil, err
 	}
@@ -328,11 +382,16 @@ func (a *App) GetCurrentUser(
 }
 
 func (a *App) getSetupState(ctx context.Context) (*p2pstreamv1.GetSetupStateResponse, error) {
+	return a.authService().getSetupState(ctx)
+}
+
+func (s *authService) getSetupState(ctx context.Context) (*p2pstreamv1.GetSetupStateResponse, error) {
+	a := s.app
 	if a.DB == nil {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("database is required for setup"))
 	}
 
-	count, err := a.DB.CountUsers(ctx)
+	count, err := s.db.CountUsers(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
@@ -353,18 +412,28 @@ func (a *App) getSetupState(ctx context.Context) (*p2pstreamv1.GetSetupStateResp
 }
 
 func (a *App) setupAvailable(now time.Time) bool {
+	return a.authService().setupAvailable(now)
+}
+
+func (s *authService) setupAvailable(now time.Time) bool {
+	a := s.app
 	expiresAt := a.StartedAt.Add(setupWindow)
 	return now.Before(expiresAt) || now.Equal(expiresAt)
 }
 
 func (a *App) requireUser(ctx context.Context, header http.Header) (*authenticatedUser, error) {
+	return a.authService().requireUser(ctx, header)
+}
+
+func (s *authService) requireUser(ctx context.Context, header http.Header) (*authenticatedUser, error) {
+	a := s.app
 	if a.DB == nil {
 		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("authentication is unavailable"))
 	}
 
 	if accessToken := managementAccessTokenFromHeader(header); accessToken != "" {
 		tokenHash := hashManagementAccessToken(accessToken)
-		row, err := a.DB.GetActiveManagementAccessTokenByHash(ctx, tokenHash)
+		row, err := s.db.GetActiveManagementAccessTokenByHash(ctx, tokenHash)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("login required"))
@@ -374,7 +443,7 @@ func (a *App) requireUser(ctx context.Context, header http.Header) (*authenticat
 		if row.ExpiresAt.Valid && !row.ExpiresAt.Time.After(time.Now()) {
 			return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("login required"))
 		}
-		if err := a.DB.TouchManagementAccessToken(ctx, row.ID); err != nil {
+		if err := s.db.TouchManagementAccessToken(ctx, row.ID); err != nil {
 			return nil, connect.NewError(connect.CodeInternal, err)
 		}
 		return &authenticatedUser{
@@ -391,7 +460,7 @@ func (a *App) requireUser(ctx context.Context, header http.Header) (*authenticat
 	}
 
 	tokenHash := hashSessionToken(token)
-	session, err := a.DB.GetActiveSessionByTokenHash(ctx, tokenHash)
+	session, err := s.db.GetActiveSessionByTokenHash(ctx, tokenHash)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("login required"))
@@ -399,7 +468,7 @@ func (a *App) requireUser(ctx context.Context, header http.Header) (*authenticat
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	if session.LastSeenAt.IsZero() || time.Since(session.LastSeenAt) >= sessionTouchInterval {
-		if err := a.DB.TouchSession(ctx, session.SessionID); err != nil {
+		if err := s.db.TouchSession(ctx, session.SessionID); err != nil {
 			return nil, connect.NewError(connect.CodeInternal, err)
 		}
 	}
@@ -414,7 +483,11 @@ func (a *App) requireUser(ctx context.Context, header http.Header) (*authenticat
 }
 
 func (a *App) requireAdmin(ctx context.Context, header http.Header) (*authenticatedUser, error) {
-	user, err := a.requireUser(ctx, header)
+	return a.authService().requireAdmin(ctx, header)
+}
+
+func (s *authService) requireAdmin(ctx context.Context, header http.Header) (*authenticatedUser, error) {
+	user, err := s.requireUser(ctx, header)
 	if err != nil {
 		return nil, err
 	}
@@ -448,6 +521,11 @@ func hashSessionToken(token string) string {
 }
 
 func (a *App) sessionCookie(token string, expiresAt time.Time) *http.Cookie {
+	return a.authService().sessionCookie(token, expiresAt)
+}
+
+func (s *authService) sessionCookie(token string, expiresAt time.Time) *http.Cookie {
+	a := s.app
 	return &http.Cookie{
 		Name:     sessionCookieName,
 		Value:    token,
@@ -460,6 +538,11 @@ func (a *App) sessionCookie(token string, expiresAt time.Time) *http.Cookie {
 }
 
 func (a *App) clearSessionCookie() *http.Cookie {
+	return a.authService().clearSessionCookie()
+}
+
+func (s *authService) clearSessionCookie() *http.Cookie {
+	a := s.app
 	return &http.Cookie{
 		Name:     sessionCookieName,
 		Value:    "",
@@ -473,6 +556,11 @@ func (a *App) clearSessionCookie() *http.Cookie {
 }
 
 func (a *App) secureCookies() bool {
+	return a.authService().secureCookies()
+}
+
+func (s *authService) secureCookies() bool {
+	a := s.app
 	return a.Config != nil && (a.Config.ManagementTLSEnabled || a.Config.Env == "production" || a.Config.ManagementCookieSecure)
 }
 

--- a/internal/server/auth_service.go
+++ b/internal/server/auth_service.go
@@ -1,0 +1,29 @@
+package server
+
+import "p2pstream/internal/db"
+
+type authService struct {
+	app      *App
+	db       *db.DB
+	throttle *loginThrottle
+}
+
+func newAuthService(app *App, database *db.DB, throttle *loginThrottle) *authService {
+	return &authService{
+		app:      app,
+		db:       database,
+		throttle: throttle,
+	}
+}
+
+func (a *App) authService() *authService {
+	if a == nil {
+		return newAuthService(nil, nil, nil)
+	}
+	if a.auth != nil {
+		return a.auth
+	}
+	// Directly constructed test Apps may not go through appServices; do not cache
+	// here because callers can race on manually shared App values.
+	return newAuthService(a, a.DB, a.LoginThrottle)
+}

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/rs/zerolog/log"
 
 	p2pstreamv1 "p2pstream/gen/proto/p2pstream/v1"
 	"p2pstream/internal/db"
@@ -586,8 +585,8 @@ func dashboardAgentWindowFromRollup(row db.GetAgentStatsRollupSummarySinceRow) d
 	}
 }
 
-func (a *App) recordProxyRequestEvent(ctx context.Context, statusCode int, duration time.Duration, errorKind string) {
-	a.recordProxyRequestEventWithIDs(ctx, statusCode, duration, errorKind, sql.NullInt64{}, sql.NullInt64{}, sql.NullInt64{}, 0, 0)
+func (a *App) recordProxyRequestEvent(ctx context.Context, event proxyRequestEvent) {
+	a.observabilityRecorderService().recordProxyRequestEvent(ctx, event)
 }
 
 func (a *App) recordProxyRequestEventWithIDs(
@@ -729,39 +728,23 @@ func (a *App) recordProxyRequestEventWithRouteTargetCacheAndContext(
 	responseBytes uint64,
 	requestContext proxyRequestContext,
 ) {
-	if a.DB == nil {
-		return
-	}
-	if duration < 0 {
-		duration = 0
-	}
-	if statusCode == 0 {
-		statusCode = http.StatusInternalServerError
-	}
-
-	occurredAt := time.Now().UTC()
-	if err := a.insertProxyRequestEventWithRollups(ctx, db.InsertProxyRequestEventAtParams{
-		OccurredAt:    occurredAt,
-		StatusCode:    int64(statusCode),
-		DurationMs:    duration.Milliseconds(),
+	a.recordProxyRequestEvent(ctx, proxyRequestEvent{
+		StatusCode:    statusCode,
+		Duration:      duration,
 		ErrorKind:     errorKind,
-		Method:        requestContext.Method,
-		Host:          requestContext.Host,
-		PathPrefix:    requestContext.PathPrefix,
 		ListenerID:    listenerID,
 		RouteID:       routeID,
 		RouteTargetID: routeTargetID,
 		WafRuleID:     wafRuleID,
 		WafAction:     wafAction,
 		AgentID:       agentID,
-		RequestBytes:  int64FromUint64(requestBytes),
-		ResponseBytes: int64FromUint64(responseBytes),
 		CacheRuleID:   cacheRuleID,
 		CacheStatus:   cacheStatus,
-		CacheBytes:    int64FromUint64(cacheBytes),
-	}); err != nil {
-		log.Warn().Err(err).Msg("Failed to record proxy request event")
-	}
+		CacheBytes:    cacheBytes,
+		RequestBytes:  requestBytes,
+		ResponseBytes: responseBytes,
+		Context:       requestContext,
+	})
 }
 
 func dashboardListenerSummaries(rows []db.ListTopProxyListenersSinceRow) []*p2pstreamv1.DashboardProxyDimensionSummary {
@@ -1252,81 +1235,7 @@ func int64FromUint64(value uint64) int64 {
 }
 
 func (a *App) cleanupObservability(ctx context.Context, now time.Time) {
-	if a.DB == nil {
-		return
-	}
-
-	a.observabilityMu.Lock()
-	if !a.observabilityLastCleanup.IsZero() && now.Sub(a.observabilityLastCleanup) < observabilityCleanupInterval {
-		a.observabilityMu.Unlock()
-		return
-	}
-	a.observabilityLastCleanup = now
-	a.observabilityMu.Unlock()
-
-	cutoff := now.AddDate(0, 0, -a.observabilityRetentionDays())
-	cutoffBucketUnixMillis := rollupBucketUnixMillis(cutoff)
-	if err := a.DB.DeleteProxyRequestRollupsBefore(ctx, cutoffBucketUnixMillis); err != nil {
-		log.Warn().Err(err).Msg("Failed to clean up old proxy request rollups")
-	}
-	if err := a.DB.DeleteProxyRequestTupleRollupsBefore(ctx, cutoffBucketUnixMillis); err != nil {
-		log.Warn().Err(err).Msg("Failed to clean up old proxy request tuple rollups")
-	}
-	if err := a.DB.DeleteProxyRequestStatusRollupsBefore(ctx, cutoffBucketUnixMillis); err != nil {
-		log.Warn().Err(err).Msg("Failed to clean up old proxy request status rollups")
-	}
-	if err := a.DB.DeleteAgentStatRollupsBefore(ctx, cutoffBucketUnixMillis); err != nil {
-		log.Warn().Err(err).Msg("Failed to clean up old agent stat rollups")
-	}
-	if err := a.DB.DeleteProxyRequestEventsBefore(ctx, cutoff); err != nil {
-		log.Warn().Err(err).Msg("Failed to clean up old proxy request events")
-	}
-	if err := a.DB.DeleteAgentStatsBefore(ctx, cutoff); err != nil {
-		log.Warn().Err(err).Msg("Failed to clean up old agent stats")
-	}
-	if err := a.DB.DeleteDisconnectedConnectionsBefore(ctx, sql.NullTime{Time: cutoff, Valid: true}); err != nil {
-		log.Warn().Err(err).Msg("Failed to clean up old disconnected agent connections")
-	}
-
-	maxRows := a.observabilityMaxRows()
-	if maxRows <= 0 {
-		return
-	}
-	ready, err := a.observabilityRollupsReady(ctx)
-	if err != nil {
-		log.Warn().Err(err).Msg("Failed to check observability rollup readiness for row cap")
-		return
-	}
-	if !ready {
-		return
-	}
-
-	for i := 0; i < observabilityRowCapDeleteMaxBatches; i++ {
-		deleted, err := a.DB.DeleteOldestProxyRequestEventsOverLimit(ctx, db.DeleteOldestProxyRequestEventsOverLimitParams{
-			Offset:      maxRows,
-			DeleteLimit: observabilityRowCapDeleteBatchRows,
-		})
-		if err != nil {
-			log.Warn().Err(err).Msg("Failed to enforce proxy request event row cap")
-			break
-		}
-		if deleted < observabilityRowCapDeleteBatchRows {
-			break
-		}
-	}
-	for i := 0; i < observabilityRowCapDeleteMaxBatches; i++ {
-		deleted, err := a.DB.DeleteOldestAgentStatsOverLimit(ctx, db.DeleteOldestAgentStatsOverLimitParams{
-			Offset:      maxRows,
-			DeleteLimit: observabilityRowCapDeleteBatchRows,
-		})
-		if err != nil {
-			log.Warn().Err(err).Msg("Failed to enforce agent stat row cap")
-			break
-		}
-		if deleted < observabilityRowCapDeleteBatchRows {
-			break
-		}
-	}
+	a.observabilityRecorderService().cleanup(ctx, now)
 }
 
 func (a *App) observabilityRetentionDays() int {

--- a/internal/server/observability_recorder.go
+++ b/internal/server/observability_recorder.go
@@ -1,0 +1,165 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"p2pstream/internal/db"
+)
+
+type proxyRequestEvent struct {
+	StatusCode    int
+	Duration      time.Duration
+	ErrorKind     string
+	ListenerID    sql.NullInt64
+	RouteID       sql.NullInt64
+	RouteTargetID sql.NullInt64
+	WafRuleID     sql.NullInt64
+	WafAction     string
+	AgentID       sql.NullInt64
+	CacheRuleID   sql.NullInt64
+	CacheStatus   string
+	CacheBytes    uint64
+	RequestBytes  uint64
+	ResponseBytes uint64
+	Context       proxyRequestContext
+}
+
+type observabilityRecorder struct {
+	app *App
+}
+
+func newObservabilityRecorder(app *App) *observabilityRecorder {
+	return &observabilityRecorder{app: app}
+}
+
+func (a *App) observabilityRecorderService() *observabilityRecorder {
+	if a == nil {
+		return newObservabilityRecorder(nil)
+	}
+	if a.observabilityRecorder != nil {
+		return a.observabilityRecorder
+	}
+	a.observabilityRecorder = newObservabilityRecorder(a)
+	return a.observabilityRecorder
+}
+
+func (r *observabilityRecorder) recordProxyRequestEvent(ctx context.Context, event proxyRequestEvent) {
+	a := r.app
+	if a == nil || a.DB == nil {
+		return
+	}
+	if event.Duration < 0 {
+		event.Duration = 0
+	}
+	if event.StatusCode == 0 {
+		event.StatusCode = http.StatusInternalServerError
+	}
+
+	occurredAt := time.Now().UTC()
+	if err := a.insertProxyRequestEventWithRollups(ctx, db.InsertProxyRequestEventAtParams{
+		OccurredAt:    occurredAt,
+		StatusCode:    int64(event.StatusCode),
+		DurationMs:    event.Duration.Milliseconds(),
+		ErrorKind:     event.ErrorKind,
+		Method:        event.Context.Method,
+		Host:          event.Context.Host,
+		PathPrefix:    event.Context.PathPrefix,
+		ListenerID:    event.ListenerID,
+		RouteID:       event.RouteID,
+		RouteTargetID: event.RouteTargetID,
+		WafRuleID:     event.WafRuleID,
+		WafAction:     event.WafAction,
+		AgentID:       event.AgentID,
+		RequestBytes:  int64FromUint64(event.RequestBytes),
+		ResponseBytes: int64FromUint64(event.ResponseBytes),
+		CacheRuleID:   event.CacheRuleID,
+		CacheStatus:   event.CacheStatus,
+		CacheBytes:    int64FromUint64(event.CacheBytes),
+	}); err != nil {
+		log.Warn().Err(err).Msg("Failed to record proxy request event")
+	}
+}
+
+func (r *observabilityRecorder) cleanup(ctx context.Context, now time.Time) {
+	a := r.app
+	if a == nil || a.DB == nil {
+		return
+	}
+
+	a.observabilityMu.Lock()
+	if !a.observabilityLastCleanup.IsZero() && now.Sub(a.observabilityLastCleanup) < observabilityCleanupInterval {
+		a.observabilityMu.Unlock()
+		return
+	}
+	a.observabilityLastCleanup = now
+	a.observabilityMu.Unlock()
+
+	cutoff := now.AddDate(0, 0, -a.observabilityRetentionDays())
+	cutoffBucketUnixMillis := rollupBucketUnixMillis(cutoff)
+	if err := a.DB.DeleteProxyRequestRollupsBefore(ctx, cutoffBucketUnixMillis); err != nil {
+		log.Warn().Err(err).Msg("Failed to clean up old proxy request rollups")
+	}
+	if err := a.DB.DeleteProxyRequestTupleRollupsBefore(ctx, cutoffBucketUnixMillis); err != nil {
+		log.Warn().Err(err).Msg("Failed to clean up old proxy request tuple rollups")
+	}
+	if err := a.DB.DeleteProxyRequestStatusRollupsBefore(ctx, cutoffBucketUnixMillis); err != nil {
+		log.Warn().Err(err).Msg("Failed to clean up old proxy request status rollups")
+	}
+	if err := a.DB.DeleteAgentStatRollupsBefore(ctx, cutoffBucketUnixMillis); err != nil {
+		log.Warn().Err(err).Msg("Failed to clean up old agent stat rollups")
+	}
+	if err := a.DB.DeleteProxyRequestEventsBefore(ctx, cutoff); err != nil {
+		log.Warn().Err(err).Msg("Failed to clean up old proxy request events")
+	}
+	if err := a.DB.DeleteAgentStatsBefore(ctx, cutoff); err != nil {
+		log.Warn().Err(err).Msg("Failed to clean up old agent stats")
+	}
+	if err := a.DB.DeleteDisconnectedConnectionsBefore(ctx, sql.NullTime{Time: cutoff, Valid: true}); err != nil {
+		log.Warn().Err(err).Msg("Failed to clean up old disconnected agent connections")
+	}
+
+	maxRows := a.observabilityMaxRows()
+	if maxRows <= 0 {
+		return
+	}
+	ready, err := a.observabilityRollupsReady(ctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to check observability rollup readiness for row cap")
+		return
+	}
+	if !ready {
+		return
+	}
+
+	for i := 0; i < observabilityRowCapDeleteMaxBatches; i++ {
+		deleted, err := a.DB.DeleteOldestProxyRequestEventsOverLimit(ctx, db.DeleteOldestProxyRequestEventsOverLimitParams{
+			Offset:      maxRows,
+			DeleteLimit: observabilityRowCapDeleteBatchRows,
+		})
+		if err != nil {
+			log.Warn().Err(err).Msg("Failed to enforce proxy request event row cap")
+			break
+		}
+		if deleted < observabilityRowCapDeleteBatchRows {
+			break
+		}
+	}
+	for i := 0; i < observabilityRowCapDeleteMaxBatches; i++ {
+		deleted, err := a.DB.DeleteOldestAgentStatsOverLimit(ctx, db.DeleteOldestAgentStatsOverLimitParams{
+			Offset:      maxRows,
+			DeleteLimit: observabilityRowCapDeleteBatchRows,
+		})
+		if err != nil {
+			log.Warn().Err(err).Msg("Failed to enforce agent stat row cap")
+			break
+		}
+		if deleted < observabilityRowCapDeleteBatchRows {
+			break
+		}
+	}
+}

--- a/internal/server/proxy_lifecycle.go
+++ b/internal/server/proxy_lifecycle.go
@@ -34,7 +34,7 @@ func (a *App) StartProxy(ctx context.Context, req *connect.Request[p2pstreamv1.S
 		return nil, err
 	}
 
-	status, err := a.startProxy(ctx)
+	status, err := a.proxyRuntimeService().start(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func (a *App) StopProxy(ctx context.Context, req *connect.Request[p2pstreamv1.St
 	shutdownCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	status, err := a.stopProxy(shutdownCtx)
+	status, err := a.proxyRuntimeService().stop(shutdownCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -57,11 +57,11 @@ func (a *App) StopProxy(ctx context.Context, req *connect.Request[p2pstreamv1.St
 }
 
 func (a *App) StartProxyListener(ctx context.Context) (*p2pstreamv1.ProxyStatus, error) {
-	return a.startProxy(ctx)
+	return a.proxyRuntimeService().start(ctx)
 }
 
 func (a *App) StopProxyListener(ctx context.Context) (*p2pstreamv1.ProxyStatus, error) {
-	return a.stopProxy(ctx)
+	return a.proxyRuntimeService().stop(ctx)
 }
 
 func (a *App) startProxy(ctx context.Context) (*p2pstreamv1.ProxyStatus, error) {

--- a/internal/server/proxy_runtime.go
+++ b/internal/server/proxy_runtime.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"context"
+
+	p2pstreamv1 "p2pstream/gen/proto/p2pstream/v1"
+)
+
+type proxyRuntime struct {
+	app *App
+}
+
+func newProxyRuntime(app *App) *proxyRuntime {
+	return &proxyRuntime{app: app}
+}
+
+func (a *App) proxyRuntimeService() *proxyRuntime {
+	if a == nil {
+		return newProxyRuntime(nil)
+	}
+	if a.proxyRuntime != nil {
+		return a.proxyRuntime
+	}
+	a.proxyRuntime = newProxyRuntime(a)
+	return a.proxyRuntime
+}
+
+func (r *proxyRuntime) start(ctx context.Context) (*p2pstreamv1.ProxyStatus, error) {
+	return r.app.startProxy(ctx)
+}
+
+func (r *proxyRuntime) stop(ctx context.Context) (*p2pstreamv1.ProxyStatus, error) {
+	return r.app.stopProxy(ctx)
+}

--- a/internal/server/public_config_handlers.go
+++ b/internal/server/public_config_handlers.go
@@ -17,6 +17,14 @@ func (a *App) GetPublicProxyConfig(
 	if _, err := a.requireUser(ctx, req.Header()); err != nil {
 		return nil, err
 	}
+	return a.publicConfigService().GetPublicProxyConfig(ctx, req)
+}
+
+func (s *publicConfigService) GetPublicProxyConfig(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.GetPublicProxyConfigRequest],
+) (*connect.Response[p2pstreamv1.GetPublicProxyConfigResponse], error) {
+	a := s.app
 	resp, err := a.publicProxyConfigResponse(ctx)
 	if err != nil {
 		return nil, err
@@ -31,6 +39,13 @@ func (a *App) ListPublicRouteTargetHealthTraces(
 	if _, err := a.requireUser(ctx, req.Header()); err != nil {
 		return nil, err
 	}
+	return a.publicConfigService().ListPublicRouteTargetHealthTraces(ctx, req)
+}
+
+func (s *publicConfigService) ListPublicRouteTargetHealthTraces(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.ListPublicRouteTargetHealthTracesRequest],
+) (*connect.Response[p2pstreamv1.ListPublicRouteTargetHealthTracesResponse], error) {
 	if req.Msg.RouteTargetId <= 0 {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("route target id is required"))
 	}
@@ -40,8 +55,8 @@ func (a *App) ListPublicRouteTargetHealthTraces(
 	}
 	var traces []*p2pstreamv1.PublicRouteTargetHealthTrace
 	var retained int64
-	if a.TargetHealth != nil {
-		traces, retained = a.TargetHealth.listHealthTraces(req.Msg.RouteTargetId, req.Msg.AgentId, limit, req.Msg.FailuresOnly)
+	if s.targetHealth != nil {
+		traces, retained = s.targetHealth.listHealthTraces(req.Msg.RouteTargetId, req.Msg.AgentId, limit, req.Msg.FailuresOnly)
 	}
 	return connect.NewResponse(&p2pstreamv1.ListPublicRouteTargetHealthTracesResponse{
 		Traces:               traces,
@@ -57,11 +72,19 @@ func (a *App) CreatePublicListener(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
+	return a.publicConfigService().CreatePublicListener(ctx, req)
+}
+
+func (s *publicConfigService) CreatePublicListener(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.CreatePublicListenerRequest],
+) (*connect.Response[p2pstreamv1.CreatePublicListenerResponse], error) {
+	a := s.app
 	params, err := a.validatePublicListenerInput(req.Msg.Name, req.Msg.BindAddress, req.Msg.Port, req.Msg.Protocol, req.Msg.Enabled, false)
 	if err != nil {
 		return nil, err
 	}
-	listener, err := a.DB.CreatePublicListener(ctx, db.CreatePublicListenerParams{
+	listener, err := s.db.CreatePublicListener(ctx, db.CreatePublicListenerParams{
 		Name:        params.Name,
 		BindAddress: params.BindAddress,
 		Port:        params.Port,
@@ -78,7 +101,7 @@ func (a *App) CreatePublicListener(
 	return connect.NewResponse(&p2pstreamv1.CreatePublicListenerResponse{
 		Listener: publicListenerToProto(listener),
 		Status:   status,
-		Proxy:    a.proxyStatus(),
+		Proxy:    publicConfigProxyStatus(s.runtime),
 	}), nil
 }
 
@@ -89,12 +112,20 @@ func (a *App) UpdatePublicListener(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
+	return a.publicConfigService().UpdatePublicListener(ctx, req)
+}
+
+func (s *publicConfigService) UpdatePublicListener(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.UpdatePublicListenerRequest],
+) (*connect.Response[p2pstreamv1.UpdatePublicListenerResponse], error) {
+	a := s.app
 	params, err := a.validatePublicListenerInput(req.Msg.Name, req.Msg.BindAddress, req.Msg.Port, req.Msg.Protocol, req.Msg.Enabled, false)
 	if err != nil {
 		return nil, err
 	}
 	params.ID = req.Msg.Id
-	listener, err := a.DB.UpdatePublicListener(ctx, params)
+	listener, err := s.db.UpdatePublicListener(ctx, params)
 	if err != nil {
 		return nil, publicDBError(err)
 	}
@@ -105,7 +136,7 @@ func (a *App) UpdatePublicListener(
 	return connect.NewResponse(&p2pstreamv1.UpdatePublicListenerResponse{
 		Listener: publicListenerToProto(listener),
 		Status:   status,
-		Proxy:    a.proxyStatus(),
+		Proxy:    publicConfigProxyStatus(s.runtime),
 	}), nil
 }
 
@@ -116,6 +147,14 @@ func (a *App) DeletePublicListener(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
+	return a.publicConfigService().DeletePublicListener(ctx, req)
+}
+
+func (s *publicConfigService) DeletePublicListener(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.DeletePublicListenerRequest],
+) (*connect.Response[p2pstreamv1.DeletePublicListenerResponse], error) {
+	a := s.app
 	a.proxyMu.Lock()
 	running := false
 	if runtime := a.publicListenerState[req.Msg.Id]; runtime != nil {
@@ -125,7 +164,7 @@ func (a *App) DeletePublicListener(
 	if running {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("stop or disable listener before deleting it"))
 	}
-	if err := a.DB.DeletePublicListener(ctx, req.Msg.Id); err != nil {
+	if err := s.db.DeletePublicListener(ctx, req.Msg.Id); err != nil {
 		return nil, publicDBError(err)
 	}
 	if err := a.refreshPublicProxySnapshot(ctx); err != nil {
@@ -141,14 +180,22 @@ func (a *App) EnablePublicListener(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	listener, err := a.DB.GetPublicListener(ctx, req.Msg.Id)
+	return a.publicConfigService().EnablePublicListener(ctx, req)
+}
+
+func (s *publicConfigService) EnablePublicListener(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.EnablePublicListenerRequest],
+) (*connect.Response[p2pstreamv1.EnablePublicListenerResponse], error) {
+	a := s.app
+	listener, err := s.db.GetPublicListener(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, publicDBError(err)
 	}
 	if _, err := a.validatePublicListenerInput(listener.Name, listener.BindAddress, listener.Port, protoProtocolFromString(listener.Protocol), true, true); err != nil {
 		return nil, err
 	}
-	listener, err = a.DB.SetPublicListenerEnabled(ctx, db.SetPublicListenerEnabledParams{ID: req.Msg.Id, Enabled: 1})
+	listener, err = s.db.SetPublicListenerEnabled(ctx, db.SetPublicListenerEnabledParams{ID: req.Msg.Id, Enabled: 1})
 	if err != nil {
 		return nil, publicDBError(err)
 	}
@@ -159,7 +206,7 @@ func (a *App) EnablePublicListener(
 	return connect.NewResponse(&p2pstreamv1.EnablePublicListenerResponse{
 		Listener: publicListenerToProto(listener),
 		Status:   status,
-		Proxy:    a.proxyStatus(),
+		Proxy:    publicConfigProxyStatus(s.runtime),
 	}), nil
 }
 
@@ -170,7 +217,15 @@ func (a *App) DisablePublicListener(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	listener, err := a.DB.SetPublicListenerEnabled(ctx, db.SetPublicListenerEnabledParams{ID: req.Msg.Id, Enabled: 0})
+	return a.publicConfigService().DisablePublicListener(ctx, req)
+}
+
+func (s *publicConfigService) DisablePublicListener(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.DisablePublicListenerRequest],
+) (*connect.Response[p2pstreamv1.DisablePublicListenerResponse], error) {
+	a := s.app
+	listener, err := s.db.SetPublicListenerEnabled(ctx, db.SetPublicListenerEnabledParams{ID: req.Msg.Id, Enabled: 0})
 	if err != nil {
 		return nil, publicDBError(err)
 	}
@@ -184,7 +239,7 @@ func (a *App) DisablePublicListener(
 	return connect.NewResponse(&p2pstreamv1.DisablePublicListenerResponse{
 		Listener: publicListenerToProto(listener),
 		Status:   status,
-		Proxy:    a.proxyStatus(),
+		Proxy:    publicConfigProxyStatus(s.runtime),
 	}), nil
 }
 
@@ -195,6 +250,14 @@ func (a *App) StartPublicListener(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
+	return a.publicConfigService().StartPublicListener(ctx, req)
+}
+
+func (s *publicConfigService) StartPublicListener(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.StartPublicListenerRequest],
+) (*connect.Response[p2pstreamv1.StartPublicListenerResponse], error) {
+	a := s.app
 	if err := a.refreshPublicProxySnapshot(ctx); err != nil {
 		return nil, err
 	}
@@ -202,7 +265,7 @@ func (a *App) StartPublicListener(
 	if err != nil {
 		return nil, err
 	}
-	return connect.NewResponse(&p2pstreamv1.StartPublicListenerResponse{Status: status, Proxy: a.proxyStatus()}), nil
+	return connect.NewResponse(&p2pstreamv1.StartPublicListenerResponse{Status: status, Proxy: publicConfigProxyStatus(s.runtime)}), nil
 }
 
 func (a *App) StopPublicListener(
@@ -212,6 +275,14 @@ func (a *App) StopPublicListener(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
+	return a.publicConfigService().StopPublicListener(ctx, req)
+}
+
+func (s *publicConfigService) StopPublicListener(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.StopPublicListenerRequest],
+) (*connect.Response[p2pstreamv1.StopPublicListenerResponse], error) {
+	a := s.app
 	if err := a.refreshPublicProxySnapshot(ctx); err != nil {
 		return nil, err
 	}
@@ -219,7 +290,7 @@ func (a *App) StopPublicListener(
 	if err != nil {
 		return nil, err
 	}
-	return connect.NewResponse(&p2pstreamv1.StopPublicListenerResponse{Status: status, Proxy: a.proxyStatus()}), nil
+	return connect.NewResponse(&p2pstreamv1.StopPublicListenerResponse{Status: status, Proxy: publicConfigProxyStatus(s.runtime)}), nil
 }
 
 func (a *App) CreatePublicRoute(
@@ -229,6 +300,14 @@ func (a *App) CreatePublicRoute(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
+	return a.publicConfigService().CreatePublicRoute(ctx, req)
+}
+
+func (s *publicConfigService) CreatePublicRoute(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.CreatePublicRouteRequest],
+) (*connect.Response[p2pstreamv1.CreatePublicRouteResponse], error) {
+	a := s.app
 	params, routeTargets, err := a.validatePublicRouteInput(
 		ctx,
 		req.Msg.ListenerId,
@@ -257,7 +336,7 @@ func (a *App) CreatePublicRoute(
 		return nil, err
 	}
 	upstreamHeaders, responseHeaders := a.publicRouteTargetHeaderMaps(ctx)
-	return connect.NewResponse(&p2pstreamv1.CreatePublicRouteResponse{Route: publicRouteToProto(route, storedTargets, upstreamHeaders, responseHeaders, a.TargetHealth)}), nil
+	return connect.NewResponse(&p2pstreamv1.CreatePublicRouteResponse{Route: publicRouteToProto(route, storedTargets, upstreamHeaders, responseHeaders, s.targetHealth)}), nil
 }
 
 func (a *App) UpdatePublicRoute(
@@ -267,6 +346,14 @@ func (a *App) UpdatePublicRoute(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
+	return a.publicConfigService().UpdatePublicRoute(ctx, req)
+}
+
+func (s *publicConfigService) UpdatePublicRoute(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.UpdatePublicRouteRequest],
+) (*connect.Response[p2pstreamv1.UpdatePublicRouteResponse], error) {
+	a := s.app
 	params, routeTargets, err := a.validatePublicRouteInput(
 		ctx,
 		req.Msg.ListenerId,
@@ -296,7 +383,7 @@ func (a *App) UpdatePublicRoute(
 		return nil, err
 	}
 	upstreamHeaders, responseHeaders := a.publicRouteTargetHeaderMaps(ctx)
-	return connect.NewResponse(&p2pstreamv1.UpdatePublicRouteResponse{Route: publicRouteToProto(route, storedTargets, upstreamHeaders, responseHeaders, a.TargetHealth)}), nil
+	return connect.NewResponse(&p2pstreamv1.UpdatePublicRouteResponse{Route: publicRouteToProto(route, storedTargets, upstreamHeaders, responseHeaders, s.targetHealth)}), nil
 }
 
 func (a *App) createPublicRouteWithTargets(
@@ -416,7 +503,15 @@ func (a *App) DeletePublicRoute(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	if err := a.DB.DeletePublicRoute(ctx, req.Msg.Id); err != nil {
+	return a.publicConfigService().DeletePublicRoute(ctx, req)
+}
+
+func (s *publicConfigService) DeletePublicRoute(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.DeletePublicRouteRequest],
+) (*connect.Response[p2pstreamv1.DeletePublicRouteResponse], error) {
+	a := s.app
+	if err := s.db.DeletePublicRoute(ctx, req.Msg.Id); err != nil {
 		return nil, publicDBError(err)
 	}
 	if err := a.refreshPublicProxySnapshot(ctx); err != nil {

--- a/internal/server/public_config_handlers.go
+++ b/internal/server/public_config_handlers.go
@@ -17,10 +17,10 @@ func (a *App) GetPublicProxyConfig(
 	if _, err := a.requireUser(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	return a.publicConfigService().GetPublicProxyConfig(ctx, req)
+	return a.publicConfigService().getPublicProxyConfig(ctx, req)
 }
 
-func (s *publicConfigService) GetPublicProxyConfig(
+func (s *publicConfigService) getPublicProxyConfig(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.GetPublicProxyConfigRequest],
 ) (*connect.Response[p2pstreamv1.GetPublicProxyConfigResponse], error) {
@@ -39,10 +39,10 @@ func (a *App) ListPublicRouteTargetHealthTraces(
 	if _, err := a.requireUser(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	return a.publicConfigService().ListPublicRouteTargetHealthTraces(ctx, req)
+	return a.publicConfigService().listPublicRouteTargetHealthTraces(ctx, req)
 }
 
-func (s *publicConfigService) ListPublicRouteTargetHealthTraces(
+func (s *publicConfigService) listPublicRouteTargetHealthTraces(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.ListPublicRouteTargetHealthTracesRequest],
 ) (*connect.Response[p2pstreamv1.ListPublicRouteTargetHealthTracesResponse], error) {
@@ -72,10 +72,10 @@ func (a *App) CreatePublicListener(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	return a.publicConfigService().CreatePublicListener(ctx, req)
+	return a.publicConfigService().createPublicListener(ctx, req)
 }
 
-func (s *publicConfigService) CreatePublicListener(
+func (s *publicConfigService) createPublicListener(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.CreatePublicListenerRequest],
 ) (*connect.Response[p2pstreamv1.CreatePublicListenerResponse], error) {
@@ -112,10 +112,10 @@ func (a *App) UpdatePublicListener(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	return a.publicConfigService().UpdatePublicListener(ctx, req)
+	return a.publicConfigService().updatePublicListener(ctx, req)
 }
 
-func (s *publicConfigService) UpdatePublicListener(
+func (s *publicConfigService) updatePublicListener(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.UpdatePublicListenerRequest],
 ) (*connect.Response[p2pstreamv1.UpdatePublicListenerResponse], error) {
@@ -147,10 +147,10 @@ func (a *App) DeletePublicListener(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	return a.publicConfigService().DeletePublicListener(ctx, req)
+	return a.publicConfigService().deletePublicListener(ctx, req)
 }
 
-func (s *publicConfigService) DeletePublicListener(
+func (s *publicConfigService) deletePublicListener(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.DeletePublicListenerRequest],
 ) (*connect.Response[p2pstreamv1.DeletePublicListenerResponse], error) {
@@ -180,10 +180,10 @@ func (a *App) EnablePublicListener(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	return a.publicConfigService().EnablePublicListener(ctx, req)
+	return a.publicConfigService().enablePublicListener(ctx, req)
 }
 
-func (s *publicConfigService) EnablePublicListener(
+func (s *publicConfigService) enablePublicListener(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.EnablePublicListenerRequest],
 ) (*connect.Response[p2pstreamv1.EnablePublicListenerResponse], error) {
@@ -217,10 +217,10 @@ func (a *App) DisablePublicListener(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	return a.publicConfigService().DisablePublicListener(ctx, req)
+	return a.publicConfigService().disablePublicListener(ctx, req)
 }
 
-func (s *publicConfigService) DisablePublicListener(
+func (s *publicConfigService) disablePublicListener(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.DisablePublicListenerRequest],
 ) (*connect.Response[p2pstreamv1.DisablePublicListenerResponse], error) {
@@ -250,10 +250,10 @@ func (a *App) StartPublicListener(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	return a.publicConfigService().StartPublicListener(ctx, req)
+	return a.publicConfigService().startPublicListener(ctx, req)
 }
 
-func (s *publicConfigService) StartPublicListener(
+func (s *publicConfigService) startPublicListener(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.StartPublicListenerRequest],
 ) (*connect.Response[p2pstreamv1.StartPublicListenerResponse], error) {
@@ -275,10 +275,10 @@ func (a *App) StopPublicListener(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	return a.publicConfigService().StopPublicListener(ctx, req)
+	return a.publicConfigService().stopPublicListener(ctx, req)
 }
 
-func (s *publicConfigService) StopPublicListener(
+func (s *publicConfigService) stopPublicListener(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.StopPublicListenerRequest],
 ) (*connect.Response[p2pstreamv1.StopPublicListenerResponse], error) {
@@ -300,10 +300,10 @@ func (a *App) CreatePublicRoute(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	return a.publicConfigService().CreatePublicRoute(ctx, req)
+	return a.publicConfigService().createPublicRoute(ctx, req)
 }
 
-func (s *publicConfigService) CreatePublicRoute(
+func (s *publicConfigService) createPublicRoute(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.CreatePublicRouteRequest],
 ) (*connect.Response[p2pstreamv1.CreatePublicRouteResponse], error) {
@@ -346,10 +346,10 @@ func (a *App) UpdatePublicRoute(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	return a.publicConfigService().UpdatePublicRoute(ctx, req)
+	return a.publicConfigService().updatePublicRoute(ctx, req)
 }
 
-func (s *publicConfigService) UpdatePublicRoute(
+func (s *publicConfigService) updatePublicRoute(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.UpdatePublicRouteRequest],
 ) (*connect.Response[p2pstreamv1.UpdatePublicRouteResponse], error) {
@@ -503,10 +503,10 @@ func (a *App) DeletePublicRoute(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	return a.publicConfigService().DeletePublicRoute(ctx, req)
+	return a.publicConfigService().deletePublicRoute(ctx, req)
 }
 
-func (s *publicConfigService) DeletePublicRoute(
+func (s *publicConfigService) deletePublicRoute(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.DeletePublicRouteRequest],
 ) (*connect.Response[p2pstreamv1.DeletePublicRouteResponse], error) {

--- a/internal/server/public_config_service.go
+++ b/internal/server/public_config_service.go
@@ -24,28 +24,26 @@ type publicConfigService struct {
 	app          *App
 	db           *db.DB
 	targetHealth *publicRouteTargetHealthMonitor
-	acme         *publicACMEManager
 	runtime      publicConfigRuntime
 }
 
-func newPublicConfigService(app *App, database *db.DB, targetHealth *publicRouteTargetHealthMonitor, acme *publicACMEManager, runtime publicConfigRuntime) *publicConfigService {
+func newPublicConfigService(app *App, database *db.DB, targetHealth *publicRouteTargetHealthMonitor, runtime publicConfigRuntime) *publicConfigService {
 	return &publicConfigService{
 		app:          app,
 		db:           database,
 		targetHealth: targetHealth,
-		acme:         acme,
 		runtime:      runtime,
 	}
 }
 
 func (a *App) publicConfigService() *publicConfigService {
 	if a == nil {
-		return newPublicConfigService(nil, nil, nil, nil, nil)
+		return newPublicConfigService(nil, nil, nil, nil)
 	}
 	if a.publicConfig != nil {
 		return a.publicConfig
 	}
-	a.publicConfig = newPublicConfigService(a, a.DB, a.TargetHealth, a.PublicACME, appPublicConfigRuntime{app: a})
+	a.publicConfig = newPublicConfigService(a, a.DB, a.TargetHealth, appPublicConfigRuntime{app: a})
 	return a.publicConfig
 }
 

--- a/internal/server/public_config_service.go
+++ b/internal/server/public_config_service.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	p2pstreamv1 "p2pstream/gen/proto/p2pstream/v1"
+	"p2pstream/internal/db"
+)
+
+type publicConfigRuntime interface {
+	proxyStatus() *p2pstreamv1.ProxyStatus
+}
+
+type appPublicConfigRuntime struct {
+	app *App
+}
+
+func (r appPublicConfigRuntime) proxyStatus() *p2pstreamv1.ProxyStatus {
+	if r.app == nil {
+		return &p2pstreamv1.ProxyStatus{State: p2pstreamv1.ProxyState_PROXY_STATE_STOPPED}
+	}
+	return r.app.proxyStatus()
+}
+
+type publicConfigService struct {
+	app          *App
+	db           *db.DB
+	targetHealth *publicRouteTargetHealthMonitor
+	acme         *publicACMEManager
+	runtime      publicConfigRuntime
+}
+
+func newPublicConfigService(app *App, database *db.DB, targetHealth *publicRouteTargetHealthMonitor, acme *publicACMEManager, runtime publicConfigRuntime) *publicConfigService {
+	return &publicConfigService{
+		app:          app,
+		db:           database,
+		targetHealth: targetHealth,
+		acme:         acme,
+		runtime:      runtime,
+	}
+}
+
+func (a *App) publicConfigService() *publicConfigService {
+	if a == nil {
+		return newPublicConfigService(nil, nil, nil, nil, nil)
+	}
+	if a.publicConfig != nil {
+		return a.publicConfig
+	}
+	a.publicConfig = newPublicConfigService(a, a.DB, a.TargetHealth, a.PublicACME, appPublicConfigRuntime{app: a})
+	return a.publicConfig
+}
+
+func publicConfigProxyStatus(runtime publicConfigRuntime) *p2pstreamv1.ProxyStatus {
+	if runtime == nil {
+		return &p2pstreamv1.ProxyStatus{State: p2pstreamv1.ProxyState_PROXY_STATE_STOPPED}
+	}
+	return runtime.proxyStatus()
+}

--- a/internal/server/public_config_service.go
+++ b/internal/server/public_config_service.go
@@ -43,6 +43,7 @@ func (a *App) publicConfigService() *publicConfigService {
 	if a.publicConfig != nil {
 		return a.publicConfig
 	}
+	// Cache the initial dependencies; callers should not reassign them after construction.
 	a.publicConfig = newPublicConfigService(a, a.DB, a.TargetHealth, appPublicConfigRuntime{app: a})
 	return a.publicConfig
 }

--- a/internal/server/public_tls_config.go
+++ b/internal/server/public_tls_config.go
@@ -27,10 +27,10 @@ func (a *App) CreatePublicTlsDnsCredential(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	return a.publicConfigService().CreatePublicTlsDnsCredential(ctx, req)
+	return a.publicConfigService().createPublicTlsDnsCredential(ctx, req)
 }
 
-func (s *publicConfigService) CreatePublicTlsDnsCredential(
+func (s *publicConfigService) createPublicTlsDnsCredential(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.CreatePublicTlsDnsCredentialRequest],
 ) (*connect.Response[p2pstreamv1.CreatePublicTlsDnsCredentialResponse], error) {
@@ -67,10 +67,10 @@ func (a *App) UpdatePublicTlsDnsCredential(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	return a.publicConfigService().UpdatePublicTlsDnsCredential(ctx, req)
+	return a.publicConfigService().updatePublicTlsDnsCredential(ctx, req)
 }
 
-func (s *publicConfigService) UpdatePublicTlsDnsCredential(
+func (s *publicConfigService) updatePublicTlsDnsCredential(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.UpdatePublicTlsDnsCredentialRequest],
 ) (*connect.Response[p2pstreamv1.UpdatePublicTlsDnsCredentialResponse], error) {
@@ -109,10 +109,10 @@ func (a *App) DeletePublicTlsDnsCredential(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	return a.publicConfigService().DeletePublicTlsDnsCredential(ctx, req)
+	return a.publicConfigService().deletePublicTlsDnsCredential(ctx, req)
 }
 
-func (s *publicConfigService) DeletePublicTlsDnsCredential(
+func (s *publicConfigService) deletePublicTlsDnsCredential(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.DeletePublicTlsDnsCredentialRequest],
 ) (*connect.Response[p2pstreamv1.DeletePublicTlsDnsCredentialResponse], error) {
@@ -133,10 +133,10 @@ func (a *App) CreatePublicTlsCertificate(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	return a.publicConfigService().CreatePublicTlsCertificate(ctx, req)
+	return a.publicConfigService().createPublicTlsCertificate(ctx, req)
 }
 
-func (s *publicConfigService) CreatePublicTlsCertificate(
+func (s *publicConfigService) createPublicTlsCertificate(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.CreatePublicTlsCertificateRequest],
 ) (*connect.Response[p2pstreamv1.CreatePublicTlsCertificateResponse], error) {
@@ -188,10 +188,10 @@ func (a *App) UpdatePublicTlsCertificate(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	return a.publicConfigService().UpdatePublicTlsCertificate(ctx, req)
+	return a.publicConfigService().updatePublicTlsCertificate(ctx, req)
 }
 
-func (s *publicConfigService) UpdatePublicTlsCertificate(
+func (s *publicConfigService) updatePublicTlsCertificate(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.UpdatePublicTlsCertificateRequest],
 ) (*connect.Response[p2pstreamv1.UpdatePublicTlsCertificateResponse], error) {
@@ -259,10 +259,10 @@ func (a *App) DeletePublicTlsCertificate(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	return a.publicConfigService().DeletePublicTlsCertificate(ctx, req)
+	return a.publicConfigService().deletePublicTlsCertificate(ctx, req)
 }
 
-func (s *publicConfigService) DeletePublicTlsCertificate(
+func (s *publicConfigService) deletePublicTlsCertificate(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.DeletePublicTlsCertificateRequest],
 ) (*connect.Response[p2pstreamv1.DeletePublicTlsCertificateResponse], error) {
@@ -288,10 +288,10 @@ func (a *App) RenewPublicTlsCertificate(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	return a.publicConfigService().RenewPublicTlsCertificate(ctx, req)
+	return a.publicConfigService().renewPublicTlsCertificate(ctx, req)
 }
 
-func (s *publicConfigService) RenewPublicTlsCertificate(
+func (s *publicConfigService) renewPublicTlsCertificate(
 	ctx context.Context,
 	req *connect.Request[p2pstreamv1.RenewPublicTlsCertificateRequest],
 ) (*connect.Response[p2pstreamv1.RenewPublicTlsCertificateResponse], error) {

--- a/internal/server/public_tls_config.go
+++ b/internal/server/public_tls_config.go
@@ -27,6 +27,14 @@ func (a *App) CreatePublicTlsDnsCredential(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
+	return a.publicConfigService().CreatePublicTlsDnsCredential(ctx, req)
+}
+
+func (s *publicConfigService) CreatePublicTlsDnsCredential(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.CreatePublicTlsDnsCredentialRequest],
+) (*connect.Response[p2pstreamv1.CreatePublicTlsDnsCredentialResponse], error) {
+	a := s.app
 	params, err := a.validatePublicTLSDNSCredentialInput(
 		req.Msg.Name,
 		req.Msg.Provider,
@@ -39,7 +47,7 @@ func (a *App) CreatePublicTlsDnsCredential(
 	if err != nil {
 		return nil, err
 	}
-	credential, err := a.DB.CreatePublicTlsDnsCredential(ctx, db.CreatePublicTlsDnsCredentialParams{
+	credential, err := s.db.CreatePublicTlsDnsCredential(ctx, db.CreatePublicTlsDnsCredentialParams{
 		Name:             params.Name,
 		Provider:         params.Provider,
 		CloudflareZoneID: params.CloudflareZoneID,
@@ -59,7 +67,15 @@ func (a *App) UpdatePublicTlsDnsCredential(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	existing, err := a.DB.GetPublicTlsDnsCredential(ctx, req.Msg.Id)
+	return a.publicConfigService().UpdatePublicTlsDnsCredential(ctx, req)
+}
+
+func (s *publicConfigService) UpdatePublicTlsDnsCredential(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.UpdatePublicTlsDnsCredentialRequest],
+) (*connect.Response[p2pstreamv1.UpdatePublicTlsDnsCredentialResponse], error) {
+	a := s.app
+	existing, err := s.db.GetPublicTlsDnsCredential(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, publicDBError(err)
 	}
@@ -76,7 +92,7 @@ func (a *App) UpdatePublicTlsDnsCredential(
 		return nil, err
 	}
 	params.ID = req.Msg.Id
-	credential, err := a.DB.UpdatePublicTlsDnsCredential(ctx, params)
+	credential, err := s.db.UpdatePublicTlsDnsCredential(ctx, params)
 	if err != nil {
 		return nil, publicDBError(err)
 	}
@@ -93,7 +109,15 @@ func (a *App) DeletePublicTlsDnsCredential(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	if err := a.DB.DeletePublicTlsDnsCredential(ctx, req.Msg.Id); err != nil {
+	return a.publicConfigService().DeletePublicTlsDnsCredential(ctx, req)
+}
+
+func (s *publicConfigService) DeletePublicTlsDnsCredential(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.DeletePublicTlsDnsCredentialRequest],
+) (*connect.Response[p2pstreamv1.DeletePublicTlsDnsCredentialResponse], error) {
+	a := s.app
+	if err := s.db.DeletePublicTlsDnsCredential(ctx, req.Msg.Id); err != nil {
 		return nil, publicDBError(err)
 	}
 	if err := a.refreshPublicProxySnapshot(ctx); err != nil {
@@ -109,6 +133,14 @@ func (a *App) CreatePublicTlsCertificate(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
+	return a.publicConfigService().CreatePublicTlsCertificate(ctx, req)
+}
+
+func (s *publicConfigService) CreatePublicTlsCertificate(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.CreatePublicTlsCertificateRequest],
+) (*connect.Response[p2pstreamv1.CreatePublicTlsCertificateResponse], error) {
+	a := s.app
 	params, material, err := a.validatePublicTLSCertificateInput(
 		ctx,
 		req.Msg.ListenerId,
@@ -136,7 +168,7 @@ func (a *App) CreatePublicTlsCertificate(
 	if material.Replace {
 		cert, err = a.createUploadedPublicTLSCertificate(ctx, params, material.CertPEM, material.KeyPEM)
 	} else {
-		cert, err = a.DB.CreatePublicTlsCertificate(ctx, publicTLSCertificateCreateParams(params))
+		cert, err = s.db.CreatePublicTlsCertificate(ctx, publicTLSCertificateCreateParams(params))
 	}
 	if err != nil {
 		return nil, publicDBError(err)
@@ -156,7 +188,15 @@ func (a *App) UpdatePublicTlsCertificate(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	existing, err := a.DB.GetPublicTlsCertificate(ctx, req.Msg.Id)
+	return a.publicConfigService().UpdatePublicTlsCertificate(ctx, req)
+}
+
+func (s *publicConfigService) UpdatePublicTlsCertificate(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.UpdatePublicTlsCertificateRequest],
+) (*connect.Response[p2pstreamv1.UpdatePublicTlsCertificateResponse], error) {
+	a := s.app
+	existing, err := s.db.GetPublicTlsCertificate(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, publicDBError(err)
 	}
@@ -196,7 +236,7 @@ func (a *App) UpdatePublicTlsCertificate(
 	if material.Replace {
 		cert, err = a.updateUploadedPublicTLSCertificate(ctx, params, material.CertPEM, material.KeyPEM)
 	} else {
-		cert, err = a.DB.UpdatePublicTlsCertificate(ctx, publicTLSCertificateUpdateParams(params))
+		cert, err = s.db.UpdatePublicTlsCertificate(ctx, publicTLSCertificateUpdateParams(params))
 	}
 	if err != nil {
 		return nil, publicDBError(err)
@@ -219,11 +259,19 @@ func (a *App) DeletePublicTlsCertificate(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	cert, err := a.DB.GetPublicTlsCertificate(ctx, req.Msg.Id)
+	return a.publicConfigService().DeletePublicTlsCertificate(ctx, req)
+}
+
+func (s *publicConfigService) DeletePublicTlsCertificate(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.DeletePublicTlsCertificateRequest],
+) (*connect.Response[p2pstreamv1.DeletePublicTlsCertificateResponse], error) {
+	a := s.app
+	cert, err := s.db.GetPublicTlsCertificate(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, publicDBError(err)
 	}
-	if err := a.DB.DeletePublicTlsCertificate(ctx, req.Msg.Id); err != nil {
+	if err := s.db.DeletePublicTlsCertificate(ctx, req.Msg.Id); err != nil {
 		return nil, publicDBError(err)
 	}
 	if err := a.refreshPublicProxySnapshot(ctx); err != nil {
@@ -240,14 +288,22 @@ func (a *App) RenewPublicTlsCertificate(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	cert, err := a.DB.GetPublicTlsCertificate(ctx, req.Msg.Id)
+	return a.publicConfigService().RenewPublicTlsCertificate(ctx, req)
+}
+
+func (s *publicConfigService) RenewPublicTlsCertificate(
+	ctx context.Context,
+	req *connect.Request[p2pstreamv1.RenewPublicTlsCertificateRequest],
+) (*connect.Response[p2pstreamv1.RenewPublicTlsCertificateResponse], error) {
+	a := s.app
+	cert, err := s.db.GetPublicTlsCertificate(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, publicDBError(err)
 	}
 	if normalizePublicTLSCertificateSource(cert.Source) != publicTLSCertificateSourceACME {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("only ACME certificates can be renewed"))
 	}
-	cert, err = a.DB.UpdatePublicTlsCertificateRenewalStatus(ctx, db.UpdatePublicTlsCertificateRenewalStatusParams{
+	cert, err = s.db.UpdatePublicTlsCertificateRenewalStatus(ctx, db.UpdatePublicTlsCertificateRenewalStatusParams{
 		ID:                   cert.ID,
 		Status:               publicTLSCertificateStatusRenewing,
 		LastError:            "",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -53,6 +53,7 @@ type App struct {
 	PublicWAF       *publicWAF
 	PublicCache     *publicProxyCache
 	PublicACME      *publicACMEManager
+	publicConfig    *publicConfigService
 	AgentTransports *agentTransportPool
 	DashboardCache  *dashboardResponseCache
 	LoginThrottle   *loginThrottle

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -44,20 +44,21 @@ type App struct {
 
 	// These service fields remain public for package tests during the extraction stack.
 	// New construction should go through appServices so they can become private later.
-	AgentHub        *agentHub
-	LoadBalancers   *loadBalancerRegistry
-	TargetHealth    *publicRouteTargetHealthMonitor
-	TrafficTracer   *trafficTracer
-	RateLimiter     *publicRateLimiter
-	TrafficShaper   *publicTrafficShaper
-	PublicWAF       *publicWAF
-	PublicCache     *publicProxyCache
-	PublicACME      *publicACMEManager
-	publicConfig    *publicConfigService
-	proxyRuntime    *proxyRuntime
-	AgentTransports *agentTransportPool
-	DashboardCache  *dashboardResponseCache
-	LoginThrottle   *loginThrottle
+	AgentHub              *agentHub
+	LoadBalancers         *loadBalancerRegistry
+	TargetHealth          *publicRouteTargetHealthMonitor
+	TrafficTracer         *trafficTracer
+	RateLimiter           *publicRateLimiter
+	TrafficShaper         *publicTrafficShaper
+	PublicWAF             *publicWAF
+	PublicCache           *publicProxyCache
+	PublicACME            *publicACMEManager
+	publicConfig          *publicConfigService
+	proxyRuntime          *proxyRuntime
+	observabilityRecorder *observabilityRecorder
+	AgentTransports       *agentTransportPool
+	DashboardCache        *dashboardResponseCache
+	LoginThrottle         *loginThrottle
 
 	ProxyIsRunning atomic.Bool
 	ProxyLastError atomic.Pointer[string]

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -54,6 +54,7 @@ type App struct {
 	PublicCache     *publicProxyCache
 	PublicACME      *publicACMEManager
 	publicConfig    *publicConfigService
+	proxyRuntime    *proxyRuntime
 	AgentTransports *agentTransportPool
 	DashboardCache  *dashboardResponseCache
 	LoginThrottle   *loginThrottle

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -56,6 +56,7 @@ type App struct {
 	publicConfig          *publicConfigService
 	proxyRuntime          *proxyRuntime
 	observabilityRecorder *observabilityRecorder
+	auth                  *authService
 	AgentTransports       *agentTransportPool
 	DashboardCache        *dashboardResponseCache
 	LoginThrottle         *loginThrottle

--- a/web/management/e2e/traffic-flow.spec.ts
+++ b/web/management/e2e/traffic-flow.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "@playwright/test";
+import { authenticate } from "./helpers/auth";
+
+test("renders the traffic flow diagram through the management page", async ({ page }, testInfo) => {
+  const baseURL = testInfo.project.use.baseURL as string;
+  await authenticate(page, baseURL);
+
+  await page.goto("/#/traffic");
+  await expect(page.getByRole("heading", { name: "Traffic Flow", exact: true })).toBeVisible();
+
+  const diagram = page.locator(".traffic-flow-shell");
+  await expect(diagram).toBeVisible();
+  await expect(diagram.locator(".traffic-flow-node-ingress")).toBeVisible();
+  await expect(diagram.locator(".traffic-flow-node-response")).toBeVisible();
+  expect(await diagram.locator(".traffic-flow-node").count()).toBeGreaterThanOrEqual(2);
+});

--- a/web/management/src/ManagementApp.vue
+++ b/web/management/src/ManagementApp.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { RefreshCw as RefreshIcon } from "@lucide/vue";
 import { NAlert, NButton, NCard, NForm, NFormItem, NInput, NSelect, NSkeleton, useMessage, useNotification } from "naive-ui";
-import { computed, onBeforeUnmount, onMounted, ref, provide, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, provide } from "vue";
 import { useRoute } from "vue-router";
-import { localManagementClient, managementClient, setActiveManagementClientBase } from "@/api/managementClient";
+import { managementClient } from "@/api/managementClient";
 import DisabledHint from "@/components/DisabledHint.vue";
 import ThemeToggle from "@/components/ui/ThemeToggle.vue";
 import {
@@ -20,34 +20,45 @@ import {
   selectedEnvironmentLabelKey,
   setProxyRunningKey,
 } from "@/composables/managementContextKeys";
+import { useDashboardRefresh } from "@/composables/useDashboardRefresh";
+import { useManagementSession } from "@/composables/useManagementSession";
 import { BUSY_REASON } from "@/lib/disabledReasons";
 import { messageFromError } from "@/lib/errors";
-import {
-  EnvironmentTrustState,
-  type Environment,
-  type GetDashboardResponse,
-  type GetPublicProxyConfigResponse,
-  type GetSetupStateResponse,
-  type User,
-} from "@/gen/proto/p2pstream/v1/management_pb";
 
 const message = useMessage();
 const notification = useNotification();
 const route = useRoute();
 
-const setupState = ref<GetSetupStateResponse | null>(null);
-const currentUser = ref<User | null>(null);
-const dashboard = ref<GetDashboardResponse | null>(null);
-const publicProxyConfig = ref<GetPublicProxyConfigResponse | null>(null);
-const environments = ref<Environment[]>([]);
-const selectedEnvironmentId = ref(loadSelectedEnvironmentId());
-const isLoading = ref(true);
-const isBusy = ref(false);
-const isRefreshing = ref(false);
-const pendingDashboardReload = ref(false);
-const isLogoutConfirmOpen = ref(false);
-const refreshTimer = ref<number | null>(null);
-const error = ref<string | null>(null);
+const session = useManagementSession();
+const {
+  setupState,
+  currentUser,
+  setupForm,
+  loginForm,
+  isLoading,
+  isBusy,
+  isLogoutConfirmOpen,
+  error,
+  requestLogout,
+  cancelLogout,
+} = session;
+const dashboardRefresh = useDashboardRefresh({ currentUser, error, isBusy, isLoading });
+const {
+  dashboard,
+  publicProxyConfig,
+  environments,
+  selectedEnvironmentId,
+  selectedEnvironmentLabel,
+  selectedEnvironmentBlocked,
+  environmentSelectOptions,
+  isRefreshing,
+  loadEnvironments,
+  loadDashboard,
+  loadAuthenticatedData,
+  clearDashboardState,
+  clearAuthenticatedData,
+  stopAutoRefresh,
+} = dashboardRefresh;
 
 const tabs = [
   { path: "/overview", label: "Overview" },
@@ -69,92 +80,13 @@ const sourceOfferTitle = computed(() => {
   return "View source and license";
 });
 
-const setupForm = ref({ username: "admin", password: "" });
-const setupToken = ref("");
-const loginForm = ref({ username: "admin", password: "" });
 const refreshDisabledReason = computed(() => {
   if (isRefreshing.value) return "Dashboard refresh is already running.";
   if (isBusy.value) return BUSY_REASON;
   return "";
 });
 const busyDisabledReason = computed(() => isBusy.value ? BUSY_REASON : "");
-const environmentOptions = computed(() => [
-  { id: "0", name: "Local", enabled: true, trustState: EnvironmentTrustState.TRUSTED },
-  ...environments.value.map((environment) => ({
-    id: environment.id.toString(),
-    name: environment.name,
-    enabled: environment.enabled,
-    trustState: environment.trustState,
-  })),
-]);
-const environmentSelectOptions = computed(() => environmentOptions.value.map((environment) => ({
-  label: `${environment.name}${environment.enabled ? "" : " (disabled)"}`,
-  value: environment.id,
-})));
-const selectedRemoteEnvironment = computed(() => {
-  if (selectedEnvironmentId.value === "0") return null;
-  return environments.value.find((environment) => environment.id.toString() === selectedEnvironmentId.value) ?? null;
-});
-const selectedEnvironmentLabel = computed(() => selectedRemoteEnvironment.value?.name ?? "Local");
-const selectedEnvironmentBlocked = computed(() => {
-  const environment = selectedRemoteEnvironment.value;
-  if (!environment) return "";
-  if (!environment.enabled) return "Environment is disabled.";
-  if (environment.trustState !== EnvironmentTrustState.TRUSTED) return "Environment certificate must be trusted before management requests can run.";
-  return "";
-});
 const canShowRouteContent = computed(() => Boolean(dashboard.value) || route.path.startsWith("/settings"));
-
-function loadSelectedEnvironmentId(): string {
-  try {
-    return window.localStorage.getItem("p2pstream:selected-environment") || "0";
-  } catch {
-    return "0";
-  }
-}
-
-function persistSelectedEnvironmentId() {
-  try {
-    window.localStorage.setItem("p2pstream:selected-environment", selectedEnvironmentId.value);
-  } catch {
-    // Ignore private browsing/storage failures.
-  }
-}
-
-async function loadEnvironments() {
-  if (!currentUser.value) {
-    environments.value = [];
-    selectedEnvironmentId.value = "0";
-    return;
-  }
-  const resp = await localManagementClient.listEnvironments({});
-  environments.value = resp.environments;
-  if (selectedEnvironmentId.value !== "0" && !environments.value.some((environment) => environment.id.toString() === selectedEnvironmentId.value && environment.enabled)) {
-    selectedEnvironmentId.value = "0";
-  }
-}
-
-function syncSelectedEnvironmentClient() {
-  const environment = selectedRemoteEnvironment.value;
-  if (!environment) {
-    setActiveManagementClientBase(window.location.origin);
-  } else {
-    setActiveManagementClientBase(`${window.location.origin}/environments/${environment.id.toString()}`);
-  }
-  persistSelectedEnvironmentId();
-}
-
-watch(selectedEnvironmentId, () => {
-  syncSelectedEnvironmentClient();
-  if (!currentUser.value) return;
-  dashboard.value = null;
-  publicProxyConfig.value = null;
-  if (isLoading.value) {
-    pendingDashboardReload.value = true;
-    return;
-  }
-  void loadDashboard();
-});
 
 // Provide state to views
 provide(dashboardKey, computed(() => dashboard.value));
@@ -173,28 +105,13 @@ async function bootstrap() {
   stopAutoRefresh();
 
   try {
-    setupState.value = await localManagementClient.getSetupState({});
-    if (setupState.value.setupRequired) {
-      currentUser.value = null;
-      dashboard.value = null;
-      publicProxyConfig.value = null;
+    const sessionState = await session.bootstrapSession();
+    if (sessionState !== "authenticated") {
+      clearDashboardState();
       return;
     }
 
-    try {
-      const userResp = await localManagementClient.getCurrentUser({});
-      currentUser.value = userResp.user ?? null;
-    } catch {
-      currentUser.value = null;
-      dashboard.value = null;
-      publicProxyConfig.value = null;
-      return;
-    }
-
-    await loadEnvironments();
-    syncSelectedEnvironmentClient();
-    await loadDashboard();
-    startAutoRefresh();
+    await loadAuthenticatedData();
   } catch (err) {
     error.value = messageFromError(err);
   } finally {
@@ -202,135 +119,16 @@ async function bootstrap() {
   }
 }
 
-async function loadDashboard() {
-  if (isRefreshing.value) {
-    pendingDashboardReload.value = true;
-    return;
-  }
-  isRefreshing.value = true;
-  error.value = null;
-  const loadEnvironmentId = selectedEnvironmentId.value;
-  try {
-    syncSelectedEnvironmentClient();
-    const [dashboardResp, publicProxyResp] = await Promise.all([
-      managementClient.getDashboard({}),
-      managementClient.getPublicProxyConfig({}),
-    ]);
-    if (loadEnvironmentId !== selectedEnvironmentId.value) {
-      pendingDashboardReload.value = true;
-      return;
-    }
-    dashboard.value = dashboardResp;
-    publicProxyConfig.value = publicProxyResp;
-  } catch (err) {
-    if (loadEnvironmentId === selectedEnvironmentId.value) {
-      error.value = messageFromError(err);
-    } else {
-      pendingDashboardReload.value = true;
-    }
-  } finally {
-    isRefreshing.value = false;
-    if (pendingDashboardReload.value && currentUser.value) {
-      pendingDashboardReload.value = false;
-      void loadDashboard();
-    }
-  }
-}
-
-function startAutoRefresh() {
-  stopAutoRefresh();
-  if (!currentUser.value) return;
-  refreshTimer.value = window.setInterval(() => {
-    if (!currentUser.value || isBusy.value || isRefreshing.value) return;
-    void loadDashboard();
-  }, 5000);
-}
-
-function stopAutoRefresh() {
-  if (refreshTimer.value !== null) {
-    window.clearInterval(refreshTimer.value);
-    refreshTimer.value = null;
-  }
-}
-
 async function submitSetup() {
-  isBusy.value = true;
-  error.value = null;
-  try {
-    await localManagementClient.setupAdmin({
-      username: setupForm.value.username,
-      password: setupForm.value.password,
-      setupToken: setupToken.value,
-    });
-    await login(setupForm.value.username, setupForm.value.password);
-    setupState.value = await localManagementClient.getSetupState({});
-    await loadDashboard();
-    startAutoRefresh();
-  } catch (err) {
-    error.value = messageFromError(err);
-  } finally {
-    isBusy.value = false;
-  }
+  await session.submitSetup(loadAuthenticatedData);
 }
 
 async function submitLogin() {
-  isBusy.value = true;
-  error.value = null;
-  try {
-    await login(loginForm.value.username, loginForm.value.password);
-    await loadDashboard();
-    startAutoRefresh();
-  } catch (err) {
-    error.value = messageFromError(err);
-  } finally {
-    isBusy.value = false;
-  }
-}
-
-async function login(username: string, password: string) {
-  const loginResp = await localManagementClient.login({ username, password });
-  currentUser.value = loginResp.user ?? null;
-  await loadEnvironments();
-  syncSelectedEnvironmentClient();
-}
-
-function requestLogout() {
-  if (isBusy.value) return;
-  isLogoutConfirmOpen.value = true;
-}
-
-function cancelLogout() {
-  if (isBusy.value) return;
-  isLogoutConfirmOpen.value = false;
+  await session.submitLogin(loadAuthenticatedData);
 }
 
 async function confirmLogout() {
-  const didLogout = await logout();
-  if (didLogout) {
-    isLogoutConfirmOpen.value = false;
-  }
-}
-
-async function logout(): Promise<boolean> {
-  isBusy.value = true;
-  error.value = null;
-  try {
-    await localManagementClient.logout({});
-    stopAutoRefresh();
-    currentUser.value = null;
-    dashboard.value = null;
-    publicProxyConfig.value = null;
-    environments.value = [];
-    selectedEnvironmentId.value = "0";
-    syncSelectedEnvironmentClient();
-    loginForm.value.password = "";
-    return true;
-  } catch (err) {
-    error.value = messageFromError(err);
-    return false;
-  } finally {
-    isBusy.value = false;
-  }
+  await session.confirmLogout(clearAuthenticatedData);
 }
 
 async function setProxyRunning(shouldRun: boolean) {
@@ -370,39 +168,8 @@ provide(setProxyRunningKey, setProxyRunning);
 provide(runManagementActionKey, runManagementAction);
 provide(logoutKey, requestLogout);
 
-function setupTokenFromURL(): string {
-  const routeToken = stringQueryValue(route.query.setup_token);
-  if (routeToken) {
-    scrubSetupTokenFromURL();
-    return routeToken;
-  }
-  try {
-    const token = new URLSearchParams(window.location.search).get("setup_token")?.trim() ?? "";
-    if (token) scrubSetupTokenFromURL();
-    return token;
-  } catch {
-    return "";
-  }
-}
-
-function scrubSetupTokenFromURL() {
-  try {
-    const url = new URL(window.location.href);
-    if (!url.searchParams.has("setup_token")) return;
-    url.searchParams.delete("setup_token");
-    window.history.replaceState(window.history.state, "", `${url.pathname}${url.search}${url.hash}`);
-  } catch {
-    // Ignore browsers or test environments without full history support.
-  }
-}
-
-function stringQueryValue(value: unknown): string {
-  if (Array.isArray(value)) return stringQueryValue(value[0]);
-  return typeof value === "string" ? value.trim() : "";
-}
-
 onMounted(() => {
-  setupToken.value = setupTokenFromURL();
+  session.initializeSetupToken();
   void bootstrap();
 });
 

--- a/web/management/src/ManagementApp.vue
+++ b/web/management/src/ManagementApp.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { RefreshCw as RefreshIcon } from "@lucide/vue";
 import { NAlert, NButton, NCard, NForm, NFormItem, NInput, NSelect, NSkeleton, useMessage, useNotification } from "naive-ui";
-import { computed, onBeforeUnmount, onMounted, provide } from "vue";
+import { computed, onMounted, provide } from "vue";
 import { useRoute } from "vue-router";
 import { managementClient } from "@/api/managementClient";
 import DisabledHint from "@/components/DisabledHint.vue";
@@ -173,9 +173,6 @@ onMounted(() => {
   void bootstrap();
 });
 
-onBeforeUnmount(() => {
-  stopAutoRefresh();
-});
 </script>
 
 <template>

--- a/web/management/src/ManagementApp.vue
+++ b/web/management/src/ManagementApp.vue
@@ -6,7 +6,22 @@ import { useRoute } from "vue-router";
 import { localManagementClient, managementClient, setActiveManagementClientBase } from "@/api/managementClient";
 import DisabledHint from "@/components/DisabledHint.vue";
 import ThemeToggle from "@/components/ui/ThemeToggle.vue";
+import {
+  dashboardKey,
+  environmentsKey,
+  isBusyKey,
+  logoutKey,
+  managementClientKey,
+  publicProxyConfigKey,
+  reloadEnvironmentsKey,
+  runManagementActionKey,
+  selectedEnvironmentBlockedKey,
+  selectedEnvironmentIdKey,
+  selectedEnvironmentLabelKey,
+  setProxyRunningKey,
+} from "@/composables/managementContextKeys";
 import { BUSY_REASON } from "@/lib/disabledReasons";
+import { messageFromError } from "@/lib/errors";
 import {
   EnvironmentTrustState,
   type Environment,
@@ -142,15 +157,15 @@ watch(selectedEnvironmentId, () => {
 });
 
 // Provide state to views
-provide('dashboard', computed(() => dashboard.value));
-provide('publicProxyConfig', computed(() => publicProxyConfig.value));
-provide('isBusy', computed(() => isBusy.value));
-provide('managementClient', managementClient);
-provide('environments', computed(() => environments.value));
-provide('selectedEnvironmentId', computed(() => selectedEnvironmentId.value));
-provide('selectedEnvironmentLabel', selectedEnvironmentLabel);
-provide('selectedEnvironmentBlocked', selectedEnvironmentBlocked);
-provide('reloadEnvironments', loadEnvironments);
+provide(dashboardKey, computed(() => dashboard.value));
+provide(publicProxyConfigKey, computed(() => publicProxyConfig.value));
+provide(isBusyKey, computed(() => isBusy.value));
+provide(managementClientKey, managementClient);
+provide(environmentsKey, computed(() => environments.value));
+provide(selectedEnvironmentIdKey, computed(() => selectedEnvironmentId.value));
+provide(selectedEnvironmentLabelKey, selectedEnvironmentLabel);
+provide(selectedEnvironmentBlockedKey, selectedEnvironmentBlocked);
+provide(reloadEnvironmentsKey, loadEnvironments);
 
 async function bootstrap() {
   isLoading.value = true;
@@ -351,13 +366,9 @@ async function runManagementAction(action: () => Promise<void>, successMessage?:
   }
 }
 
-provide('setProxyRunning', setProxyRunning);
-provide('runManagementAction', runManagementAction);
-provide('logout', requestLogout);
-
-function messageFromError(err: unknown): string {
-  return err instanceof Error ? err.message : "Request failed";
-}
+provide(setProxyRunningKey, setProxyRunning);
+provide(runManagementActionKey, runManagementAction);
+provide(logoutKey, requestLogout);
 
 function setupTokenFromURL(): string {
   const routeToken = stringQueryValue(route.query.setup_token);

--- a/web/management/src/components/TrafficFlowDiagram.vue
+++ b/web/management/src/components/TrafficFlowDiagram.vue
@@ -16,134 +16,58 @@ import TrafficFlowEdge from "@/components/TrafficFlowEdge.vue";
 import TrafficFlowNode from "@/components/TrafficFlowNode.vue";
 import {
   CACHE_KEY,
-  RATE_LIMIT_KEY,
-  TRAFFIC_SHAPER_KEY,
-  WAF_KEY,
   TrafficRequestPathCache,
-  agentKey,
-  targetKey,
   createTrafficFlowConfigIndex,
-  agentsMatchingTargetSelector,
-  isRedirectRoute,
-  isTerminalTraceRequest,
-  listenerDefaultRouteKey,
-  listenerKey,
-  redirectKey,
-  routeTargetAssignments,
-  requestUsesRateLimitNode,
-  requestUsesCacheNode,
-  requestUsesTrafficShaperNode,
-  requestUsesWafNode,
-  routeConfigForRequest,
-  routeKey,
   type TrafficRequestPathCacheEntry,
 } from "@/lib/trafficFlowLayout";
 import {
+  buildTrafficFlowDiagramLayout,
+  buildTrafficFlowEdgeRoutes,
+  cacheStatusForTone,
+  cacheTonePriority,
+  edgeKey,
+  nodeBounds,
+  pointInsideBounds,
+  routeToMotionPoints,
+} from "@/lib/trafficFlowDiagramLayout";
+import {
+  activeVisualTokens,
+  advanceVisualToken,
+  cacheStorePulseActive,
+  createVisualToken,
+  nextFrameStressState,
+  renderedTokenCap,
+  resetFrameStressState,
+  shouldEnqueueCacheStorePulse,
+  tokenColorClass,
+  updateVisualToken,
+  visualTokenOpacity,
+  visualTokenPoint,
+} from "@/lib/trafficFlowAnimation";
+import {
+  CACHE_PROXIMITY_PX,
+  CACHE_STORE_PULSE_MS,
+  FLOW_ID,
+  NODE_HEIGHT,
+  NODE_WIDTH,
+  type CacheNodeStatus,
+  type CacheStorePulse,
+  type Point,
+  type TrafficNodeData,
+  type VisualToken,
+} from "@/lib/trafficFlowModel";
+import {
   buildMotionNodeBox,
   buildMotionPlan,
-  motionEdgeKey,
-  pointAtMotionDistance,
   type MotionNodeBox,
   type MotionPlan,
   type MotionPoint,
 } from "@/lib/trafficMotion";
-import {
-  PublicRouteRedirectTargetMode,
-  PublicRouteTargetTransport,
-  PublicRouteTargetType,
-  TrafficTraceStage,
-  type Agent,
-  type GetPublicProxyConfigResponse,
-  type PublicRoute,
-  type PublicRouteTarget,
-} from "@/gen/proto/p2pstream/v1/management_pb";
-import type { TrafficFlowEditRequest, TrafficFlowEditTarget } from "@/types/trafficFlowEdit";
+import type { GetPublicProxyConfigResponse } from "@/gen/proto/p2pstream/v1/management_pb";
+import type { TrafficFlowEditRequest } from "@/types/trafficFlowEdit";
 import type { TraceRequest } from "@/types/trafficTrace";
 import "@vue-flow/core/dist/style.css";
 import "@vue-flow/core/dist/theme-default.css";
-
-export type TrafficNodeKind = "ingress" | "listener" | "waf" | "rate-limit" | "traffic-shaper" | "cache" | "route" | "target" | "redirect" | "agent" | "upstream" | "response";
-type AgentNodeStatus = {
-  state: "connected" | "offline" | "disabled" | "unknown";
-  label: string;
-};
-export type CacheNodeTone = "hit" | "miss" | "bypass" | "stored" | "lookup" | "neutral";
-type CacheNodeStatus = {
-  label: string;
-  tone: CacheNodeTone;
-};
-
-export type TrafficNodeData = {
-  label: string;
-  subLabel: string;
-  kind: TrafficNodeKind;
-  editTargets: TrafficFlowEditTarget[];
-  agentStatus?: AgentNodeStatus;
-  cacheStatus?: CacheNodeStatus;
-};
-
-type DiagramNode = TrafficNodeData & {
-  key: string;
-  column: number;
-  x: number;
-  y: number;
-};
-type DiagramNodeInput = Omit<DiagramNode, "x" | "y" | "editTargets"> & {
-  editTargets?: TrafficFlowEditTarget[];
-};
-
-type DiagramEdgeRoute = "default" | "agent-bypass" | "intermediate-bypass";
-type DiagramEdge = {
-  from: string;
-  to: string;
-  route: DiagramEdgeRoute;
-};
-type Point = { x: number; y: number };
-type CubicSegment = {
-  source: Point;
-  sourceControl: Point;
-  targetControl: Point;
-  target: Point;
-  lengthTable: Array<{ t: number; length: number }>;
-  totalLength: number;
-};
-type EdgeRouteGeometry = {
-  from: string;
-  to: string;
-  route: DiagramEdgeRoute;
-  segments: CubicSegment[];
-  totalLength: number;
-  path: string;
-};
-type Bounds = {
-  left: number;
-  right: number;
-  top: number;
-  bottom: number;
-};
-type VisualTokenStatus = "in-flight" | "success" | "client-error" | "server-error" | "failed";
-type VisualTokenCacheTone = "hit" | "miss" | "bypass" | "stored" | "";
-
-type VisualToken = {
-  requestId: string;
-  request: TraceRequest;
-  path: string[];
-  label: string;
-  motionPlan: MotionPlan;
-  currentDistance: number;
-  targetDistance: number;
-  startedAt: number;
-  updatedAt: number;
-  durationMs: number;
-  finishedAt: number | null;
-  status: VisualTokenStatus;
-  cacheTone: VisualTokenCacheTone;
-  skipped: boolean;
-};
-type CacheStorePulse = {
-  requestId: string;
-  startedAt: number;
-};
 
 const props = withDefaults(
   defineProps<{
@@ -160,35 +84,6 @@ const emit = defineEmits<{
   (event: "skipped-change", count: number): void;
   (event: "edit-node", request: TrafficFlowEditRequest): void;
 }>();
-
-const NODE_WIDTH = 152;
-const NODE_HEIGHT = 58;
-const COLUMN_X = [0, 190, 380, 570, 760, 950, 1140, 1330, 1520, 1710, 1900];
-const ROW_GAP = 92;
-const MIN_CENTER_Y = 92;
-const CACHE_SIDE_CENTER_Y = MIN_CENTER_Y;
-const FLOW_ID = "traffic-flow-diagram";
-const EDGE_CURVATURE = 0.25;
-const BEZIER_LENGTH_SAMPLES = 32;
-const BYPASS_LANE_GAP = 54;
-const BYPASS_X_GAP = 24;
-const MIN_BYPASS_Y = 28;
-
-const MIN_PLAYBACK_MS = 1800;
-const MAX_PLAYBACK_MS = 6000;
-const BASE_PLAYBACK_MS = 1200;
-const PER_HOP_MS = 450;
-const LOW_BURST_THRESHOLD = 12;
-const HIGH_BURST_THRESHOLD = 40;
-const MAX_RENDERED_TOKENS_NORMAL = 36;
-const MAX_RENDERED_TOKENS_STRESSED = 16;
-const FRAME_STRESS_MS = 40;
-const FRAME_RECOVERY_MS = 20;
-const FRAME_RECOVERY_COUNT = 12;
-const COMPLETION_HOLD_MS = 2000;
-const COMPLETION_FADE_MS = 650;
-const CACHE_PROXIMITY_PX = 40;
-const CACHE_STORE_PULSE_MS = 900;
 
 const nodeTypes: NodeTypesObject = {
   traffic: markRaw(TrafficFlowNode),
@@ -210,279 +105,19 @@ const seenRequestIds = new Set<string>();
 const seenCacheStorePulseRequestIds = new Set<string>();
 let rafId: number | null = null;
 let didInitialFit = false;
-let previousFrameAt: number | null = null;
-let recoveryFrames = 0;
+let frameStressState = resetFrameStressState();
 
-const layout = computed(() => {
-  const nodes = new Map<string, Omit<DiagramNode, "x" | "y">>();
-  const edges: DiagramEdge[] = [];
-
-  const addNode = (node: DiagramNodeInput) => {
-    const existing = nodes.get(node.key);
-    if (!existing) {
-      nodes.set(node.key, { ...node, editTargets: dedupeEditTargets(node.editTargets ?? []) });
-      return;
-    }
-    nodes.set(node.key, {
-      ...existing,
-      editTargets: dedupeEditTargets([...existing.editTargets, ...(node.editTargets ?? [])]),
-      agentStatus: mergeAgentStatus(existing.agentStatus, node.agentStatus),
-      cacheStatus: mergeCacheStatus(existing.cacheStatus, node.cacheStatus),
-    });
-  };
-  const addEdge = (from: string, to: string, route: DiagramEdgeRoute = "default") => {
-    if (!from || !to || from === to) return;
-    edges.push({ from, to, route });
-  };
-  const index = configIndex.value;
-
-  addNode({ key: "ingress", label: "Ingress", subLabel: "Public request", column: 0, kind: "ingress", editTargets: [] });
-  addNode({ key: "response", label: "Response", subLabel: "Client", column: 10, kind: "response", editTargets: [] });
-
-  const listeners = props.config?.listeners ?? [];
-  const targets = props.config?.routeTargets ?? [];
-  const enabledRateLimitTargets = index.enabledRateLimitTargets;
-  const enabledWafTargets = index.enabledWafTargets;
-  const enabledCacheTargets = index.enabledCacheTargets;
-  const enabledTrafficShaperTargets = index.enabledTrafficShaperTargets;
-  const showWafNode = index.hasEnabledWafRules || props.requests.some((request) => requestUsesWafNode(request, index));
-  const showRateLimitNode = index.hasEnabledRateLimitRules || props.requests.some((request) => requestUsesRateLimitNode(request, index));
-  const showTrafficShaperNode = index.hasEnabledTrafficShaperRules || props.requests.some((request) => requestUsesTrafficShaperNode(request, index));
-  const showCacheNode = index.hasEnabledCacheRules || props.requests.some((request) => requestUsesCacheNode(request, index));
-
-  if (showWafNode) {
-    addNode({
-      key: WAF_KEY,
-      label: "WAF",
-      subLabel: enabledWafTargets.length ? `${enabledWafTargets.length.toString()} enabled` : "Observed",
-      column: 2,
-      kind: "waf",
-      editTargets: enabledWafTargets,
-    });
-  }
-
-  if (showRateLimitNode) {
-    addNode({
-      key: RATE_LIMIT_KEY,
-      label: "Rate limit",
-      subLabel: enabledRateLimitTargets.length ? `${enabledRateLimitTargets.length.toString()} enabled` : "Observed",
-      column: 3,
-      kind: "rate-limit",
-      editTargets: enabledRateLimitTargets,
-    });
-  }
-
-  if (showTrafficShaperNode) {
-    addNode({
-      key: TRAFFIC_SHAPER_KEY,
-      label: "Traffic shaper",
-      subLabel: enabledTrafficShaperTargets.length ? `${enabledTrafficShaperTargets.length.toString()} enabled` : "Observed",
-      column: 4,
-      kind: "traffic-shaper",
-      editTargets: enabledTrafficShaperTargets,
-    });
-  }
-
-  if (showCacheNode) {
-    addNode({
-      key: CACHE_KEY,
-      label: "Cache",
-      subLabel: enabledCacheTargets.length ? `${enabledCacheTargets.length.toString()} enabled` : "Observed",
-      column: 7,
-      kind: "cache",
-      editTargets: enabledCacheTargets,
-      cacheStatus: { label: "READY", tone: "neutral" },
-    });
-  }
-
-  for (const listener of listeners) {
-    const listenerNodeKey = listenerKey(listener.id);
-    const routeEntryKey = showTrafficShaperNode ? TRAFFIC_SHAPER_KEY : showRateLimitNode ? RATE_LIMIT_KEY : showWafNode ? WAF_KEY : listenerNodeKey;
-    const rateEntryKey = showWafNode ? WAF_KEY : listenerNodeKey;
-    const shaperEntryKey = showRateLimitNode ? RATE_LIMIT_KEY : showWafNode ? WAF_KEY : listenerNodeKey;
-    addNode({
-      key: listenerNodeKey,
-      label: listener.name || `Listener ${listener.id.toString()}`,
-      subLabel: `${listener.bindAddress || "*"}:${listener.port.toString()}`,
-      column: 1,
-      kind: "listener",
-      editTargets: [listenerEditTarget(listener.id, listener.name || `Listener ${listener.id.toString()}`, `${listener.bindAddress || "*"}:${listener.port.toString()}`)],
-    });
-    addEdge("ingress", listenerNodeKey);
-    if (showWafNode) {
-      addEdge(listenerNodeKey, WAF_KEY);
-    }
-    if (showRateLimitNode) {
-      addEdge(rateEntryKey, RATE_LIMIT_KEY);
-    }
-    if (showTrafficShaperNode) {
-      addEdge(shaperEntryKey, TRAFFIC_SHAPER_KEY);
-    }
-
-    const defaultRouteKey = listenerDefaultRouteKey(listener.id);
-    addNode({
-      key: defaultRouteKey,
-      label: "Default route",
-      subLabel: "Listener fallbacks",
-      column: 5,
-      kind: "route",
-      editTargets: [listenerEditTarget(listener.id, listener.name || `Listener ${listener.id.toString()}`, "Default target")],
-    });
-    addEdge(routeEntryKey, defaultRouteKey);
-    const defaultRoute = (index.routesByListenerId.get(listener.id.toString()) ?? []).find((route) => route.isDefault);
-    if (defaultRoute) {
-      for (const target of routeTargetAssignments(defaultRoute, index).filter((item) => item.enabled)) {
-        addEdge(defaultRouteKey, targetKey(target.id));
-      }
-    } else {
-      addEdge(defaultRouteKey, "response", "agent-bypass");
-    }
-
-    for (const route of index.routesByListenerId.get(listener.id.toString()) ?? []) {
-      if (route.isDefault) continue;
-      const key = routeKey(route.id);
-      addNode({
-        key,
-        label: routeLabel(route.hostPattern, route.pathPrefix, route.id),
-        subLabel: `P${route.priority.toString()}`,
-        column: 5,
-        kind: "route",
-        editTargets: [routeEditTarget(route)],
-      });
-      addEdge(routeEntryKey, key);
-      if (isRedirectRoute(route)) {
-        addRedirectNode(route, addNode);
-        addEdge(key, redirectKey(route.id));
-        addEdge(redirectKey(route.id), "response", "intermediate-bypass");
-      } else {
-        const assignments = routeTargetAssignments(route, index).filter((target) => target.enabled);
-        if (assignments.length) {
-          for (const target of assignments) {
-            addEdge(key, targetKey(target.id));
-          }
-        } else {
-          addEdge(key, "response", "agent-bypass");
-        }
-      }
-    }
-  }
-
-  for (const target of targets) {
-    const key = targetKey(target.id);
-    const isStatic = target.targetType === PublicRouteTargetType.STATIC;
-    const isAgentTarget = target.transport === PublicRouteTargetTransport.AGENT;
-    addNode({
-      key,
-      label: target.name || `Target ${target.id.toString()}`,
-      subLabel: isStatic ? "Static" : isAgentTarget ? "Agent selected" : "Direct",
-      column: 6,
-      kind: "target",
-      editTargets: [targetEditTarget(target.id, target.name || `Target ${target.id.toString()}`, isStatic ? "Static" : isAgentTarget ? "Agent selected" : "Direct")],
-    });
-
-    if (isStatic) {
-      addStaticNode(addNode, targetEditTarget(target.id, target.name || `Target ${target.id.toString()}`, "Static"));
-      addEdge(key, "static-response", "agent-bypass");
-      addEdge("static-response", "response");
-      continue;
-    }
-
-    if (isAgentTarget) {
-      const matchedAgents = agentsMatchingTarget(target, props.config?.agents ?? []);
-      if (matchedAgents.length) {
-        for (const agent of matchedAgents) {
-          const agentNodeKey = agentKey(agent.id);
-          addNode({
-            key: agentNodeKey,
-            label: agent.name || `Agent ${agent.id.toString()}`,
-            subLabel: agent.publicId,
-            column: 8,
-            kind: "agent",
-            agentStatus: agentNodeStatus(agent),
-            editTargets: [agentEditTarget(agent.id, agent.name || `Agent ${agent.id.toString()}`, agent.publicId)],
-          });
-          addUpstreamNode(addNode, targetEditTarget(target.id, target.name || `Target ${target.id.toString()}`, "Agent selected"));
-          if (showCacheNode) {
-            addEdge(key, CACHE_KEY);
-            addEdge(CACHE_KEY, "response", "intermediate-bypass");
-          }
-          addEdge(key, agentNodeKey);
-          addEdge(agentNodeKey, "upstream");
-          addEdge("upstream", "response");
-        }
-      } else {
-        if (showCacheNode) {
-          addEdge(key, CACHE_KEY);
-          addEdge(CACHE_KEY, "response", "agent-bypass");
-        }
-        addEdge(key, "response", "agent-bypass");
-      }
-      continue;
-    }
-
-    addUpstreamNode(addNode, targetEditTarget(target.id, target.name || `Target ${target.id.toString()}`, "Direct"));
-    if (showCacheNode) {
-      addEdge(key, CACHE_KEY);
-      addEdge(CACHE_KEY, "response", "intermediate-bypass");
-    }
-    addEdge(key, "upstream", "agent-bypass");
-    addEdge("upstream", "response");
-  }
-
-  for (const request of props.requests) {
-    addObservedNodes(request, addNode);
-    const path = cachedRequestPath(request).path;
-    for (let index = 0; index < path.length - 1; index += 1) {
-      addEdge(path[index], path[index + 1], routeForRequestSegment(request, path[index], path[index + 1]));
-    }
-  }
-
-  if (!listeners.length && !props.requests.length) {
-    const policyPath = [
-      showWafNode ? WAF_KEY : "",
-      showRateLimitNode ? RATE_LIMIT_KEY : "",
-      showTrafficShaperNode ? TRAFFIC_SHAPER_KEY : "",
-    ].filter(Boolean);
-    if (policyPath.length) {
-      addEdge("ingress", policyPath[0]);
-      for (let index = 0; index < policyPath.length - 1; index += 1) {
-        addEdge(policyPath[index], policyPath[index + 1]);
-      }
-      addEdge(policyPath[policyPath.length - 1], "response", "intermediate-bypass");
-    } else {
-      addEdge("ingress", "response");
-    }
-  }
-
-  const byColumn = new Map<number, Omit<DiagramNode, "x" | "y">[]>();
-  for (const node of nodes.values()) {
-    const group = byColumn.get(node.column) ?? [];
-    group.push(node);
-    byColumn.set(node.column, group);
-  }
-
-  const positioned: DiagramNode[] = [];
-  for (const [column, group] of byColumn.entries()) {
-    group.sort((a, b) => kindOrder(a.kind) - kindOrder(b.kind) || a.label.localeCompare(b.label));
-    group.forEach((node, index) => {
-      const centerY = node.key === CACHE_KEY ? CACHE_SIDE_CENTER_Y : yPosition(index, group.length);
-      positioned.push({
-        ...node,
-        x: COLUMN_X[column] ?? COLUMN_X[0],
-        y: centerY - NODE_HEIGHT / 2,
-      });
-    });
-  }
-
-  const nodeByKey = new Map(positioned.map((node) => [node.key, node]));
-  const uniqueEdges = dedupeEdges(edges).filter((edge) => nodeByKey.has(edge.from) && nodeByKey.has(edge.to));
-  return { nodes: positioned, nodeByKey, edges: uniqueEdges };
-});
+const layout = computed(() => buildTrafficFlowDiagramLayout({
+  config: props.config,
+  requests: props.requests,
+  configIndex: configIndex.value,
+  requestPath: cachedRequestPath,
+}));
 
 const activeCacheStatus = computed<CacheNodeStatus | undefined>(() => {
   const cacheNode = layout.value.nodeByKey.get(CACHE_KEY);
   if (!cacheNode) return undefined;
-  const now = rafNow.value;
+  rafNow.value;
   const candidates: CacheNodeStatus[] = [];
   const bounds = nodeBounds(cacheNode);
   const expandedBounds = {
@@ -493,7 +128,7 @@ const activeCacheStatus = computed<CacheNodeStatus | undefined>(() => {
   };
   for (const token of visualTokens.value) {
     if (!token.cacheTone || !token.path.includes(CACHE_KEY)) continue;
-    const point = tokenPoint(token, now);
+    const point = tokenPoint(token);
     if (!point || !pointInsideBounds(point, expandedBounds)) continue;
     candidates.push(cacheStatusForTone(token.cacheTone));
   }
@@ -553,27 +188,7 @@ const flowEdges = computed<Edge[]>(() =>
   }),
 );
 
-const edgeRoutes = computed(() => {
-  const routes = new Map<string, EdgeRouteGeometry>();
-  for (const edge of layout.value.edges) {
-    const sourceNode = layout.value.nodeByKey.get(edge.from);
-    const targetNode = layout.value.nodeByKey.get(edge.to);
-    if (!sourceNode || !targetNode) continue;
-
-    const source = sourceHandlePoint(sourceNode);
-    const target = targetHandlePoint(targetNode);
-    const bypassBounds = bypassBoundsForEdge(edge);
-    const route =
-      edge.route !== "default" && bypassBounds
-        ? buildBypassRoute(edge, source, target, bypassBounds)
-        : buildDefaultBezierRoute(edge, source, target);
-    routes.set(
-      edgeKey(edge.from, edge.to),
-      route,
-    );
-  }
-  return routes;
-});
+const edgeRoutes = computed(() => buildTrafficFlowEdgeRoutes(layout.value));
 
 const motionNodeBoxes = computed(() => {
   const boxes = new Map<string, MotionNodeBox>();
@@ -612,7 +227,7 @@ const tokenViews = computed(() => {
   const now = rafNow.value;
   return visualTokens.value
     .map((token) => {
-      const point = tokenPoint(token, now);
+      const point = tokenPoint(token);
       if (!point) return null;
       return {
         token,
@@ -620,7 +235,7 @@ const tokenViews = computed(() => {
         y: point.y * transform.zoom + transform.y,
         colorClass: tokenColorClass(token),
         label: token.label,
-        opacity: tokenOpacity(token, now),
+        opacity: visualTokenOpacity(token, now),
         nearCache: isTokenNearCache(token, point),
       };
     })
@@ -640,7 +255,7 @@ const cacheStorePulseViews = computed(() => {
   return cacheStorePulses.value
     .map((pulse) => {
       const age = now - pulse.startedAt;
-      if (age < 0 || age > CACHE_STORE_PULSE_MS) return null;
+      if (age < 0 || !cacheStorePulseActive(pulse.startedAt, now, CACHE_STORE_PULSE_MS)) return null;
       return {
         id: pulse.requestId,
         x: center.x,
@@ -799,51 +414,37 @@ function createToken(request: TraceRequest): VisualToken {
   const cached = cachedRequestPath(request);
   const motionPlan = motionPlanForCachedPath(request.requestId, cached);
   const now = nowMs();
-  const durationMs = playbackDuration(cached.path.length - 1, visualTokens.value.length);
-  return {
-    requestId: request.requestId,
+  return createVisualToken({
     request,
-    path: cached.path,
-    label: requestLabel(request),
+    cached,
     motionPlan,
-    currentDistance: 0,
-    targetDistance: motionPlan.targetLength,
-    startedAt: now,
-    updatedAt: now,
-    durationMs,
-    finishedAt: null,
-    status: statusForRequest(request),
-    cacheTone: cacheToneForRequest(request),
-    skipped: false,
-  };
+    activeTokenCount: visualTokens.value.length,
+    now,
+  });
 }
 
 function updateToken(token: VisualToken, request: TraceRequest) {
-  advanceToken(token, nowMs());
+  const now = nowMs();
   const cached = cachedRequestPath(request);
   const motionPlan = motionPlanForCachedPath(request.requestId, cached);
-  token.request = request;
-  token.path = cached.path;
-  token.label = requestLabel(request);
-  token.motionPlan = motionPlan;
-  token.currentDistance = clamp(token.currentDistance, 0, motionPlan.targetLength);
-  token.targetDistance = motionPlan.targetLength;
-  token.durationMs = Math.max(token.durationMs, playbackDuration(token.path.length - 1, visualTokens.value.length));
-  token.status = statusForRequest(request);
-  token.cacheTone = cacheToneForRequest(request);
+  updateVisualToken({
+    token,
+    request,
+    cached,
+    motionPlan,
+    activeTokenCount: visualTokens.value.length,
+    now,
+  });
 }
 
 function maybeEnqueueCacheStorePulse(request: TraceRequest): boolean {
-  if (cacheToneForRequest(request) !== "stored") return false;
-  if (!requestUsesCacheNode(request, configIndex.value)) return false;
-  if (seenCacheStorePulseRequestIds.has(request.requestId)) return false;
-  seenCacheStorePulseRequestIds.add(request.requestId);
+  if (!shouldEnqueueCacheStorePulse(request, configIndex.value, seenCacheStorePulseRequestIds)) return false;
   cacheStorePulses.value.push({ requestId: request.requestId, startedAt: nowMs() });
   return true;
 }
 
 function pruneCacheStorePulses(now: number) {
-  const active = cacheStorePulses.value.filter((pulse) => now - pulse.startedAt <= CACHE_STORE_PULSE_MS);
+  const active = cacheStorePulses.value.filter((pulse) => cacheStorePulseActive(pulse.startedAt, now, CACHE_STORE_PULSE_MS));
   if (active.length !== cacheStorePulses.value.length) {
     cacheStorePulses.value = active;
   }
@@ -866,14 +467,11 @@ function tick(now: number) {
   let changed = false;
 
   for (const token of visualTokens.value) {
-    advanceToken(token, now);
+    advanceVisualToken(token, now);
   }
   pruneCacheStorePulses(now);
 
-  const activeTokens = visualTokens.value.filter((token) => {
-    if (token.finishedAt === null) return true;
-    return now - token.finishedAt <= COMPLETION_HOLD_MS + COMPLETION_FADE_MS;
-  });
+  const activeTokens = activeVisualTokens(visualTokens.value, now);
   if (activeTokens.length !== visualTokens.value.length) {
     visualTokens.value = activeTokens;
     changed = true;
@@ -896,36 +494,8 @@ function tick(now: number) {
   }
 }
 
-function advanceToken(token: VisualToken, now: number) {
-  if (token.finishedAt !== null) {
-    token.updatedAt = now;
-    return;
-  }
-
-  const elapsed = Math.max(0, now - token.updatedAt);
-  token.updatedAt = now;
-  if (token.currentDistance < token.targetDistance) {
-    const speed = Math.max(token.motionPlan.totalLength, token.targetDistance, 1) / token.durationMs;
-    token.currentDistance = Math.min(token.targetDistance, token.currentDistance + speed * elapsed);
-  }
-
-  if (isTerminalTraceRequest(token.request) && token.currentDistance >= token.targetDistance && token.finishedAt === null) {
-    token.finishedAt = now;
-  }
-}
-
-function tokenPoint(token: VisualToken, _now: number): Point | null {
-  const point = pointAtMotionDistance(token.motionPlan, token.currentDistance);
-  if (point) return point;
-  const fallbackKey = token.path[Math.min(token.motionPlan.targetNodeIndex, token.path.length - 1)] ?? "ingress";
-  return motionNodeBoxes.value.get(fallbackKey)?.center ?? null;
-}
-
-function tokenOpacity(token: VisualToken, now: number): number {
-  if (token.finishedAt === null) return 1;
-  const age = now - token.finishedAt;
-  if (age <= COMPLETION_HOLD_MS) return 1;
-  return clamp(1 - (age - COMPLETION_HOLD_MS) / COMPLETION_FADE_MS, 0, 1);
+function tokenPoint(token: VisualToken): Point | null {
+  return visualTokenPoint(token, motionNodeBoxes.value);
 }
 
 function cachedRequestPath(request: TraceRequest) {
@@ -959,38 +529,17 @@ function pruneTokenMotionPlanCache(requestIds: Set<string>) {
   }
 }
 
-function requestLabel(request: TraceRequest): string {
-  return `${request.method || "REQUEST"} ${request.path || "/"}`;
-}
-
 function nowMs(): number {
   return typeof performance === "undefined" ? Date.now() : performance.now();
 }
 
 function currentTokenCap(): number {
-  return isAnimationStressed.value ? MAX_RENDERED_TOKENS_STRESSED : MAX_RENDERED_TOKENS_NORMAL;
+  return renderedTokenCap(isAnimationStressed.value);
 }
 
 function updateFrameStress(now: number) {
-  if (previousFrameAt === null) {
-    previousFrameAt = now;
-    return;
-  }
-  const delta = now - previousFrameAt;
-  previousFrameAt = now;
-  if (delta > FRAME_STRESS_MS) {
-    isAnimationStressed.value = true;
-    recoveryFrames = 0;
-    return;
-  }
-  if (delta < FRAME_RECOVERY_MS) {
-    recoveryFrames += 1;
-    if (recoveryFrames >= FRAME_RECOVERY_COUNT) {
-      isAnimationStressed.value = false;
-    }
-    return;
-  }
-  recoveryFrames = 0;
+  frameStressState = nextFrameStressState(frameStressState, now);
+  isAnimationStressed.value = frameStressState.stressed;
 }
 
 function seedCurrentRequestsAsSeen() {
@@ -1008,258 +557,11 @@ function handleVisibilityChange() {
     emit("active-change", 0);
     return;
   }
-  previousFrameAt = null;
-  recoveryFrames = 0;
+  frameStressState = resetFrameStressState(isAnimationStressed.value);
   seedCurrentRequestsAsSeen();
   if (props.tracingEnabled) {
     syncTokens();
   }
-}
-
-function routeForRequestSegment(request: TraceRequest, from: string, to: string): DiagramEdgeRoute {
-  if (from.startsWith("redirect:") && to === "response") return "intermediate-bypass";
-  if (from === RATE_LIMIT_KEY && to === "response") return "intermediate-bypass";
-  if (from === TRAFFIC_SHAPER_KEY && to === "response") return "intermediate-bypass";
-  if (from === CACHE_KEY && to === "response") return "intermediate-bypass";
-  const targetNode = request.routeTargetId > 0n ? targetKey(request.routeTargetId) : "";
-  if (from !== targetNode) return "default";
-  if (to === CACHE_KEY) return "default";
-  if (request.agentId > 0n) return "default";
-  if (to === "static-response" || to === "upstream" || to === "response") return "agent-bypass";
-  return "default";
-}
-
-function sourceHandlePoint(node: DiagramNode): Point {
-  return {
-    x: node.x + NODE_WIDTH,
-    y: node.y + NODE_HEIGHT / 2,
-  };
-}
-
-function targetHandlePoint(node: DiagramNode): Point {
-  return {
-    x: node.x,
-    y: node.y + NODE_HEIGHT / 2,
-  };
-}
-
-function calculateControlOffset(distance: number, curvature: number): number {
-  if (distance >= 0) return 0.5 * distance;
-  return curvature * 25 * Math.sqrt(-distance);
-}
-
-function bezierControls(source: Point, target: Point): { sourceControl: Point; targetControl: Point } {
-  const offset = calculateControlOffset(target.x - source.x, EDGE_CURVATURE);
-  return {
-    sourceControl: {
-      x: source.x + offset,
-      y: source.y,
-    },
-    targetControl: {
-      x: target.x - offset,
-      y: target.y,
-    },
-  };
-}
-
-function buildDefaultBezierRoute(edge: DiagramEdge, source: Point, target: Point): EdgeRouteGeometry {
-  const controls = bezierControls(source, target);
-  return buildEdgeRouteGeometry(edge, [
-    buildCubicSegment(source, controls.sourceControl, controls.targetControl, target),
-  ]);
-}
-
-function bypassBoundsForEdge(edge: DiagramEdge): Bounds | null {
-  if (edge.route === "agent-bypass") {
-    return boundsForNodes(layout.value.nodes.filter((node) => node.kind === "agent" && node.key !== edge.from && node.key !== edge.to));
-  }
-  if (edge.route === "intermediate-bypass") {
-    return boundsForNodes(layout.value.nodes.filter((node) => {
-      if (node.key === edge.from || node.key === edge.to) return false;
-      return node.kind === "route" || node.kind === "target" || node.kind === "redirect" || node.kind === "agent" || node.kind === "upstream";
-    }));
-  }
-  return null;
-}
-
-function buildBypassRoute(edge: DiagramEdge, source: Point, target: Point, obstacleBounds: Bounds): EdgeRouteGeometry {
-  const laneY = bypassLaneY(source, target, obstacleBounds);
-  const entryX = obstacleBounds.left - BYPASS_X_GAP;
-  const exitX = obstacleBounds.right + BYPASS_X_GAP;
-  const laneEntry = { x: entryX, y: laneY };
-  const laneExit = { x: exitX, y: laneY };
-
-  return buildEdgeRouteGeometry(edge, [
-    buildCubicSegment(
-      source,
-      { x: source.x + 32, y: source.y },
-      { x: laneEntry.x - 32, y: laneEntry.y },
-      laneEntry,
-    ),
-    buildCubicSegment(
-      laneEntry,
-      { x: laneEntry.x + 40, y: laneEntry.y },
-      { x: laneExit.x - 40, y: laneExit.y },
-      laneExit,
-    ),
-    buildCubicSegment(
-      laneExit,
-      { x: laneExit.x + 32, y: laneExit.y },
-      { x: target.x - 32, y: target.y },
-      target,
-    ),
-  ]);
-}
-
-function buildEdgeRouteGeometry(edge: DiagramEdge, segments: CubicSegment[]): EdgeRouteGeometry {
-  return {
-    from: edge.from,
-    to: edge.to,
-    route: edge.route,
-    segments,
-    totalLength: segments.reduce((sum, segment) => sum + segment.totalLength, 0),
-    path: routePath(segments),
-  };
-}
-
-function buildCubicSegment(
-  source: Point,
-  sourceControl: Point,
-  targetControl: Point,
-  target: Point,
-): CubicSegment {
-  const segment: CubicSegment = {
-    source,
-    sourceControl,
-    targetControl,
-    target,
-    lengthTable: [{ t: 0, length: 0 }],
-    totalLength: 0,
-  };
-  let previous = source;
-  let totalLength = 0;
-
-  for (let index = 1; index <= BEZIER_LENGTH_SAMPLES; index += 1) {
-    const t = index / BEZIER_LENGTH_SAMPLES;
-    const point = cubicBezierPoint(segment, t);
-    totalLength += pointDistance(previous, point);
-    segment.lengthTable.push({ t, length: totalLength });
-    previous = point;
-  }
-
-  segment.totalLength = totalLength;
-  return segment;
-}
-
-function cubicBezierPoint(segment: CubicSegment, t: number): Point {
-  const inv = 1 - t;
-  return {
-    x:
-      inv * inv * inv * segment.source.x +
-      3 * inv * inv * t * segment.sourceControl.x +
-      3 * inv * t * t * segment.targetControl.x +
-      t * t * t * segment.target.x,
-    y:
-      inv * inv * inv * segment.source.y +
-      3 * inv * inv * t * segment.sourceControl.y +
-      3 * inv * t * t * segment.targetControl.y +
-      t * t * t * segment.target.y,
-  };
-}
-
-function pointAtRouteProgress(route: EdgeRouteGeometry, progress: number): Point {
-  const targetLength = route.totalLength * clamp(progress, 0, 1);
-  let traversed = 0;
-
-  for (const segment of route.segments) {
-    const nextTraversed = traversed + segment.totalLength;
-    if (targetLength <= nextTraversed) {
-      const segmentProgress = segment.totalLength <= 0 ? 0 : (targetLength - traversed) / segment.totalLength;
-      return pointAtSegmentProgress(segment, segmentProgress);
-    }
-    traversed = nextTraversed;
-  }
-
-  return route.segments.at(-1)?.target ?? { x: 0, y: 0 };
-}
-
-function routeToMotionPoints(route: EdgeRouteGeometry): MotionPoint[] {
-  const sampleCount = Math.max(2, Math.ceil(route.totalLength / 24));
-  const points: MotionPoint[] = [];
-  for (let index = 0; index <= sampleCount; index += 1) {
-    points.push(pointAtRouteProgress(route, index / sampleCount));
-  }
-  return points;
-}
-
-function pointAtSegmentProgress(segment: CubicSegment, progress: number): Point {
-  const targetLength = segment.totalLength * clamp(progress, 0, 1);
-  if (segment.totalLength <= 0) return cubicBezierPoint(segment, progress);
-
-  let previous = segment.lengthTable[0];
-  for (let index = 1; index < segment.lengthTable.length; index += 1) {
-    const current = segment.lengthTable[index];
-    if (current.length < targetLength) {
-      previous = current;
-      continue;
-    }
-
-    const lengthSpan = current.length - previous.length;
-    const localProgress = lengthSpan <= 0 ? 0 : (targetLength - previous.length) / lengthSpan;
-    const t = previous.t + (current.t - previous.t) * localProgress;
-    return cubicBezierPoint(segment, t);
-  }
-
-  return segment.target;
-}
-
-function routePath(segments: CubicSegment[]): string {
-  return segments
-    .map((segment, index) => {
-      const start = index === 0 ? `M${segment.source.x},${segment.source.y} ` : "";
-      return `${start}C${segment.sourceControl.x},${segment.sourceControl.y} ${segment.targetControl.x},${segment.targetControl.y} ${segment.target.x},${segment.target.y}`;
-    })
-    .join(" ");
-}
-
-function pointDistance(a: Point, b: Point): number {
-  return Math.hypot(b.x - a.x, b.y - a.y);
-}
-
-function nodeBounds(node: DiagramNode): Bounds {
-  return {
-    left: node.x,
-    right: node.x + NODE_WIDTH,
-    top: node.y,
-    bottom: node.y + NODE_HEIGHT,
-  };
-}
-
-function boundsForNodes(nodes: DiagramNode[]): Bounds | null {
-  if (!nodes.length) return null;
-  return nodes.reduce((bounds, node) => {
-    const next = nodeBounds(node);
-    return {
-      left: Math.min(bounds.left, next.left),
-      right: Math.max(bounds.right, next.right),
-      top: Math.min(bounds.top, next.top),
-      bottom: Math.max(bounds.bottom, next.bottom),
-    };
-  }, nodeBounds(nodes[0]));
-}
-
-function bypassLaneY(source: Point, target: Point, agentBounds: Bounds): number {
-  const averageY = (source.y + target.y) / 2;
-  const topLane = Math.min(source.y, target.y, agentBounds.top) - BYPASS_LANE_GAP;
-  const bottomLane = Math.max(source.y, target.y, agentBounds.bottom) + BYPASS_LANE_GAP;
-
-  if (topLane >= MIN_BYPASS_Y) {
-    const topCost = Math.abs(averageY - topLane);
-    const bottomCost = Math.abs(averageY - bottomLane);
-    return topCost <= bottomCost ? topLane : bottomLane;
-  }
-
-  return bottomLane;
 }
 
 function fitDiagram(duration = 240) {
@@ -1277,272 +579,6 @@ function handleNodeClick(event: NodeMouseEvent) {
   });
 }
 
-function addObservedNodes(
-  request: TraceRequest,
-  addNode: (node: DiagramNodeInput) => void,
-) {
-  const index = configIndex.value;
-  if (requestUsesWafNode(request, index)) {
-    addNode({
-      key: WAF_KEY,
-      label: "WAF",
-      subLabel: request.wafRuleName || "Observed",
-      column: 2,
-      kind: "waf",
-      editTargets: request.wafRuleId > 0n
-        ? [wafEditTarget(request.wafRuleId, request.wafRuleName || `WAF ${request.wafRuleId.toString()}`, "Observed")]
-        : index.enabledWafTargets,
-    });
-  }
-
-  if (requestUsesRateLimitNode(request, index)) {
-    addNode({
-      key: RATE_LIMIT_KEY,
-      label: "Rate limit",
-      subLabel: request.rateLimitRuleName || "Observed",
-      column: 3,
-      kind: "rate-limit",
-      editTargets: index.enabledRateLimitTargets,
-    });
-  }
-
-  if (requestUsesTrafficShaperNode(request, index)) {
-    addNode({
-      key: TRAFFIC_SHAPER_KEY,
-      label: "Traffic shaper",
-      subLabel: request.trafficShaperRuleName || "Observed",
-      column: 4,
-      kind: "traffic-shaper",
-      editTargets: request.trafficShaperRuleId > 0n
-        ? [trafficShaperEditTarget(request.trafficShaperRuleId, request.trafficShaperRuleName || `Traffic shaper ${request.trafficShaperRuleId.toString()}`, "Observed")]
-        : index.enabledTrafficShaperTargets,
-    });
-  }
-
-  if (requestUsesCacheNode(request, index)) {
-    addNode({
-      key: CACHE_KEY,
-      label: "Cache",
-      subLabel: request.cacheRuleName || request.cacheStatus || "Observed",
-      column: 7,
-      kind: "cache",
-      cacheStatus: cacheStatusForRequest(request),
-      editTargets: request.cacheRuleId > 0n
-        ? [cacheEditTarget(request.cacheRuleId, request.cacheRuleName || `Cache ${request.cacheRuleId.toString()}`, request.cacheStatus || "Observed")]
-        : index.enabledCacheTargets,
-    });
-  }
-
-  if (request.listenerId > 0n) {
-    addNode({
-      key: listenerKey(request.listenerId),
-      label: request.listenerName || `Listener ${request.listenerId.toString()}`,
-      subLabel: "Observed",
-      column: 1,
-      kind: "listener",
-      editTargets: [listenerEditTarget(request.listenerId, request.listenerName || `Listener ${request.listenerId.toString()}`, "Observed")],
-    });
-  }
-
-  if (request.routeId > 0n) {
-    addNode({
-      key: routeKey(request.routeId),
-      label: request.routeLabel || `Route ${request.routeId.toString()}`,
-      subLabel: "Observed",
-      column: 5,
-      kind: "route",
-      editTargets: [routeEditTargetByID(request.routeId, request.routeLabel || `Route ${request.routeId.toString()}`, "Observed")],
-    });
-    const route = routeConfigForRequest(request, index);
-    if (route && isRedirectRoute(route)) {
-      addRedirectNode(route, addNode);
-    }
-  } else if (request.defaultRoute && request.listenerId > 0n) {
-    addNode({
-      key: listenerDefaultRouteKey(request.listenerId),
-      label: "Default route",
-      subLabel: "Observed fallback",
-      column: 5,
-      kind: "route",
-      editTargets: request.listenerId > 0n
-        ? [listenerEditTarget(request.listenerId, request.listenerName || `Listener ${request.listenerId.toString()}`, "Default route")]
-        : [],
-    });
-  }
-
-  const selectedTargetId = requestTargetID(request);
-  if (selectedTargetId > 0n) {
-    addNode({
-      key: targetKey(selectedTargetId),
-      label: requestTargetLabel(request),
-      subLabel: targetTypeLabel(request),
-      column: 6,
-      kind: "target",
-      editTargets: [targetEditTarget(selectedTargetId, requestTargetLabel(request), targetTypeLabel(request))],
-    });
-  }
-
-  if (requestTargetType(request) === PublicRouteTargetType.STATIC) {
-    addStaticNode(addNode, selectedTargetId > 0n ? targetEditTarget(selectedTargetId, requestTargetLabel(request), "Static") : undefined);
-  } else if (selectedTargetId > 0n && requestTargetTransport(request) !== PublicRouteTargetTransport.AGENT) {
-    addUpstreamNode(addNode, targetEditTarget(selectedTargetId, requestTargetLabel(request), "Direct"));
-  }
-
-  if (request.agentId > 0n) {
-    const agent = index.agentById.get(request.agentId.toString());
-    addNode({
-      key: agentKey(request.agentId),
-      label: request.agentName || request.agentPublicId || `Agent ${request.agentId.toString()}`,
-      subLabel: request.agentPublicId || "Observed",
-      column: 8,
-      kind: "agent",
-      agentStatus: agentNodeStatus(agent),
-      editTargets: [agentEditTarget(request.agentId, request.agentName || request.agentPublicId || `Agent ${request.agentId.toString()}`, request.agentPublicId || "Observed")],
-    });
-    addUpstreamNode(addNode, selectedTargetId > 0n ? targetEditTarget(selectedTargetId, requestTargetLabel(request), "Agent selected") : undefined);
-  }
-}
-
-function addStaticNode(addNode: (node: DiagramNodeInput) => void, target?: TrafficFlowEditTarget) {
-  addNode({ key: "static-response", label: "Static", subLabel: "Generated", column: 9, kind: "upstream", editTargets: target ? [target] : [] });
-}
-
-function addUpstreamNode(addNode: (node: DiagramNodeInput) => void, target?: TrafficFlowEditTarget) {
-  addNode({ key: "upstream", label: "Upstream", subLabel: "Origin", column: 9, kind: "upstream", editTargets: target ? [target] : [] });
-}
-
-function addRedirectNode(route: PublicRoute, addNode: (node: DiagramNodeInput) => void) {
-  addNode({
-    key: redirectKey(route.id),
-    label: "Redirect",
-    subLabel: redirectNodeSubLabel(route),
-    column: 6,
-    kind: "redirect",
-    editTargets: [routeEditTarget(route)],
-  });
-}
-
-function yPosition(index: number, total: number): number {
-  if (total <= 1) return 236;
-  const visibleRows = Math.min(total, 4);
-  const centeringOffset = Math.max(0, (4 - visibleRows) * ROW_GAP * 0.5);
-  return MIN_CENTER_Y + centeringOffset + index * ROW_GAP;
-}
-
-function dedupeEdges(edges: DiagramEdge[]): DiagramEdge[] {
-  const byKey = new Map<string, DiagramEdge>();
-  for (const edge of edges) {
-    const key = edgeKey(edge.from, edge.to);
-    const existing = byKey.get(key);
-    if (!existing || edgeRoutePriority(edge.route) > edgeRoutePriority(existing.route)) {
-      byKey.set(key, edge);
-    }
-  }
-  return [...byKey.values()];
-}
-
-function edgeRoutePriority(route: DiagramEdgeRoute): number {
-  switch (route) {
-    case "intermediate-bypass": return 2;
-    case "agent-bypass": return 1;
-    default: return 0;
-  }
-}
-
-function edgeKey(from: string, to: string): string {
-  return motionEdgeKey(from, to);
-}
-
-function dedupeEditTargets(targets: TrafficFlowEditTarget[]): TrafficFlowEditTarget[] {
-  const byKey = new Map<string, TrafficFlowEditTarget>();
-  for (const target of targets) {
-    byKey.set(`${target.kind}:${target.id}`, target);
-  }
-  return [...byKey.values()];
-}
-
-function agentNodeStatus(agent: Agent | undefined): AgentNodeStatus {
-  if (!agent) return { state: "unknown", label: "Unknown" };
-  if (!agent.enabled) return { state: "disabled", label: "Disabled" };
-  if (agent.connected) return { state: "connected", label: "Connected" };
-  return { state: "offline", label: "Offline" };
-}
-
-function agentsMatchingTarget(target: PublicRouteTarget, agents: readonly Agent[]): Agent[] {
-  return agentsMatchingTargetSelector(target, agents);
-}
-
-function mergeAgentStatus(existing: AgentNodeStatus | undefined, next: AgentNodeStatus | undefined): AgentNodeStatus | undefined {
-  if (!existing) return next;
-  if (!next) return existing;
-  if (existing.state === "unknown" && next.state !== "unknown") return next;
-  return existing;
-}
-
-function mergeCacheStatus(existing: CacheNodeStatus | undefined, next: CacheNodeStatus | undefined): CacheNodeStatus | undefined {
-  if (!existing) return next;
-  if (!next) return existing;
-  return cacheTonePriority(next.tone) > cacheTonePriority(existing.tone) ? next : existing;
-}
-
-function playbackDuration(hopCount: number, activeTokens: number): number {
-  const raw = BASE_PLAYBACK_MS + Math.max(1, hopCount) * PER_HOP_MS;
-  if (activeTokens < LOW_BURST_THRESHOLD) return clamp(raw, 2500, MAX_PLAYBACK_MS);
-  if (activeTokens < HIGH_BURST_THRESHOLD) return clamp(raw, 2000, 4500);
-  return clamp(raw, MIN_PLAYBACK_MS, 3000);
-}
-
-function statusForRequest(request: TraceRequest): VisualTokenStatus {
-  if (request.stage === TrafficTraceStage.FAILED) return "failed";
-  const status = Number(request.statusCode);
-  if (status >= 500) return "server-error";
-  if (status >= 400) return "client-error";
-  if (status >= 200) return "success";
-  return "in-flight";
-}
-
-function cacheToneForRequest(request: TraceRequest): VisualTokenCacheTone {
-  const status = request.cacheStatus.toLowerCase();
-  if (status === "hit" || request.stage === TrafficTraceStage.CACHE_HIT) return "hit";
-  if (status === "miss" || request.stage === TrafficTraceStage.CACHE_MISS) return "miss";
-  if (status === "bypass" || request.stage === TrafficTraceStage.CACHE_BYPASS) return "bypass";
-  if (status === "stored" || request.stage === TrafficTraceStage.CACHE_STORED) return "stored";
-  return "";
-}
-
-function cacheStatusForTone(tone: Exclude<VisualTokenCacheTone, ""> | CacheNodeTone): CacheNodeStatus {
-  switch (tone) {
-    case "hit": return { label: "HIT", tone: "hit" };
-    case "miss": return { label: "MISS", tone: "miss" };
-    case "bypass": return { label: "BYPASS", tone: "bypass" };
-    case "stored": return { label: "STORED", tone: "stored" };
-    case "lookup": return { label: "LOOKUP", tone: "lookup" };
-    default: return { label: "READY", tone: "neutral" };
-  }
-}
-
-function cacheStatusForRequest(request: TraceRequest): CacheNodeStatus {
-  return cacheStatusForTone(cacheToneForRequest(request) || "lookup");
-}
-
-function cacheTonePriority(tone: CacheNodeTone): number {
-  switch (tone) {
-    case "hit": return 6;
-    case "stored": return 5;
-    case "miss": return 4;
-    case "bypass": return 3;
-    case "lookup": return 2;
-    default: return 1;
-  }
-}
-
-function tokenColorClass(token: VisualToken): string {
-  if (token.status === "client-error" || token.status === "server-error" || token.status === "failed") {
-    return `traffic-token-${token.status}`;
-  }
-  return token.cacheTone ? `traffic-token-cache-${token.cacheTone}` : `traffic-token-${token.status}`;
-}
-
 function isTokenNearCache(token: VisualToken, point: Point): boolean {
   if (!token.cacheTone || !token.path.includes(CACHE_KEY)) return false;
   const cacheNode = layout.value.nodeByKey.get(CACHE_KEY);
@@ -1556,109 +592,10 @@ function isTokenNearCache(token: VisualToken, point: Point): boolean {
   });
 }
 
-function pointInsideBounds(point: Point, bounds: Bounds): boolean {
-  return point.x >= bounds.left && point.x <= bounds.right && point.y >= bounds.top && point.y <= bounds.bottom;
-}
-
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
-function kindOrder(kind: TrafficNodeKind): number {
-  switch (kind) {
-    case "ingress": return 0;
-    case "listener": return 1;
-    case "waf": return 2;
-    case "rate-limit": return 3;
-    case "traffic-shaper": return 4;
-    case "route": return 5;
-    case "target": return 6;
-    case "redirect": return 6;
-    case "cache": return 7;
-    case "agent": return 8;
-    case "upstream": return 9;
-    case "response": return 10;
-    default: return 99;
-  }
-}
-
-function routeLabel(hostPattern: string, pathPrefix: string, id: bigint): string {
-  const parts = [hostPattern, pathPrefix].filter(Boolean);
-  return parts.length ? parts.join(" ") : `Route ${id.toString()}`;
-}
-
-function listenerEditTarget(id: bigint | string | number, label: string, subLabel?: string): TrafficFlowEditTarget {
-  return { kind: "listener", id: id.toString(), label, subLabel };
-}
-
-function routeEditTarget(route: PublicRoute): TrafficFlowEditTarget {
-  return routeEditTargetByID(route.id, routeLabel(route.hostPattern, route.pathPrefix, route.id), `P${route.priority.toString()}`);
-}
-
-function routeEditTargetByID(id: bigint | string | number, label: string, subLabel?: string): TrafficFlowEditTarget {
-  return { kind: "route", id: id.toString(), label, subLabel };
-}
-
-function targetEditTarget(id: bigint | string | number, label: string, subLabel?: string): TrafficFlowEditTarget {
-  return { kind: "target", id: id.toString(), label, subLabel };
-}
-
-function agentEditTarget(id: bigint | string | number, label: string, subLabel?: string): TrafficFlowEditTarget {
-  return { kind: "agent", id: id.toString(), label, subLabel };
-}
-
-function trafficShaperEditTarget(id: bigint | string | number, label: string, subLabel?: string): TrafficFlowEditTarget {
-  return { kind: "traffic-shaper", id: id.toString(), label, subLabel };
-}
-
-function wafEditTarget(id: bigint | string | number, label: string, subLabel?: string): TrafficFlowEditTarget {
-  return { kind: "waf", id: id.toString(), label, subLabel };
-}
-
-function cacheEditTarget(id: bigint | string | number, label: string, subLabel?: string): TrafficFlowEditTarget {
-  return { kind: "cache", id: id.toString(), label, subLabel };
-}
-
-function targetTypeLabel(request: TraceRequest): string {
-  if (requestTargetType(request) === PublicRouteTargetType.STATIC) return "Static";
-  if (requestTargetTransport(request) === PublicRouteTargetTransport.AGENT) return "Agent selected";
-  return "Direct";
-}
-
-function requestTargetID(request: TraceRequest): bigint {
-  return request.routeTargetId;
-}
-
-function requestTargetLabel(request: TraceRequest): string {
-  const id = requestTargetID(request);
-  return request.routeTargetName || `Target ${id.toString()}`;
-}
-
-function requestTargetType(request: TraceRequest): PublicRouteTargetType {
-  return request.routeTargetType || PublicRouteTargetType.UNSPECIFIED;
-}
-
-function requestTargetTransport(request: TraceRequest): PublicRouteTargetTransport {
-  return request.routeTargetTransport || PublicRouteTargetTransport.UNSPECIFIED;
-}
-
-function redirectNodeSubLabel(route: PublicRoute): string {
-  const status = Number(route.redirectStatusCode || 302);
-  return `${status} ${redirectModeShortLabel(route.redirectTargetMode)}`;
-}
-
-function redirectModeShortLabel(mode: PublicRouteRedirectTargetMode): string {
-  switch (mode) {
-    case PublicRouteRedirectTargetMode.EXTERNAL_ORIGIN_KEEP_PATH:
-      return "origin";
-    case PublicRouteRedirectTargetMode.ABSOLUTE_URL:
-      return "url";
-    case PublicRouteRedirectTargetMode.SAME_HOST_PATH:
-      return "same-host";
-    default:
-      return "redirect";
-  }
-}
 </script>
 
 <template>

--- a/web/management/src/components/TrafficFlowDiagram.vue
+++ b/web/management/src/components/TrafficFlowDiagram.vue
@@ -21,7 +21,7 @@ import {
   type TrafficRequestPathCacheEntry,
 } from "@/lib/trafficFlowLayout";
 import {
-  buildTrafficFlowDiagramLayout,
+  buildTrafficFlowGraph,
   buildTrafficFlowEdgeRoutes,
   cacheStatusForTone,
   cacheTonePriority,
@@ -29,7 +29,7 @@ import {
   nodeBounds,
   pointInsideBounds,
   routeToMotionPoints,
-} from "@/lib/trafficFlowDiagramLayout";
+} from "@/lib/trafficFlowGraph";
 import {
   activeVisualTokens,
   advanceVisualToken,
@@ -107,7 +107,7 @@ let rafId: number | null = null;
 let didInitialFit = false;
 let frameStressState = resetFrameStressState();
 
-const layout = computed(() => buildTrafficFlowDiagramLayout({
+const layout = computed(() => buildTrafficFlowGraph({
   config: props.config,
   requests: props.requests,
   configIndex: configIndex.value,

--- a/web/management/src/components/TrafficFlowNode.vue
+++ b/web/management/src/components/TrafficFlowNode.vue
@@ -1,25 +1,7 @@
 <script setup lang="ts">
 import { Handle, Position } from "@vue-flow/core";
 import type { NodeProps } from "@vue-flow/core";
-import type { TrafficFlowEditTarget } from "@/types/trafficFlowEdit";
-
-type AgentNodeStatus = {
-  state: "connected" | "offline" | "disabled" | "unknown";
-  label: string;
-};
-type CacheNodeStatus = {
-  label: string;
-  tone: "hit" | "miss" | "bypass" | "stored" | "lookup" | "neutral";
-};
-
-type TrafficNodeData = {
-  label: string;
-  subLabel: string;
-  kind: "ingress" | "listener" | "waf" | "rate-limit" | "traffic-shaper" | "cache" | "route" | "target" | "redirect" | "agent" | "upstream" | "response";
-  editTargets: TrafficFlowEditTarget[];
-  agentStatus?: AgentNodeStatus;
-  cacheStatus?: CacheNodeStatus;
-};
+import type { TrafficNodeData } from "@/lib/trafficFlowModel";
 
 defineProps<NodeProps<TrafficNodeData>>();
 </script>

--- a/web/management/src/components/editors/AgentEditorModal.vue
+++ b/web/management/src/components/editors/AgentEditorModal.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { computed, inject, reactive, ref } from "vue";
-import type { ComputedRef } from "vue";
 import { Plus as PlusIcon } from "@lucide/vue";
 import { Trash2 as TrashIcon } from "@lucide/vue";
 import { NButton, NCheckbox, NEmpty, NInput, NModal, NTag } from "naive-ui";
+import { isBusyKey, runManagementActionKey } from "@/composables/managementContextKeys";
 import { useManagementClient } from "@/composables/useManagementClient";
 import DisabledHint from "@/components/DisabledHint.vue";
 import {
@@ -19,7 +19,6 @@ import type { Agent, GetPublicProxyConfigResponse } from "@/gen/proto/p2pstream/
 
 const managementClient = useManagementClient();
 
-type Runner = (action: () => Promise<void>) => Promise<boolean>;
 
 const props = defineProps<{
   config: GetPublicProxyConfigResponse | null;
@@ -31,8 +30,8 @@ const emit = defineEmits<{
   (event: "saved"): void;
 }>();
 
-const runManagementAction = inject<Runner>("runManagementAction");
-const isBusy = inject<ComputedRef<boolean>>("isBusy");
+const runManagementAction = inject(runManagementActionKey);
+const isBusy = inject(isBusyKey, computed(() => false));
 
 const isOpen = ref(false);
 const agents = computed(() => props.config?.agents ?? []);

--- a/web/management/src/components/editors/PublicCacheRuleEditorModal.vue
+++ b/web/management/src/components/editors/PublicCacheRuleEditorModal.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { computed, inject, reactive, ref } from "vue";
-import type { ComputedRef } from "vue";
 import { NButton, NCheckbox, NDynamicTags, NInput, NInputNumber, NModal, NRadioButton, NRadioGroup, NSelect, NTransfer } from "naive-ui";
 import type { TransferOption } from "naive-ui";
 import PublicPolicyMatchEditor from "@/components/editors/PublicPolicyMatchEditor.vue";
+import { isBusyKey, runManagementActionKey } from "@/composables/managementContextKeys";
 import { useManagementClient } from "@/composables/useManagementClient";
 import { BUSY_REASON } from "@/lib/disabledReasons";
 import { modalCardStyle } from "@/lib/naiveUi";
@@ -26,7 +26,6 @@ import {
 
 const managementClient = useManagementClient();
 
-type Runner = (action: () => Promise<void>) => Promise<boolean>;
 type CacheTransferOption = TransferOption & {
   searchText: string;
 };
@@ -40,8 +39,8 @@ const emit = defineEmits<{
   (event: "saved"): void;
 }>();
 
-const runManagementAction = inject<Runner>("runManagementAction");
-const isBusy = inject<ComputedRef<boolean>>("isBusy");
+const runManagementAction = inject(runManagementActionKey);
+const isBusy = inject(isBusyKey, computed(() => false));
 
 const isOpen = ref(false);
 const rules = computed(() => props.config?.cacheRules ?? []);

--- a/web/management/src/components/editors/PublicListenerEditorModal.vue
+++ b/web/management/src/components/editors/PublicListenerEditorModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, inject, reactive, ref } from "vue";
-import type { ComputedRef } from "vue";
 import { NButton, NCheckbox, NInput, NInputNumber, NModal, NSelect } from "naive-ui";
+import { isBusyKey, runManagementActionKey } from "@/composables/managementContextKeys";
 import { useManagementClient } from "@/composables/useManagementClient";
 import DisabledHint from "@/components/DisabledHint.vue";
 import { BUSY_REASON } from "@/lib/disabledReasons";
@@ -13,7 +13,6 @@ import {
 
 const managementClient = useManagementClient();
 
-type Runner = (action: () => Promise<void>) => Promise<boolean>;
 
 const props = defineProps<{
   config: GetPublicProxyConfigResponse | null;
@@ -23,8 +22,8 @@ const emit = defineEmits<{
   (event: "saved"): void;
 }>();
 
-const runManagementAction = inject<Runner>("runManagementAction");
-const isBusy = inject<ComputedRef<boolean>>("isBusy");
+const runManagementAction = inject(runManagementActionKey);
+const isBusy = inject(isBusyKey, computed(() => false));
 
 const isOpen = ref(false);
 const listeners = computed(() => props.config?.listeners ?? []);

--- a/web/management/src/components/editors/PublicRateLimitRuleEditorModal.vue
+++ b/web/management/src/components/editors/PublicRateLimitRuleEditorModal.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { computed, inject, reactive, ref } from "vue";
-import type { ComputedRef } from "vue";
 import { Trash2 as TrashIcon } from "@lucide/vue";
 import { NButton, NButtonGroup, NCheckbox, NInput, NInputNumber, NModal, NSelect } from "naive-ui";
+import { isBusyKey, runManagementActionKey } from "@/composables/managementContextKeys";
 import { useManagementClient } from "@/composables/useManagementClient";
 import DisabledHint from "@/components/DisabledHint.vue";
 import PublicRateLimitPreview from "@/components/editors/PublicRateLimitPreview.vue";
@@ -27,7 +27,6 @@ import {
 
 const managementClient = useManagementClient();
 
-type Runner = (action: () => Promise<void>) => Promise<boolean>;
 type KeyPartForm = {
   source: PublicRateLimitKeySource;
   name: string;
@@ -45,8 +44,8 @@ const emit = defineEmits<{
   (event: "saved"): void;
 }>();
 
-const runManagementAction = inject<Runner>("runManagementAction");
-const isBusy = inject<ComputedRef<boolean>>("isBusy");
+const runManagementAction = inject(runManagementActionKey);
+const isBusy = inject(isBusyKey, computed(() => false));
 
 const isOpen = ref(false);
 const rules = computed(() => props.config?.rateLimitRules ?? []);

--- a/web/management/src/components/editors/PublicResponseTemplateEditorModal.vue
+++ b/web/management/src/components/editors/PublicResponseTemplateEditorModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, inject, reactive, ref } from "vue";
-import type { ComputedRef } from "vue";
 import { NButton, NInput, NModal, NSelect } from "naive-ui";
+import { isBusyKey, runManagementActionKey } from "@/composables/managementContextKeys";
 import { useManagementClient } from "@/composables/useManagementClient";
 import DisabledHint from "@/components/DisabledHint.vue";
 import HtmlTemplateEditor from "@/components/editors/HtmlTemplateEditor.vue";
@@ -14,14 +14,13 @@ import {
 
 const managementClient = useManagementClient();
 
-type Runner = (action: () => Promise<void>, successMessage?: string) => Promise<boolean>;
 
 const emit = defineEmits<{
   (event: "saved"): void;
 }>();
 
-const runManagementAction = inject<Runner>("runManagementAction");
-const isBusy = inject<ComputedRef<boolean>>("isBusy");
+const runManagementAction = inject(runManagementActionKey);
+const isBusy = inject(isBusyKey, computed(() => false));
 
 const isOpen = ref(false);
 const form = reactive({

--- a/web/management/src/components/editors/PublicRouteEditorModal.vue
+++ b/web/management/src/components/editors/PublicRouteEditorModal.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { computed, inject, reactive, ref, watch } from "vue";
-import type { ComputedRef, InputHTMLAttributes } from "vue";
+import type { InputHTMLAttributes } from "vue";
 import { Plus as PlusIcon } from "@lucide/vue";
 import { Trash2 as TrashIcon } from "@lucide/vue";
 import { NButton, NCheckbox, NInput, NInputNumber, NModal, NSelect } from "naive-ui";
+import { isBusyKey, runManagementActionKey } from "@/composables/managementContextKeys";
 import { useManagementClient } from "@/composables/useManagementClient";
 import DisabledHint from "@/components/DisabledHint.vue";
 import {
@@ -30,7 +31,6 @@ import {
 
 const managementClient = useManagementClient();
 
-type Runner = (action: () => Promise<void>) => Promise<boolean>;
 type RouteFormMode = "create" | "edit" | "clone";
 type TargetForm = {
   id: string;
@@ -56,8 +56,8 @@ const emit = defineEmits<{
   (event: "saved"): void;
 }>();
 
-const runManagementAction = inject<Runner>("runManagementAction");
-const isBusy = inject<ComputedRef<boolean>>("isBusy");
+const runManagementAction = inject(runManagementActionKey);
+const isBusy = inject(isBusyKey, computed(() => false));
 
 const isOpen = ref(false);
 const routeFormMode = ref<RouteFormMode>("create");

--- a/web/management/src/components/editors/PublicTrafficShaperRuleEditorModal.vue
+++ b/web/management/src/components/editors/PublicTrafficShaperRuleEditorModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, inject, reactive, ref } from "vue";
-import type { ComputedRef } from "vue";
 import { NButton, NButtonGroup, NCheckbox, NInput, NInputNumber, NModal } from "naive-ui";
+import { isBusyKey, runManagementActionKey } from "@/composables/managementContextKeys";
 import { useManagementClient } from "@/composables/useManagementClient";
 import DisabledHint from "@/components/DisabledHint.vue";
 import PublicPolicyMatchEditor from "@/components/editors/PublicPolicyMatchEditor.vue";
@@ -23,7 +23,6 @@ import {
 
 const managementClient = useManagementClient();
 
-type Runner = (action: () => Promise<void>) => Promise<boolean>;
 type KeyPartForm = {
   source: PublicRateLimitKeySource;
   name: string;
@@ -37,8 +36,8 @@ const emit = defineEmits<{
   (event: "saved"): void;
 }>();
 
-const runManagementAction = inject<Runner>("runManagementAction");
-const isBusy = inject<ComputedRef<boolean>>("isBusy");
+const runManagementAction = inject(runManagementActionKey);
+const isBusy = inject(isBusyKey, computed(() => false));
 
 const isOpen = ref(false);
 const rules = computed(() => props.config?.trafficShaperRules ?? []);

--- a/web/management/src/components/editors/PublicWafCaptchaProviderEditorModal.vue
+++ b/web/management/src/components/editors/PublicWafCaptchaProviderEditorModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, inject, reactive, ref } from "vue";
-import type { ComputedRef } from "vue";
 import { NButton, NCheckbox, NInput, NModal, NSelect } from "naive-ui";
+import { isBusyKey, runManagementActionKey } from "@/composables/managementContextKeys";
 import { useManagementClient } from "@/composables/useManagementClient";
 import DisabledHint from "@/components/DisabledHint.vue";
 import { BUSY_REASON } from "@/lib/disabledReasons";
@@ -13,7 +13,6 @@ import {
 
 const managementClient = useManagementClient();
 
-type Runner = (action: () => Promise<void>) => Promise<boolean>;
 
 const props = defineProps<{
   config: GetPublicProxyConfigResponse | null;
@@ -23,8 +22,8 @@ const emit = defineEmits<{
   (event: "saved"): void;
 }>();
 
-const runManagementAction = inject<Runner>("runManagementAction");
-const isBusy = inject<ComputedRef<boolean>>("isBusy");
+const runManagementAction = inject(runManagementActionKey);
+const isBusy = inject(isBusyKey, computed(() => false));
 
 const isOpen = ref(false);
 const providers = computed(() => props.config?.wafCaptchaProviders ?? []);

--- a/web/management/src/components/editors/PublicWafRuleEditorModal.vue
+++ b/web/management/src/components/editors/PublicWafRuleEditorModal.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { computed, inject, reactive, ref, watch } from "vue";
-import type { ComputedRef } from "vue";
 import { Trash2 as TrashIcon } from "@lucide/vue";
 import { NButton, NButtonGroup, NCheckbox, NInput, NInputNumber, NModal, NSelect } from "naive-ui";
+import { isBusyKey, runManagementActionKey } from "@/composables/managementContextKeys";
 import { useManagementClient } from "@/composables/useManagementClient";
 import DisabledHint from "@/components/DisabledHint.vue";
 import PublicPolicyKeyPartsEditor from "@/components/editors/PublicPolicyKeyPartsEditor.vue";
@@ -34,7 +34,6 @@ import {
 
 const managementClient = useManagementClient();
 
-type Runner = (action: () => Promise<void>) => Promise<boolean>;
 type KeyPartForm = {
   source: PublicRateLimitKeySource;
   name: string;
@@ -66,8 +65,8 @@ const emit = defineEmits<{
   (event: "saved"): void;
 }>();
 
-const runManagementAction = inject<Runner>("runManagementAction");
-const isBusy = inject<ComputedRef<boolean>>("isBusy");
+const runManagementAction = inject(runManagementActionKey);
+const isBusy = inject(isBusyKey, computed(() => false));
 
 const isOpen = ref(false);
 const rules = computed(() => props.config?.wafRules ?? []);

--- a/web/management/src/composables/managementContextKeys.ts
+++ b/web/management/src/composables/managementContextKeys.ts
@@ -1,0 +1,22 @@
+import type { ComputedRef, InjectionKey } from "vue";
+import type { ManagementClient } from "@/api/managementClient";
+import type {
+  Environment,
+  GetDashboardResponse,
+  GetPublicProxyConfigResponse,
+} from "@/gen/proto/p2pstream/v1/management_pb";
+
+export type ManagementActionRunner = (action: () => Promise<void>, successMessage?: string) => Promise<boolean>;
+
+export const dashboardKey = Symbol("dashboard") as InjectionKey<ComputedRef<GetDashboardResponse | null>>;
+export const publicProxyConfigKey = Symbol("publicProxyConfig") as InjectionKey<ComputedRef<GetPublicProxyConfigResponse | null>>;
+export const isBusyKey = Symbol("isBusy") as InjectionKey<ComputedRef<boolean>>;
+export const managementClientKey = Symbol("managementClient") as InjectionKey<ManagementClient>;
+export const environmentsKey = Symbol("environments") as InjectionKey<ComputedRef<Environment[]>>;
+export const selectedEnvironmentIdKey = Symbol("selectedEnvironmentId") as InjectionKey<ComputedRef<string>>;
+export const selectedEnvironmentLabelKey = Symbol("selectedEnvironmentLabel") as InjectionKey<ComputedRef<string>>;
+export const selectedEnvironmentBlockedKey = Symbol("selectedEnvironmentBlocked") as InjectionKey<ComputedRef<string>>;
+export const reloadEnvironmentsKey = Symbol("reloadEnvironments") as InjectionKey<() => Promise<void>>;
+export const runManagementActionKey = Symbol("runManagementAction") as InjectionKey<ManagementActionRunner>;
+export const setProxyRunningKey = Symbol("setProxyRunning") as InjectionKey<(shouldRun: boolean) => Promise<void>>;
+export const logoutKey = Symbol("logout") as InjectionKey<() => void>;

--- a/web/management/src/composables/useDashboardRefresh.ts
+++ b/web/management/src/composables/useDashboardRefresh.ts
@@ -1,0 +1,192 @@
+import { computed, ref, watch, type Ref } from "vue";
+import { localManagementClient, managementClient, setActiveManagementClientBase } from "@/api/managementClient";
+import { messageFromError } from "@/lib/errors";
+import {
+  EnvironmentTrustState,
+  type Environment,
+  type GetDashboardResponse,
+  type GetPublicProxyConfigResponse,
+  type User,
+} from "@/gen/proto/p2pstream/v1/management_pb";
+
+interface DashboardRefreshOptions {
+  currentUser: Ref<User | null>;
+  error: Ref<string | null>;
+  isBusy: Ref<boolean>;
+  isLoading: Ref<boolean>;
+}
+
+export function useDashboardRefresh({ currentUser, error, isBusy, isLoading }: DashboardRefreshOptions) {
+  const dashboard = ref<GetDashboardResponse | null>(null);
+  const publicProxyConfig = ref<GetPublicProxyConfigResponse | null>(null);
+  const environments = ref<Environment[]>([]);
+  const selectedEnvironmentId = ref(loadSelectedEnvironmentId());
+  const isRefreshing = ref(false);
+  const pendingDashboardReload = ref(false);
+  const refreshTimer = ref<number | null>(null);
+
+  const environmentOptions = computed(() => [
+    { id: "0", name: "Local", enabled: true, trustState: EnvironmentTrustState.TRUSTED },
+    ...environments.value.map((environment) => ({
+      id: environment.id.toString(),
+      name: environment.name,
+      enabled: environment.enabled,
+      trustState: environment.trustState,
+    })),
+  ]);
+  const environmentSelectOptions = computed(() => environmentOptions.value.map((environment) => ({
+    label: `${environment.name}${environment.enabled ? "" : " (disabled)"}`,
+    value: environment.id,
+  })));
+  const selectedRemoteEnvironment = computed(() => {
+    if (selectedEnvironmentId.value === "0") return null;
+    return environments.value.find((environment) => environment.id.toString() === selectedEnvironmentId.value) ?? null;
+  });
+  const selectedEnvironmentLabel = computed(() => selectedRemoteEnvironment.value?.name ?? "Local");
+  const selectedEnvironmentBlocked = computed(() => {
+    const environment = selectedRemoteEnvironment.value;
+    if (!environment) return "";
+    if (!environment.enabled) return "Environment is disabled.";
+    if (environment.trustState !== EnvironmentTrustState.TRUSTED) return "Environment certificate must be trusted before management requests can run.";
+    return "";
+  });
+
+  function loadSelectedEnvironmentId(): string {
+    try {
+      return window.localStorage.getItem("p2pstream:selected-environment") || "0";
+    } catch {
+      return "0";
+    }
+  }
+
+  function persistSelectedEnvironmentId() {
+    try {
+      window.localStorage.setItem("p2pstream:selected-environment", selectedEnvironmentId.value);
+    } catch {
+      // Ignore private browsing/storage failures.
+    }
+  }
+
+  async function loadEnvironments() {
+    if (!currentUser.value) {
+      environments.value = [];
+      selectedEnvironmentId.value = "0";
+      return;
+    }
+    const resp = await localManagementClient.listEnvironments({});
+    environments.value = resp.environments;
+    if (selectedEnvironmentId.value !== "0" && !environments.value.some((environment) => environment.id.toString() === selectedEnvironmentId.value && environment.enabled)) {
+      selectedEnvironmentId.value = "0";
+    }
+  }
+
+  function syncSelectedEnvironmentClient() {
+    const environment = selectedRemoteEnvironment.value;
+    if (!environment) {
+      setActiveManagementClientBase(window.location.origin);
+    } else {
+      setActiveManagementClientBase(`${window.location.origin}/environments/${environment.id.toString()}`);
+    }
+    persistSelectedEnvironmentId();
+  }
+
+  function clearDashboardState() {
+    dashboard.value = null;
+    publicProxyConfig.value = null;
+  }
+
+  function clearAuthenticatedData() {
+    stopAutoRefresh();
+    clearDashboardState();
+    environments.value = [];
+    selectedEnvironmentId.value = "0";
+    syncSelectedEnvironmentClient();
+  }
+
+  async function loadDashboard() {
+    if (isRefreshing.value) {
+      pendingDashboardReload.value = true;
+      return;
+    }
+    isRefreshing.value = true;
+    error.value = null;
+    const loadEnvironmentId = selectedEnvironmentId.value;
+    try {
+      syncSelectedEnvironmentClient();
+      const [dashboardResp, publicProxyResp] = await Promise.all([
+        managementClient.getDashboard({}),
+        managementClient.getPublicProxyConfig({}),
+      ]);
+      if (loadEnvironmentId !== selectedEnvironmentId.value) {
+        pendingDashboardReload.value = true;
+        return;
+      }
+      dashboard.value = dashboardResp;
+      publicProxyConfig.value = publicProxyResp;
+    } catch (err) {
+      if (loadEnvironmentId === selectedEnvironmentId.value) {
+        error.value = messageFromError(err);
+      } else {
+        pendingDashboardReload.value = true;
+      }
+    } finally {
+      isRefreshing.value = false;
+      if (pendingDashboardReload.value && currentUser.value) {
+        pendingDashboardReload.value = false;
+        void loadDashboard();
+      }
+    }
+  }
+
+  function startAutoRefresh() {
+    stopAutoRefresh();
+    if (!currentUser.value) return;
+    refreshTimer.value = window.setInterval(() => {
+      if (!currentUser.value || isBusy.value || isRefreshing.value) return;
+      void loadDashboard();
+    }, 5000);
+  }
+
+  function stopAutoRefresh() {
+    if (refreshTimer.value !== null) {
+      window.clearInterval(refreshTimer.value);
+      refreshTimer.value = null;
+    }
+  }
+
+  async function loadAuthenticatedData() {
+    await loadEnvironments();
+    syncSelectedEnvironmentClient();
+    await loadDashboard();
+    startAutoRefresh();
+  }
+
+  watch(selectedEnvironmentId, () => {
+    syncSelectedEnvironmentClient();
+    if (!currentUser.value) return;
+    clearDashboardState();
+    if (isLoading.value) {
+      pendingDashboardReload.value = true;
+      return;
+    }
+    void loadDashboard();
+  });
+
+  return {
+    dashboard,
+    publicProxyConfig,
+    environments,
+    selectedEnvironmentId,
+    selectedEnvironmentLabel,
+    selectedEnvironmentBlocked,
+    environmentSelectOptions,
+    isRefreshing,
+    loadEnvironments,
+    loadDashboard,
+    loadAuthenticatedData,
+    clearDashboardState,
+    clearAuthenticatedData,
+    startAutoRefresh,
+    stopAutoRefresh,
+  };
+}

--- a/web/management/src/composables/useDashboardRefresh.ts
+++ b/web/management/src/composables/useDashboardRefresh.ts
@@ -1,4 +1,4 @@
-import { computed, ref, watch, type Ref } from "vue";
+import { computed, onScopeDispose, ref, watch, type Ref } from "vue";
 import { localManagementClient, managementClient, setActiveManagementClientBase } from "@/api/managementClient";
 import { messageFromError } from "@/lib/errors";
 import {
@@ -11,6 +11,7 @@ import {
 
 interface DashboardRefreshOptions {
   currentUser: Ref<User | null>;
+  // Session-owned refs shared with dashboard refresh so global request state stays centralized.
   error: Ref<string | null>;
   isBusy: Ref<boolean>;
   isLoading: Ref<boolean>;
@@ -153,6 +154,8 @@ export function useDashboardRefresh({ currentUser, error, isBusy, isLoading }: D
       refreshTimer.value = null;
     }
   }
+
+  onScopeDispose(stopAutoRefresh);
 
   async function loadAuthenticatedData() {
     await loadEnvironments();

--- a/web/management/src/composables/useManagementClient.ts
+++ b/web/management/src/composables/useManagementClient.ts
@@ -1,6 +1,7 @@
 import { inject } from "vue";
 import { managementClient, type ManagementClient } from "@/api/managementClient";
+import { managementClientKey } from "@/composables/managementContextKeys";
 
 export function useManagementClient(): ManagementClient {
-  return inject<ManagementClient>("managementClient", managementClient);
+  return inject(managementClientKey, managementClient);
 }

--- a/web/management/src/composables/useManagementContext.ts
+++ b/web/management/src/composables/useManagementContext.ts
@@ -1,22 +1,25 @@
 import { computed, inject } from "vue";
-import type { ComputedRef } from "vue";
-import type {
-  Environment,
-  GetDashboardResponse,
-  GetPublicProxyConfigResponse,
-} from "@/gen/proto/p2pstream/v1/management_pb";
-
-export type ManagementActionRunner = (action: () => Promise<void>, successMessage?: string) => Promise<boolean>;
+import {
+  dashboardKey,
+  environmentsKey,
+  isBusyKey,
+  logoutKey,
+  publicProxyConfigKey,
+  runManagementActionKey,
+  selectedEnvironmentIdKey,
+  setProxyRunningKey,
+} from "@/composables/managementContextKeys";
+export type { ManagementActionRunner } from "@/composables/managementContextKeys";
 
 export function useManagementContext() {
-  const dashboard = inject<ComputedRef<GetDashboardResponse | null>>("dashboard", computed(() => null));
-  const publicProxyConfig = inject<ComputedRef<GetPublicProxyConfigResponse | null>>("publicProxyConfig", computed(() => null));
-  const isBusy = inject<ComputedRef<boolean>>("isBusy", computed(() => false));
-  const environments = inject<ComputedRef<Environment[]>>("environments", computed(() => []));
-  const selectedEnvironmentId = inject<ComputedRef<string>>("selectedEnvironmentId", computed(() => "0"));
-  const runManagementAction = inject<ManagementActionRunner | undefined>("runManagementAction", undefined);
-  const setProxyRunning = inject<((shouldRun: boolean) => Promise<void>) | undefined>("setProxyRunning", undefined);
-  const logout = inject<(() => void) | undefined>("logout", undefined);
+  const dashboard = inject(dashboardKey, computed(() => null));
+  const publicProxyConfig = inject(publicProxyConfigKey, computed(() => null));
+  const isBusy = inject(isBusyKey, computed(() => false));
+  const environments = inject(environmentsKey, computed(() => []));
+  const selectedEnvironmentId = inject(selectedEnvironmentIdKey, computed(() => "0"));
+  const runManagementAction = inject(runManagementActionKey, undefined);
+  const setProxyRunning = inject(setProxyRunningKey, undefined);
+  const logout = inject(logoutKey, undefined);
 
   return {
     dashboard,

--- a/web/management/src/composables/useManagementSession.ts
+++ b/web/management/src/composables/useManagementSession.ts
@@ -1,0 +1,165 @@
+import { ref } from "vue";
+import { useRoute } from "vue-router";
+import { localManagementClient } from "@/api/managementClient";
+import { messageFromError } from "@/lib/errors";
+import type { GetSetupStateResponse, User } from "@/gen/proto/p2pstream/v1/management_pb";
+
+type BootstrapSessionState = "setup-required" | "authenticated" | "unauthenticated";
+type AuthenticatedCallback = () => Promise<void>;
+type LogoutCallback = () => void;
+
+export function useManagementSession() {
+  const route = useRoute();
+  const setupState = ref<GetSetupStateResponse | null>(null);
+  const currentUser = ref<User | null>(null);
+  const setupForm = ref({ username: "admin", password: "" });
+  const setupToken = ref("");
+  const loginForm = ref({ username: "admin", password: "" });
+  const isLoading = ref(true);
+  const isBusy = ref(false);
+  const isLogoutConfirmOpen = ref(false);
+  const error = ref<string | null>(null);
+
+  async function bootstrapSession(): Promise<BootstrapSessionState> {
+    setupState.value = await localManagementClient.getSetupState({});
+    if (setupState.value.setupRequired) {
+      currentUser.value = null;
+      return "setup-required";
+    }
+
+    try {
+      const userResp = await localManagementClient.getCurrentUser({});
+      currentUser.value = userResp.user ?? null;
+    } catch {
+      currentUser.value = null;
+      return "unauthenticated";
+    }
+
+    return currentUser.value ? "authenticated" : "unauthenticated";
+  }
+
+  async function submitSetup(afterAuthenticated: AuthenticatedCallback) {
+    isBusy.value = true;
+    error.value = null;
+    try {
+      await localManagementClient.setupAdmin({
+        username: setupForm.value.username,
+        password: setupForm.value.password,
+        setupToken: setupToken.value,
+      });
+      await login(setupForm.value.username, setupForm.value.password);
+      setupState.value = await localManagementClient.getSetupState({});
+      await afterAuthenticated();
+    } catch (err) {
+      error.value = messageFromError(err);
+    } finally {
+      isBusy.value = false;
+    }
+  }
+
+  async function submitLogin(afterAuthenticated: AuthenticatedCallback) {
+    isBusy.value = true;
+    error.value = null;
+    try {
+      await login(loginForm.value.username, loginForm.value.password);
+      await afterAuthenticated();
+    } catch (err) {
+      error.value = messageFromError(err);
+    } finally {
+      isBusy.value = false;
+    }
+  }
+
+  async function login(username: string, password: string) {
+    const loginResp = await localManagementClient.login({ username, password });
+    currentUser.value = loginResp.user ?? null;
+  }
+
+  function requestLogout() {
+    if (isBusy.value) return;
+    isLogoutConfirmOpen.value = true;
+  }
+
+  function cancelLogout() {
+    if (isBusy.value) return;
+    isLogoutConfirmOpen.value = false;
+  }
+
+  async function confirmLogout(afterLogout: LogoutCallback) {
+    const didLogout = await logout(afterLogout);
+    if (didLogout) {
+      isLogoutConfirmOpen.value = false;
+    }
+  }
+
+  async function logout(afterLogout: LogoutCallback): Promise<boolean> {
+    isBusy.value = true;
+    error.value = null;
+    try {
+      await localManagementClient.logout({});
+      currentUser.value = null;
+      afterLogout();
+      loginForm.value.password = "";
+      return true;
+    } catch (err) {
+      error.value = messageFromError(err);
+      return false;
+    } finally {
+      isBusy.value = false;
+    }
+  }
+
+  function initializeSetupToken() {
+    setupToken.value = setupTokenFromURL();
+  }
+
+  function setupTokenFromURL(): string {
+    const routeToken = stringQueryValue(route.query.setup_token);
+    if (routeToken) {
+      scrubSetupTokenFromURL();
+      return routeToken;
+    }
+    try {
+      const token = new URLSearchParams(window.location.search).get("setup_token")?.trim() ?? "";
+      if (token) scrubSetupTokenFromURL();
+      return token;
+    } catch {
+      return "";
+    }
+  }
+
+  function scrubSetupTokenFromURL() {
+    try {
+      const url = new URL(window.location.href);
+      if (!url.searchParams.has("setup_token")) return;
+      url.searchParams.delete("setup_token");
+      window.history.replaceState(window.history.state, "", `${url.pathname}${url.search}${url.hash}`);
+    } catch {
+      // Ignore browsers or test environments without full history support.
+    }
+  }
+
+  function stringQueryValue(value: unknown): string {
+    if (Array.isArray(value)) return stringQueryValue(value[0]);
+    return typeof value === "string" ? value.trim() : "";
+  }
+
+  return {
+    setupState,
+    currentUser,
+    setupForm,
+    setupToken,
+    loginForm,
+    isLoading,
+    isBusy,
+    isLogoutConfirmOpen,
+    error,
+    bootstrapSession,
+    submitSetup,
+    submitLogin,
+    requestLogout,
+    cancelLogout,
+    confirmLogout,
+    initializeSetupToken,
+  };
+}

--- a/web/management/src/lib/errors.ts
+++ b/web/management/src/lib/errors.ts
@@ -1,0 +1,3 @@
+export function messageFromError(err: unknown): string {
+  return err instanceof Error ? err.message : "Request failed";
+}

--- a/web/management/src/lib/trafficFlowAnimation.test.ts
+++ b/web/management/src/lib/trafficFlowAnimation.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import {
+  PublicRouteTargetTransport,
+  PublicRouteTargetType,
+  TrafficTraceStage,
+  type GetPublicProxyConfigResponse,
+} from "@/gen/proto/p2pstream/v1/management_pb";
+import { createTrafficFlowConfigIndex } from "@/lib/trafficFlowLayout";
+import {
+  initialFrameStressState,
+  nextFrameStressState,
+  renderedTokenCap,
+  shouldEnqueueCacheStorePulse,
+} from "@/lib/trafficFlowAnimation";
+import { MAX_RENDERED_TOKENS_NORMAL, MAX_RENDERED_TOKENS_STRESSED } from "@/lib/trafficFlowModel";
+import { newTraceRequest } from "@/lib/trafficTraceStore";
+import type { TraceRequest } from "@/types/trafficTrace";
+
+describe("trafficFlowAnimation", () => {
+  test("uses a lower token cap while animation is stressed", () => {
+    expect(renderedTokenCap(false)).toBe(MAX_RENDERED_TOKENS_NORMAL);
+    expect(renderedTokenCap(true)).toBe(MAX_RENDERED_TOKENS_STRESSED);
+  });
+
+  test("enters stress on slow frames and recovers after sustained fast frames", () => {
+    let state = nextFrameStressState(initialFrameStressState, 0);
+    state = nextFrameStressState(state, 50);
+    expect(state.stressed).toBe(true);
+
+    for (let index = 0; index < 12; index += 1) {
+      state = nextFrameStressState(state, 60 + index * 10);
+    }
+
+    expect(state.stressed).toBe(false);
+  });
+
+  test("cache-store pulse is emitted once for stored cache requests", () => {
+    const seen = new Set<string>();
+    const index = createTrafficFlowConfigIndex({
+      $typeName: "p2pstream.v1.GetPublicProxyConfigResponse",
+      listeners: [],
+      agents: [],
+      routes: [],
+      routeTargets: [],
+      rateLimitRules: [],
+      trafficShaperRules: [],
+      cacheRules: [],
+      tlsDnsCredentials: [],
+      wafCaptchaProviders: [],
+      wafRules: [],
+      responseTemplates: [],
+      tlsCertificates: [],
+      proxy: undefined,
+    } as GetPublicProxyConfigResponse);
+    const request = traceRequest({
+      requestId: "cache-store",
+      routeTargetId: 2n,
+      routeTargetType: PublicRouteTargetType.PROXY,
+      routeTargetTransport: PublicRouteTargetTransport.DIRECT,
+      cacheRuleId: 4n,
+      cacheStatus: "stored",
+      stage: TrafficTraceStage.CACHE_STORED,
+    });
+
+    expect(shouldEnqueueCacheStorePulse(request, index, seen)).toBe(true);
+    expect(shouldEnqueueCacheStorePulse(request, index, seen)).toBe(false);
+    expect(seen.has("cache-store")).toBe(true);
+  });
+});
+
+function traceRequest(overrides: Partial<TraceRequest>): TraceRequest {
+  return {
+    ...newTraceRequest(overrides.requestId ?? "req"),
+    ...overrides,
+  };
+}

--- a/web/management/src/lib/trafficFlowAnimation.ts
+++ b/web/management/src/lib/trafficFlowAnimation.ts
@@ -1,5 +1,5 @@
 import { isTerminalTraceRequest, requestUsesCacheNode, type TrafficFlowConfigIndex, type TrafficRequestPathCacheEntry } from "@/lib/trafficFlowLayout";
-import { cacheToneForRequest } from "@/lib/trafficFlowDiagramLayout";
+import { cacheToneForRequest } from "@/lib/trafficFlowGraph";
 import {
   BASE_PLAYBACK_MS,
   COMPLETION_FADE_MS,
@@ -82,6 +82,7 @@ export function createVisualToken(input: {
   };
 }
 
+// Mutates input.token in place; this runs in the animation hot path.
 export function updateVisualToken(input: {
   token: VisualToken;
   request: TraceRequest;
@@ -102,6 +103,7 @@ export function updateVisualToken(input: {
   input.token.cacheTone = cacheToneForRequest(input.request);
 }
 
+// Mutates token in place; callers should not treat this helper as pure.
 export function advanceVisualToken(token: VisualToken, now: number) {
   if (token.finishedAt !== null) {
     token.updatedAt = now;

--- a/web/management/src/lib/trafficFlowAnimation.ts
+++ b/web/management/src/lib/trafficFlowAnimation.ts
@@ -1,0 +1,204 @@
+import { isTerminalTraceRequest, requestUsesCacheNode, type TrafficFlowConfigIndex, type TrafficRequestPathCacheEntry } from "@/lib/trafficFlowLayout";
+import { cacheToneForRequest } from "@/lib/trafficFlowDiagramLayout";
+import {
+  BASE_PLAYBACK_MS,
+  COMPLETION_FADE_MS,
+  COMPLETION_HOLD_MS,
+  FRAME_RECOVERY_COUNT,
+  FRAME_RECOVERY_MS,
+  FRAME_STRESS_MS,
+  HIGH_BURST_THRESHOLD,
+  LOW_BURST_THRESHOLD,
+  MAX_PLAYBACK_MS,
+  MAX_RENDERED_TOKENS_NORMAL,
+  MAX_RENDERED_TOKENS_STRESSED,
+  MIN_PLAYBACK_MS,
+  PER_HOP_MS,
+  type VisualToken,
+  type VisualTokenStatus,
+} from "@/lib/trafficFlowModel";
+import { pointAtMotionDistance, type MotionNodeBox, type MotionPlan, type MotionPoint } from "@/lib/trafficMotion";
+import { TrafficTraceStage } from "@/gen/proto/p2pstream/v1/management_pb";
+import type { TraceRequest } from "@/types/trafficTrace";
+
+export type FrameStressState = {
+  previousFrameAt: number | null;
+  recoveryFrames: number;
+  stressed: boolean;
+};
+
+export const initialFrameStressState: FrameStressState = {
+  previousFrameAt: null,
+  recoveryFrames: 0,
+  stressed: false,
+};
+
+export function renderedTokenCap(stressed: boolean): number {
+  return stressed ? MAX_RENDERED_TOKENS_STRESSED : MAX_RENDERED_TOKENS_NORMAL;
+}
+
+export function playbackDuration(hopCount: number, activeTokens: number): number {
+  const raw = BASE_PLAYBACK_MS + Math.max(1, hopCount) * PER_HOP_MS;
+  if (activeTokens < LOW_BURST_THRESHOLD) return clamp(raw, 2500, MAX_PLAYBACK_MS);
+  if (activeTokens < HIGH_BURST_THRESHOLD) return clamp(raw, 2000, 4500);
+  return clamp(raw, MIN_PLAYBACK_MS, 3000);
+}
+
+export function statusForRequest(request: TraceRequest): VisualTokenStatus {
+  if (request.stage === TrafficTraceStage.FAILED) return "failed";
+  const status = Number(request.statusCode);
+  if (status >= 500) return "server-error";
+  if (status >= 400) return "client-error";
+  if (status >= 200) return "success";
+  return "in-flight";
+}
+
+export function requestLabel(request: TraceRequest): string {
+  return `${request.method || "REQUEST"} ${request.path || "/"}`;
+}
+
+export function createVisualToken(input: {
+  request: TraceRequest;
+  cached: TrafficRequestPathCacheEntry;
+  motionPlan: MotionPlan;
+  activeTokenCount: number;
+  now: number;
+}): VisualToken {
+  return {
+    requestId: input.request.requestId,
+    request: input.request,
+    path: input.cached.path,
+    label: requestLabel(input.request),
+    motionPlan: input.motionPlan,
+    currentDistance: 0,
+    targetDistance: input.motionPlan.targetLength,
+    startedAt: input.now,
+    updatedAt: input.now,
+    durationMs: playbackDuration(input.cached.path.length - 1, input.activeTokenCount),
+    finishedAt: null,
+    status: statusForRequest(input.request),
+    cacheTone: cacheToneForRequest(input.request),
+    skipped: false,
+  };
+}
+
+export function updateVisualToken(input: {
+  token: VisualToken;
+  request: TraceRequest;
+  cached: TrafficRequestPathCacheEntry;
+  motionPlan: MotionPlan;
+  activeTokenCount: number;
+  now: number;
+}) {
+  advanceVisualToken(input.token, input.now);
+  input.token.request = input.request;
+  input.token.path = input.cached.path;
+  input.token.label = requestLabel(input.request);
+  input.token.motionPlan = input.motionPlan;
+  input.token.currentDistance = clamp(input.token.currentDistance, 0, input.motionPlan.targetLength);
+  input.token.targetDistance = input.motionPlan.targetLength;
+  input.token.durationMs = Math.max(input.token.durationMs, playbackDuration(input.token.path.length - 1, input.activeTokenCount));
+  input.token.status = statusForRequest(input.request);
+  input.token.cacheTone = cacheToneForRequest(input.request);
+}
+
+export function advanceVisualToken(token: VisualToken, now: number) {
+  if (token.finishedAt !== null) {
+    token.updatedAt = now;
+    return;
+  }
+
+  const elapsed = Math.max(0, now - token.updatedAt);
+  token.updatedAt = now;
+  if (token.currentDistance < token.targetDistance) {
+    const speed = Math.max(token.motionPlan.totalLength, token.targetDistance, 1) / token.durationMs;
+    token.currentDistance = Math.min(token.targetDistance, token.currentDistance + speed * elapsed);
+  }
+
+  if (isTerminalTraceRequest(token.request) && token.currentDistance >= token.targetDistance && token.finishedAt === null) {
+    token.finishedAt = now;
+  }
+}
+
+export function activeVisualTokens(tokens: readonly VisualToken[], now: number): VisualToken[] {
+  return tokens.filter((token) => {
+    if (token.finishedAt === null) return true;
+    return now - token.finishedAt <= COMPLETION_HOLD_MS + COMPLETION_FADE_MS;
+  });
+}
+
+export function visualTokenPoint(token: VisualToken, motionNodeBoxes: Map<string, MotionNodeBox>): MotionPoint | null {
+  const point = pointAtMotionDistance(token.motionPlan, token.currentDistance);
+  if (point) return point;
+  const fallbackKey = token.path[Math.min(token.motionPlan.targetNodeIndex, token.path.length - 1)] ?? "ingress";
+  return motionNodeBoxes.get(fallbackKey)?.center ?? null;
+}
+
+export function visualTokenOpacity(token: VisualToken, now: number): number {
+  if (token.finishedAt === null) return 1;
+  const age = now - token.finishedAt;
+  if (age <= COMPLETION_HOLD_MS) return 1;
+  return clamp(1 - (age - COMPLETION_HOLD_MS) / COMPLETION_FADE_MS, 0, 1);
+}
+
+export function tokenColorClass(token: VisualToken): string {
+  if (token.status === "client-error" || token.status === "server-error" || token.status === "failed") {
+    return `traffic-token-${token.status}`;
+  }
+  return token.cacheTone ? `traffic-token-cache-${token.cacheTone}` : `traffic-token-${token.status}`;
+}
+
+export function shouldEnqueueCacheStorePulse(
+  request: TraceRequest,
+  index: TrafficFlowConfigIndex,
+  seenRequestIds: Set<string>,
+): boolean {
+  if (cacheToneForRequest(request) !== "stored") return false;
+  if (!requestUsesCacheNode(request, index)) return false;
+  if (seenRequestIds.has(request.requestId)) return false;
+  seenRequestIds.add(request.requestId);
+  return true;
+}
+
+export function nextFrameStressState(state: FrameStressState, now: number): FrameStressState {
+  if (state.previousFrameAt === null) {
+    return { ...state, previousFrameAt: now };
+  }
+  const delta = now - state.previousFrameAt;
+  if (delta > FRAME_STRESS_MS) {
+    return {
+      previousFrameAt: now,
+      recoveryFrames: 0,
+      stressed: true,
+    };
+  }
+  if (delta < FRAME_RECOVERY_MS) {
+    const recoveryFrames = state.recoveryFrames + 1;
+    return {
+      previousFrameAt: now,
+      recoveryFrames,
+      stressed: recoveryFrames >= FRAME_RECOVERY_COUNT ? false : state.stressed,
+    };
+  }
+  return {
+    previousFrameAt: now,
+    recoveryFrames: 0,
+    stressed: state.stressed,
+  };
+}
+
+export function resetFrameStressState(stressed = false): FrameStressState {
+  return {
+    previousFrameAt: null,
+    recoveryFrames: 0,
+    stressed,
+  };
+}
+
+export function cacheStorePulseActive(startedAt: number, now: number, durationMs: number): boolean {
+  return now - startedAt <= durationMs;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/web/management/src/lib/trafficFlowDiagramLayout.test.ts
+++ b/web/management/src/lib/trafficFlowDiagramLayout.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test } from "bun:test";
+import {
+  PublicRouteAction,
+  PublicRouteTargetTransport,
+  PublicRouteTargetType,
+  TrafficTraceStage,
+  type Agent,
+  type GetPublicProxyConfigResponse,
+  type PublicListener,
+  type PublicRoute,
+  type PublicRouteTarget,
+} from "@/gen/proto/p2pstream/v1/management_pb";
+import {
+  CACHE_KEY,
+  RATE_LIMIT_KEY,
+  WAF_KEY,
+  agentKey,
+  createTrafficFlowConfigIndex,
+  listenerKey,
+  routeKey,
+  targetKey,
+  TrafficRequestPathCache,
+} from "@/lib/trafficFlowLayout";
+import { buildTrafficFlowDiagramLayout } from "@/lib/trafficFlowDiagramLayout";
+import { newTraceRequest } from "@/lib/trafficTraceStore";
+import type { TraceRequest } from "@/types/trafficTrace";
+
+describe("trafficFlowDiagramLayout", () => {
+  test("generates listener, route, and target nodes from config", () => {
+    const config = configWith({
+      listeners: [listener()],
+      routes: [route({ id: 3n, listenerId: 1n })],
+      routeTargets: [routeTarget({ id: 2n, routeId: 3n })],
+    });
+    const layout = buildLayout(config, []);
+
+    expect(layout.nodeByKey.get(listenerKey(1n))?.kind).toBe("listener");
+    expect(layout.nodeByKey.get(routeKey(3n))?.kind).toBe("route");
+    expect(layout.nodeByKey.get(targetKey(2n))?.kind).toBe("target");
+    expect(edgeKeys(layout.edges)).toContain(`${routeKey(3n)}->${targetKey(2n)}`);
+    expect(edgeKeys(layout.edges)).toContain(`${targetKey(2n)}->upstream`);
+  });
+
+  test("includes WAF, rate-limit, and cache path nodes from traced requests", () => {
+    const request = traceRequest({
+      listenerId: 1n,
+      routeId: 3n,
+      routeTargetId: 2n,
+      routeTargetType: PublicRouteTargetType.PROXY,
+      routeTargetTransport: PublicRouteTargetTransport.DIRECT,
+      wafRuleId: 8n,
+      rateLimitRuleId: 9n,
+      cacheRuleId: 4n,
+      cacheStatus: "miss",
+      stage: TrafficTraceStage.CACHE_LOOKUP,
+    });
+    const layout = buildLayout(configWith({}), [request]);
+
+    expect(layout.nodeByKey.get(WAF_KEY)?.kind).toBe("waf");
+    expect(layout.nodeByKey.get(RATE_LIMIT_KEY)?.kind).toBe("rate-limit");
+    expect(layout.nodeByKey.get(CACHE_KEY)?.kind).toBe("cache");
+    expect(edgeKeys(layout.edges)).toContain(`${WAF_KEY}->${RATE_LIMIT_KEY}`);
+    expect(edgeKeys(layout.edges)).toContain(`${targetKey(2n)}->${CACHE_KEY}`);
+  });
+
+  test("generates agent target path nodes for matching agents", () => {
+    const config = configWith({
+      listeners: [listener()],
+      routes: [route({ id: 3n, listenerId: 1n })],
+      routeTargets: [routeTarget({
+        id: 2n,
+        routeId: 3n,
+        transport: PublicRouteTargetTransport.AGENT,
+        agentSelector: {
+          $typeName: "p2pstream.v1.PublicAgentSelector",
+          matchLabels: { site: "edge" },
+        },
+      })],
+      agents: [agent({ id: 7n, publicId: "agent-7", labels: { site: "edge" }, connected: true })],
+    });
+    const layout = buildLayout(config, []);
+
+    expect(layout.nodeByKey.get(agentKey(7n))?.kind).toBe("agent");
+    expect(layout.nodeByKey.get(agentKey(7n))?.agentStatus?.state).toBe("connected");
+    expect(edgeKeys(layout.edges)).toContain(`${targetKey(2n)}->${agentKey(7n)}`);
+    expect(edgeKeys(layout.edges)).toContain(`${agentKey(7n)}->upstream`);
+  });
+});
+
+function buildLayout(config: GetPublicProxyConfigResponse, requests: TraceRequest[]) {
+  const index = createTrafficFlowConfigIndex(config);
+  const cache = new TrafficRequestPathCache();
+  return buildTrafficFlowDiagramLayout({
+    config,
+    requests,
+    configIndex: index,
+    requestPath: (request) => cache.get(request, index),
+  });
+}
+
+function edgeKeys(edges: Array<{ from: string; to: string }>): string[] {
+  return edges.map((edge) => `${edge.from}->${edge.to}`);
+}
+
+function traceRequest(overrides: Partial<TraceRequest>): TraceRequest {
+  return {
+    ...newTraceRequest(overrides.requestId ?? "req"),
+    ...overrides,
+  };
+}
+
+function configWith(overrides: Partial<GetPublicProxyConfigResponse>): GetPublicProxyConfigResponse {
+  return {
+    $typeName: "p2pstream.v1.GetPublicProxyConfigResponse",
+    listeners: [],
+    agents: [],
+    routes: [],
+    routeTargets: [],
+    rateLimitRules: [],
+    trafficShaperRules: [],
+    cacheRules: [],
+    tlsDnsCredentials: [],
+    wafCaptchaProviders: [],
+    wafRules: [],
+    responseTemplates: [],
+    tlsCertificates: [],
+    proxy: undefined,
+    ...overrides,
+  } as GetPublicProxyConfigResponse;
+}
+
+function listener(): PublicListener {
+  return {
+    $typeName: "p2pstream.v1.PublicListener",
+    id: 1n,
+    name: "HTTP",
+    bindAddress: "",
+    port: 8080n,
+    protocol: 1,
+    enabled: true,
+  } as PublicListener;
+}
+
+function route(overrides: Partial<PublicRoute>): PublicRoute {
+  return {
+    $typeName: "p2pstream.v1.PublicRoute",
+    id: 0n,
+    listenerId: 0n,
+    priority: 100n,
+    hostPattern: "",
+    pathPrefix: "",
+    enabled: true,
+    action: PublicRouteAction.FORWARD,
+    redirectTargetMode: 0,
+    redirectTarget: "",
+    redirectStatusCode: 302n,
+    redirectPreservePathSuffix: true,
+    redirectPreserveQuery: true,
+    targetLoadBalancing: 0,
+    isDefault: false,
+    targets: [],
+    ...overrides,
+  } as PublicRoute;
+}
+
+function routeTarget(overrides: Partial<PublicRouteTarget>): PublicRouteTarget {
+  return {
+    $typeName: "p2pstream.v1.PublicRouteTarget",
+    id: 0n,
+    routeId: 0n,
+    name: "",
+    position: 0n,
+    priorityGroup: 0n,
+    weight: 100n,
+    enabled: true,
+    targetType: PublicRouteTargetType.PROXY,
+    url: "http://127.0.0.1:9000",
+    transport: PublicRouteTargetTransport.DIRECT,
+    agentSelector: undefined,
+    agentLoadBalancing: 0,
+    tlsSkipVerify: false,
+    upstreamResponseHeaderTimeoutMillis: 60000n,
+    upstreamRequestHeaders: [],
+    upstreamBasicAuth: undefined,
+    healthCheck: undefined,
+    staticStatusCode: 200n,
+    staticResponseHeaders: [],
+    staticResponseBody: "",
+    staticResponseBodyMode: 0,
+    staticResponseTemplateId: 0n,
+    health: undefined,
+    ...overrides,
+  } as PublicRouteTarget;
+}
+
+function agent(overrides: Partial<Agent>): Agent {
+  return {
+    $typeName: "p2pstream.v1.Agent",
+    id: 0n,
+    publicId: "",
+    name: "",
+    enabled: true,
+    connected: false,
+    activeRequests: 0n,
+    createdAtUnixMillis: 0n,
+    updatedAtUnixMillis: 0n,
+    lastConnectedAtUnixMillis: 0n,
+    lastDisconnectedAtUnixMillis: 0n,
+    latestStats: undefined,
+    labels: {},
+    ...overrides,
+  } as Agent;
+}

--- a/web/management/src/lib/trafficFlowDiagramLayout.test.ts
+++ b/web/management/src/lib/trafficFlowDiagramLayout.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   PublicRouteAction,
+  PublicRouteRedirectTargetMode,
   PublicRouteTargetTransport,
   PublicRouteTargetType,
   TrafficTraceStage,
@@ -17,6 +18,7 @@ import {
   agentKey,
   createTrafficFlowConfigIndex,
   listenerKey,
+  redirectKey,
   routeKey,
   targetKey,
   TrafficRequestPathCache,
@@ -84,6 +86,84 @@ describe("trafficFlowDiagramLayout", () => {
     expect(layout.nodeByKey.get(agentKey(7n))?.agentStatus?.state).toBe("connected");
     expect(edgeKeys(layout.edges)).toContain(`${targetKey(2n)}->${agentKey(7n)}`);
     expect(edgeKeys(layout.edges)).toContain(`${agentKey(7n)}->upstream`);
+  });
+
+  test("routes redirect actions through redirect and response nodes", () => {
+    const config = configWith({
+      listeners: [listener()],
+      routes: [route({
+        id: 3n,
+        listenerId: 1n,
+        action: PublicRouteAction.REDIRECT,
+        redirectTargetMode: PublicRouteRedirectTargetMode.ABSOLUTE_URL,
+        redirectTarget: "https://example.test/new",
+      })],
+    });
+    const layout = buildLayout(config, []);
+
+    expect(layout.nodeByKey.get(redirectKey(3n))?.kind).toBe("redirect");
+    expect(layout.nodeByKey.get(redirectKey(3n))?.subLabel).toBe("302 url");
+    expect(edgeKeys(layout.edges)).toContain(`${routeKey(3n)}->${redirectKey(3n)}`);
+    expect(edgeKeys(layout.edges)).toContain(`${redirectKey(3n)}->response`);
+  });
+
+  test("routes static targets through the static response node", () => {
+    const config = configWith({
+      listeners: [listener()],
+      routes: [route({ id: 3n, listenerId: 1n })],
+      routeTargets: [routeTarget({
+        id: 2n,
+        routeId: 3n,
+        targetType: PublicRouteTargetType.STATIC,
+        staticStatusCode: 204n,
+      })],
+    });
+    const layout = buildLayout(config, []);
+
+    expect(layout.nodeByKey.get("static-response")?.kind).toBe("upstream");
+    expect(edgeKeys(layout.edges)).toContain(`${targetKey(2n)}->static-response`);
+    expect(edgeKeys(layout.edges)).toContain("static-response->response");
+  });
+
+  test("routes terminal policy decisions directly to response", () => {
+    const wafBlocked = traceRequest({
+      requestId: "waf-blocked",
+      listenerId: 1n,
+      wafRuleId: 8n,
+      stage: TrafficTraceStage.WAF_BLOCKED,
+    });
+    const rateLimited = traceRequest({
+      requestId: "rate-limited",
+      listenerId: 1n,
+      rateLimitRuleId: 9n,
+      stage: TrafficTraceStage.RATE_LIMITED,
+    });
+    const layout = buildLayout(configWith({}), [wafBlocked, rateLimited]);
+
+    expect(edgeKeys(layout.edges)).toContain(`${WAF_KEY}->response`);
+    expect(edgeKeys(layout.edges)).toContain(`${RATE_LIMIT_KEY}->response`);
+  });
+
+  test("preserves attacker-controlled trace labels as node data", () => {
+    const hostileLabel = `<script>alert("x")</script> ${"very-long-hostname.".repeat(8)}`;
+    const request = traceRequest({
+      requestId: "hostile-labels",
+      listenerId: 1n,
+      listenerName: hostileLabel,
+      routeId: 3n,
+      routeLabel: `/prefix?<img src=x onerror=alert(1)> ${"segment/".repeat(16)}`,
+      routeTargetId: 2n,
+      routeTargetName: `target ${"<b>bold</b>".repeat(12)}`,
+      routeTargetType: PublicRouteTargetType.PROXY,
+      routeTargetTransport: PublicRouteTargetTransport.DIRECT,
+      stage: TrafficTraceStage.UPSTREAM_STARTED,
+    });
+    const layout = buildLayout(configWith({}), [request]);
+
+    expect(layout.nodeByKey.get(listenerKey(1n))?.label).toBe(hostileLabel);
+    expect(layout.nodeByKey.get(routeKey(3n))?.label).toContain("<img");
+    expect(layout.nodeByKey.get(targetKey(2n))?.label).toContain("<b>bold</b>");
+    expect(edgeKeys(layout.edges)).toContain(`${targetKey(2n)}->upstream`);
   });
 });
 

--- a/web/management/src/lib/trafficFlowDiagramLayout.ts
+++ b/web/management/src/lib/trafficFlowDiagramLayout.ts
@@ -1,0 +1,920 @@
+import {
+  CACHE_KEY,
+  RATE_LIMIT_KEY,
+  TRAFFIC_SHAPER_KEY,
+  WAF_KEY,
+  agentKey,
+  agentsMatchingTargetSelector,
+  isRedirectRoute,
+  listenerDefaultRouteKey,
+  listenerKey,
+  redirectKey,
+  requestUsesCacheNode,
+  requestUsesRateLimitNode,
+  requestUsesTrafficShaperNode,
+  requestUsesWafNode,
+  routeConfigForRequest,
+  routeKey,
+  routeTargetAssignments,
+  targetKey,
+  type TrafficFlowConfigIndex,
+  type TrafficRequestPathCacheEntry,
+} from "@/lib/trafficFlowLayout";
+import { motionEdgeKey, type MotionPoint } from "@/lib/trafficMotion";
+import {
+  BEZIER_LENGTH_SAMPLES,
+  BYPASS_LANE_GAP,
+  BYPASS_X_GAP,
+  CACHE_SIDE_CENTER_Y,
+  COLUMN_X,
+  EDGE_CURVATURE,
+  MIN_BYPASS_Y,
+  MIN_CENTER_Y,
+  NODE_HEIGHT,
+  NODE_WIDTH,
+  ROW_GAP,
+  type AgentNodeStatus,
+  type Bounds,
+  type CacheNodeStatus,
+  type CacheNodeTone,
+  type CubicSegment,
+  type DiagramEdge,
+  type DiagramEdgeRoute,
+  type DiagramNode,
+  type DiagramNodeInput,
+  type EdgeRouteGeometry,
+  type Point,
+  type TrafficFlowDiagramLayout,
+  type TrafficNodeKind,
+  type VisualTokenCacheTone,
+} from "@/lib/trafficFlowModel";
+import {
+  PublicRouteRedirectTargetMode,
+  PublicRouteTargetTransport,
+  PublicRouteTargetType,
+  TrafficTraceStage,
+  type Agent,
+  type GetPublicProxyConfigResponse,
+  type PublicRoute,
+  type PublicRouteTarget,
+} from "@/gen/proto/p2pstream/v1/management_pb";
+import type { TrafficFlowEditTarget } from "@/types/trafficFlowEdit";
+import type { TraceRequest } from "@/types/trafficTrace";
+
+export function buildTrafficFlowDiagramLayout(input: {
+  config: GetPublicProxyConfigResponse | null;
+  requests: readonly TraceRequest[];
+  configIndex: TrafficFlowConfigIndex;
+  requestPath: (request: TraceRequest) => TrafficRequestPathCacheEntry;
+}): TrafficFlowDiagramLayout {
+  const nodes = new Map<string, Omit<DiagramNode, "x" | "y">>();
+  const edges: DiagramEdge[] = [];
+
+  const addNode = (node: DiagramNodeInput) => {
+    const existing = nodes.get(node.key);
+    if (!existing) {
+      nodes.set(node.key, { ...node, editTargets: dedupeEditTargets(node.editTargets ?? []) });
+      return;
+    }
+    nodes.set(node.key, {
+      ...existing,
+      editTargets: dedupeEditTargets([...existing.editTargets, ...(node.editTargets ?? [])]),
+      agentStatus: mergeAgentStatus(existing.agentStatus, node.agentStatus),
+      cacheStatus: mergeCacheStatus(existing.cacheStatus, node.cacheStatus),
+    });
+  };
+  const addEdge = (from: string, to: string, route: DiagramEdgeRoute = "default") => {
+    if (!from || !to || from === to) return;
+    edges.push({ from, to, route });
+  };
+  const index = input.configIndex;
+
+  addNode({ key: "ingress", label: "Ingress", subLabel: "Public request", column: 0, kind: "ingress", editTargets: [] });
+  addNode({ key: "response", label: "Response", subLabel: "Client", column: 10, kind: "response", editTargets: [] });
+
+  const listeners = input.config?.listeners ?? [];
+  const targets = input.config?.routeTargets ?? [];
+  const enabledRateLimitTargets = index.enabledRateLimitTargets;
+  const enabledWafTargets = index.enabledWafTargets;
+  const enabledCacheTargets = index.enabledCacheTargets;
+  const enabledTrafficShaperTargets = index.enabledTrafficShaperTargets;
+  const showWafNode = index.hasEnabledWafRules || input.requests.some((request) => requestUsesWafNode(request, index));
+  const showRateLimitNode = index.hasEnabledRateLimitRules || input.requests.some((request) => requestUsesRateLimitNode(request, index));
+  const showTrafficShaperNode = index.hasEnabledTrafficShaperRules || input.requests.some((request) => requestUsesTrafficShaperNode(request, index));
+  const showCacheNode = index.hasEnabledCacheRules || input.requests.some((request) => requestUsesCacheNode(request, index));
+
+  if (showWafNode) {
+    addNode({
+      key: WAF_KEY,
+      label: "WAF",
+      subLabel: enabledWafTargets.length ? `${enabledWafTargets.length.toString()} enabled` : "Observed",
+      column: 2,
+      kind: "waf",
+      editTargets: enabledWafTargets,
+    });
+  }
+
+  if (showRateLimitNode) {
+    addNode({
+      key: RATE_LIMIT_KEY,
+      label: "Rate limit",
+      subLabel: enabledRateLimitTargets.length ? `${enabledRateLimitTargets.length.toString()} enabled` : "Observed",
+      column: 3,
+      kind: "rate-limit",
+      editTargets: enabledRateLimitTargets,
+    });
+  }
+
+  if (showTrafficShaperNode) {
+    addNode({
+      key: TRAFFIC_SHAPER_KEY,
+      label: "Traffic shaper",
+      subLabel: enabledTrafficShaperTargets.length ? `${enabledTrafficShaperTargets.length.toString()} enabled` : "Observed",
+      column: 4,
+      kind: "traffic-shaper",
+      editTargets: enabledTrafficShaperTargets,
+    });
+  }
+
+  if (showCacheNode) {
+    addNode({
+      key: CACHE_KEY,
+      label: "Cache",
+      subLabel: enabledCacheTargets.length ? `${enabledCacheTargets.length.toString()} enabled` : "Observed",
+      column: 7,
+      kind: "cache",
+      editTargets: enabledCacheTargets,
+      cacheStatus: { label: "READY", tone: "neutral" },
+    });
+  }
+
+  for (const listener of listeners) {
+    const listenerNodeKey = listenerKey(listener.id);
+    const routeEntryKey = showTrafficShaperNode ? TRAFFIC_SHAPER_KEY : showRateLimitNode ? RATE_LIMIT_KEY : showWafNode ? WAF_KEY : listenerNodeKey;
+    const rateEntryKey = showWafNode ? WAF_KEY : listenerNodeKey;
+    const shaperEntryKey = showRateLimitNode ? RATE_LIMIT_KEY : showWafNode ? WAF_KEY : listenerNodeKey;
+    addNode({
+      key: listenerNodeKey,
+      label: listener.name || `Listener ${listener.id.toString()}`,
+      subLabel: `${listener.bindAddress || "*"}:${listener.port.toString()}`,
+      column: 1,
+      kind: "listener",
+      editTargets: [listenerEditTarget(listener.id, listener.name || `Listener ${listener.id.toString()}`, `${listener.bindAddress || "*"}:${listener.port.toString()}`)],
+    });
+    addEdge("ingress", listenerNodeKey);
+    if (showWafNode) addEdge(listenerNodeKey, WAF_KEY);
+    if (showRateLimitNode) addEdge(rateEntryKey, RATE_LIMIT_KEY);
+    if (showTrafficShaperNode) addEdge(shaperEntryKey, TRAFFIC_SHAPER_KEY);
+
+    const defaultRouteKey = listenerDefaultRouteKey(listener.id);
+    addNode({
+      key: defaultRouteKey,
+      label: "Default route",
+      subLabel: "Listener fallbacks",
+      column: 5,
+      kind: "route",
+      editTargets: [listenerEditTarget(listener.id, listener.name || `Listener ${listener.id.toString()}`, "Default target")],
+    });
+    addEdge(routeEntryKey, defaultRouteKey);
+    const defaultRoute = (index.routesByListenerId.get(listener.id.toString()) ?? []).find((route) => route.isDefault);
+    if (defaultRoute) {
+      for (const target of routeTargetAssignments(defaultRoute, index).filter((item) => item.enabled)) {
+        addEdge(defaultRouteKey, targetKey(target.id));
+      }
+    } else {
+      addEdge(defaultRouteKey, "response", "agent-bypass");
+    }
+
+    for (const route of index.routesByListenerId.get(listener.id.toString()) ?? []) {
+      if (route.isDefault) continue;
+      const key = routeKey(route.id);
+      addNode({
+        key,
+        label: routeLabel(route.hostPattern, route.pathPrefix, route.id),
+        subLabel: `P${route.priority.toString()}`,
+        column: 5,
+        kind: "route",
+        editTargets: [routeEditTarget(route)],
+      });
+      addEdge(routeEntryKey, key);
+      if (isRedirectRoute(route)) {
+        addRedirectNode(route, addNode);
+        addEdge(key, redirectKey(route.id));
+        addEdge(redirectKey(route.id), "response", "intermediate-bypass");
+      } else {
+        const assignments = routeTargetAssignments(route, index).filter((target) => target.enabled);
+        if (assignments.length) {
+          for (const target of assignments) addEdge(key, targetKey(target.id));
+        } else {
+          addEdge(key, "response", "agent-bypass");
+        }
+      }
+    }
+  }
+
+  for (const target of targets) {
+    const key = targetKey(target.id);
+    const isStatic = target.targetType === PublicRouteTargetType.STATIC;
+    const isAgentTarget = target.transport === PublicRouteTargetTransport.AGENT;
+    addNode({
+      key,
+      label: target.name || `Target ${target.id.toString()}`,
+      subLabel: isStatic ? "Static" : isAgentTarget ? "Agent selected" : "Direct",
+      column: 6,
+      kind: "target",
+      editTargets: [targetEditTarget(target.id, target.name || `Target ${target.id.toString()}`, isStatic ? "Static" : isAgentTarget ? "Agent selected" : "Direct")],
+    });
+
+    if (isStatic) {
+      addStaticNode(addNode, targetEditTarget(target.id, target.name || `Target ${target.id.toString()}`, "Static"));
+      addEdge(key, "static-response", "agent-bypass");
+      addEdge("static-response", "response");
+      continue;
+    }
+
+    if (isAgentTarget) {
+      const matchedAgents = agentsMatchingTarget(target, input.config?.agents ?? []);
+      if (matchedAgents.length) {
+        for (const agent of matchedAgents) {
+          const agentNodeKey = agentKey(agent.id);
+          addNode({
+            key: agentNodeKey,
+            label: agent.name || `Agent ${agent.id.toString()}`,
+            subLabel: agent.publicId,
+            column: 8,
+            kind: "agent",
+            agentStatus: agentNodeStatus(agent),
+            editTargets: [agentEditTarget(agent.id, agent.name || `Agent ${agent.id.toString()}`, agent.publicId)],
+          });
+          addUpstreamNode(addNode, targetEditTarget(target.id, target.name || `Target ${target.id.toString()}`, "Agent selected"));
+          if (showCacheNode) {
+            addEdge(key, CACHE_KEY);
+            addEdge(CACHE_KEY, "response", "intermediate-bypass");
+          }
+          addEdge(key, agentNodeKey);
+          addEdge(agentNodeKey, "upstream");
+          addEdge("upstream", "response");
+        }
+      } else {
+        if (showCacheNode) {
+          addEdge(key, CACHE_KEY);
+          addEdge(CACHE_KEY, "response", "agent-bypass");
+        }
+        addEdge(key, "response", "agent-bypass");
+      }
+      continue;
+    }
+
+    addUpstreamNode(addNode, targetEditTarget(target.id, target.name || `Target ${target.id.toString()}`, "Direct"));
+    if (showCacheNode) {
+      addEdge(key, CACHE_KEY);
+      addEdge(CACHE_KEY, "response", "intermediate-bypass");
+    }
+    addEdge(key, "upstream", "agent-bypass");
+    addEdge("upstream", "response");
+  }
+
+  for (const request of input.requests) {
+    addObservedNodes(request, addNode, index);
+    const path = input.requestPath(request).path;
+    for (let index = 0; index < path.length - 1; index += 1) {
+      addEdge(path[index], path[index + 1], routeForRequestSegment(request, path[index], path[index + 1]));
+    }
+  }
+
+  if (!listeners.length && !input.requests.length) {
+    const policyPath = [
+      showWafNode ? WAF_KEY : "",
+      showRateLimitNode ? RATE_LIMIT_KEY : "",
+      showTrafficShaperNode ? TRAFFIC_SHAPER_KEY : "",
+    ].filter(Boolean);
+    if (policyPath.length) {
+      addEdge("ingress", policyPath[0]);
+      for (let index = 0; index < policyPath.length - 1; index += 1) {
+        addEdge(policyPath[index], policyPath[index + 1]);
+      }
+      addEdge(policyPath[policyPath.length - 1], "response", "intermediate-bypass");
+    } else {
+      addEdge("ingress", "response");
+    }
+  }
+
+  const byColumn = new Map<number, Omit<DiagramNode, "x" | "y">[]>();
+  for (const node of nodes.values()) {
+    const group = byColumn.get(node.column) ?? [];
+    group.push(node);
+    byColumn.set(node.column, group);
+  }
+
+  const positioned: DiagramNode[] = [];
+  for (const [column, group] of byColumn.entries()) {
+    group.sort((a, b) => kindOrder(a.kind) - kindOrder(b.kind) || a.label.localeCompare(b.label));
+    group.forEach((node, index) => {
+      const centerY = node.key === CACHE_KEY ? CACHE_SIDE_CENTER_Y : yPosition(index, group.length);
+      positioned.push({
+        ...node,
+        x: COLUMN_X[column] ?? COLUMN_X[0],
+        y: centerY - NODE_HEIGHT / 2,
+      });
+    });
+  }
+
+  const nodeByKey = new Map(positioned.map((node) => [node.key, node]));
+  const uniqueEdges = dedupeEdges(edges).filter((edge) => nodeByKey.has(edge.from) && nodeByKey.has(edge.to));
+  return { nodes: positioned, nodeByKey, edges: uniqueEdges };
+}
+
+export function buildTrafficFlowEdgeRoutes(layout: TrafficFlowDiagramLayout): Map<string, EdgeRouteGeometry> {
+  const routes = new Map<string, EdgeRouteGeometry>();
+  for (const edge of layout.edges) {
+    const sourceNode = layout.nodeByKey.get(edge.from);
+    const targetNode = layout.nodeByKey.get(edge.to);
+    if (!sourceNode || !targetNode) continue;
+
+    const source = sourceHandlePoint(sourceNode);
+    const target = targetHandlePoint(targetNode);
+    const bypassBounds = bypassBoundsForEdge(layout, edge);
+    const route =
+      edge.route !== "default" && bypassBounds
+        ? buildBypassRoute(edge, source, target, bypassBounds)
+        : buildDefaultBezierRoute(edge, source, target);
+    routes.set(edgeKey(edge.from, edge.to), route);
+  }
+  return routes;
+}
+
+export function routeToMotionPoints(route: EdgeRouteGeometry): MotionPoint[] {
+  const sampleCount = Math.max(2, Math.ceil(route.totalLength / 24));
+  const points: MotionPoint[] = [];
+  for (let index = 0; index <= sampleCount; index += 1) {
+    points.push(pointAtRouteProgress(route, index / sampleCount));
+  }
+  return points;
+}
+
+export function nodeBounds(node: DiagramNode): Bounds {
+  return {
+    left: node.x,
+    right: node.x + NODE_WIDTH,
+    top: node.y,
+    bottom: node.y + NODE_HEIGHT,
+  };
+}
+
+export function pointInsideBounds(point: Point, bounds: Bounds): boolean {
+  return point.x >= bounds.left && point.x <= bounds.right && point.y >= bounds.top && point.y <= bounds.bottom;
+}
+
+export function edgeKey(from: string, to: string): string {
+  return motionEdgeKey(from, to);
+}
+
+export function cacheStatusForTone(tone: Exclude<VisualTokenCacheTone, ""> | CacheNodeTone): CacheNodeStatus {
+  switch (tone) {
+    case "hit": return { label: "HIT", tone: "hit" };
+    case "miss": return { label: "MISS", tone: "miss" };
+    case "bypass": return { label: "BYPASS", tone: "bypass" };
+    case "stored": return { label: "STORED", tone: "stored" };
+    case "lookup": return { label: "LOOKUP", tone: "lookup" };
+    default: return { label: "READY", tone: "neutral" };
+  }
+}
+
+export function cacheStatusForRequest(request: TraceRequest): CacheNodeStatus {
+  return cacheStatusForTone(cacheToneForRequest(request) || "lookup");
+}
+
+export function cacheToneForRequest(request: TraceRequest): VisualTokenCacheTone {
+  const status = request.cacheStatus.toLowerCase();
+  if (status === "hit" || request.stage === TrafficTraceStage.CACHE_HIT) return "hit";
+  if (status === "miss" || request.stage === TrafficTraceStage.CACHE_MISS) return "miss";
+  if (status === "bypass" || request.stage === TrafficTraceStage.CACHE_BYPASS) return "bypass";
+  if (status === "stored" || request.stage === TrafficTraceStage.CACHE_STORED) return "stored";
+  return "";
+}
+
+export function cacheTonePriority(tone: CacheNodeTone): number {
+  switch (tone) {
+    case "hit": return 6;
+    case "stored": return 5;
+    case "miss": return 4;
+    case "bypass": return 3;
+    case "lookup": return 2;
+    default: return 1;
+  }
+}
+
+function addObservedNodes(
+  request: TraceRequest,
+  addNode: (node: DiagramNodeInput) => void,
+  index: TrafficFlowConfigIndex,
+) {
+  if (requestUsesWafNode(request, index)) {
+    addNode({
+      key: WAF_KEY,
+      label: "WAF",
+      subLabel: request.wafRuleName || "Observed",
+      column: 2,
+      kind: "waf",
+      editTargets: request.wafRuleId > 0n
+        ? [wafEditTarget(request.wafRuleId, request.wafRuleName || `WAF ${request.wafRuleId.toString()}`, "Observed")]
+        : index.enabledWafTargets,
+    });
+  }
+
+  if (requestUsesRateLimitNode(request, index)) {
+    addNode({
+      key: RATE_LIMIT_KEY,
+      label: "Rate limit",
+      subLabel: request.rateLimitRuleName || "Observed",
+      column: 3,
+      kind: "rate-limit",
+      editTargets: index.enabledRateLimitTargets,
+    });
+  }
+
+  if (requestUsesTrafficShaperNode(request, index)) {
+    addNode({
+      key: TRAFFIC_SHAPER_KEY,
+      label: "Traffic shaper",
+      subLabel: request.trafficShaperRuleName || "Observed",
+      column: 4,
+      kind: "traffic-shaper",
+      editTargets: request.trafficShaperRuleId > 0n
+        ? [trafficShaperEditTarget(request.trafficShaperRuleId, request.trafficShaperRuleName || `Traffic shaper ${request.trafficShaperRuleId.toString()}`, "Observed")]
+        : index.enabledTrafficShaperTargets,
+    });
+  }
+
+  if (requestUsesCacheNode(request, index)) {
+    addNode({
+      key: CACHE_KEY,
+      label: "Cache",
+      subLabel: request.cacheRuleName || request.cacheStatus || "Observed",
+      column: 7,
+      kind: "cache",
+      cacheStatus: cacheStatusForRequest(request),
+      editTargets: request.cacheRuleId > 0n
+        ? [cacheEditTarget(request.cacheRuleId, request.cacheRuleName || `Cache ${request.cacheRuleId.toString()}`, request.cacheStatus || "Observed")]
+        : index.enabledCacheTargets,
+    });
+  }
+
+  if (request.listenerId > 0n) {
+    addNode({
+      key: listenerKey(request.listenerId),
+      label: request.listenerName || `Listener ${request.listenerId.toString()}`,
+      subLabel: "Observed",
+      column: 1,
+      kind: "listener",
+      editTargets: [listenerEditTarget(request.listenerId, request.listenerName || `Listener ${request.listenerId.toString()}`, "Observed")],
+    });
+  }
+
+  if (request.routeId > 0n) {
+    addNode({
+      key: routeKey(request.routeId),
+      label: request.routeLabel || `Route ${request.routeId.toString()}`,
+      subLabel: "Observed",
+      column: 5,
+      kind: "route",
+      editTargets: [routeEditTargetByID(request.routeId, request.routeLabel || `Route ${request.routeId.toString()}`, "Observed")],
+    });
+    const route = routeConfigForRequest(request, index);
+    if (route && isRedirectRoute(route)) addRedirectNode(route, addNode);
+  } else if (request.defaultRoute && request.listenerId > 0n) {
+    addNode({
+      key: listenerDefaultRouteKey(request.listenerId),
+      label: "Default route",
+      subLabel: "Observed fallback",
+      column: 5,
+      kind: "route",
+      editTargets: request.listenerId > 0n
+        ? [listenerEditTarget(request.listenerId, request.listenerName || `Listener ${request.listenerId.toString()}`, "Default route")]
+        : [],
+    });
+  }
+
+  const selectedTargetId = requestTargetID(request);
+  if (selectedTargetId > 0n) {
+    addNode({
+      key: targetKey(selectedTargetId),
+      label: requestTargetLabel(request),
+      subLabel: targetTypeLabel(request),
+      column: 6,
+      kind: "target",
+      editTargets: [targetEditTarget(selectedTargetId, requestTargetLabel(request), targetTypeLabel(request))],
+    });
+  }
+
+  if (requestTargetType(request) === PublicRouteTargetType.STATIC) {
+    addStaticNode(addNode, selectedTargetId > 0n ? targetEditTarget(selectedTargetId, requestTargetLabel(request), "Static") : undefined);
+  } else if (selectedTargetId > 0n && requestTargetTransport(request) !== PublicRouteTargetTransport.AGENT) {
+    addUpstreamNode(addNode, targetEditTarget(selectedTargetId, requestTargetLabel(request), "Direct"));
+  }
+
+  if (request.agentId > 0n) {
+    const agent = index.agentById.get(request.agentId.toString());
+    addNode({
+      key: agentKey(request.agentId),
+      label: request.agentName || request.agentPublicId || `Agent ${request.agentId.toString()}`,
+      subLabel: request.agentPublicId || "Observed",
+      column: 8,
+      kind: "agent",
+      agentStatus: agentNodeStatus(agent),
+      editTargets: [agentEditTarget(request.agentId, request.agentName || request.agentPublicId || `Agent ${request.agentId.toString()}`, request.agentPublicId || "Observed")],
+    });
+    addUpstreamNode(addNode, selectedTargetId > 0n ? targetEditTarget(selectedTargetId, requestTargetLabel(request), "Agent selected") : undefined);
+  }
+}
+
+function routeForRequestSegment(request: TraceRequest, from: string, to: string): DiagramEdgeRoute {
+  if (from.startsWith("redirect:") && to === "response") return "intermediate-bypass";
+  if (from === RATE_LIMIT_KEY && to === "response") return "intermediate-bypass";
+  if (from === TRAFFIC_SHAPER_KEY && to === "response") return "intermediate-bypass";
+  if (from === CACHE_KEY && to === "response") return "intermediate-bypass";
+  const targetNode = request.routeTargetId > 0n ? targetKey(request.routeTargetId) : "";
+  if (from !== targetNode) return "default";
+  if (to === CACHE_KEY) return "default";
+  if (request.agentId > 0n) return "default";
+  if (to === "static-response" || to === "upstream" || to === "response") return "agent-bypass";
+  return "default";
+}
+
+function sourceHandlePoint(node: DiagramNode): Point {
+  return {
+    x: node.x + NODE_WIDTH,
+    y: node.y + NODE_HEIGHT / 2,
+  };
+}
+
+function targetHandlePoint(node: DiagramNode): Point {
+  return {
+    x: node.x,
+    y: node.y + NODE_HEIGHT / 2,
+  };
+}
+
+function calculateControlOffset(distance: number, curvature: number): number {
+  if (distance >= 0) return 0.5 * distance;
+  return curvature * 25 * Math.sqrt(-distance);
+}
+
+function bezierControls(source: Point, target: Point): { sourceControl: Point; targetControl: Point } {
+  const offset = calculateControlOffset(target.x - source.x, EDGE_CURVATURE);
+  return {
+    sourceControl: {
+      x: source.x + offset,
+      y: source.y,
+    },
+    targetControl: {
+      x: target.x - offset,
+      y: target.y,
+    },
+  };
+}
+
+function buildDefaultBezierRoute(edge: DiagramEdge, source: Point, target: Point): EdgeRouteGeometry {
+  const controls = bezierControls(source, target);
+  return buildEdgeRouteGeometry(edge, [
+    buildCubicSegment(source, controls.sourceControl, controls.targetControl, target),
+  ]);
+}
+
+function bypassBoundsForEdge(layout: TrafficFlowDiagramLayout, edge: DiagramEdge): Bounds | null {
+  if (edge.route === "agent-bypass") {
+    return boundsForNodes(layout.nodes.filter((node) => node.kind === "agent" && node.key !== edge.from && node.key !== edge.to));
+  }
+  if (edge.route === "intermediate-bypass") {
+    return boundsForNodes(layout.nodes.filter((node) => {
+      if (node.key === edge.from || node.key === edge.to) return false;
+      return node.kind === "route" || node.kind === "target" || node.kind === "redirect" || node.kind === "agent" || node.kind === "upstream";
+    }));
+  }
+  return null;
+}
+
+function buildBypassRoute(edge: DiagramEdge, source: Point, target: Point, obstacleBounds: Bounds): EdgeRouteGeometry {
+  const laneY = bypassLaneY(source, target, obstacleBounds);
+  const entryX = obstacleBounds.left - BYPASS_X_GAP;
+  const exitX = obstacleBounds.right + BYPASS_X_GAP;
+  const laneEntry = { x: entryX, y: laneY };
+  const laneExit = { x: exitX, y: laneY };
+
+  return buildEdgeRouteGeometry(edge, [
+    buildCubicSegment(source, { x: source.x + 32, y: source.y }, { x: laneEntry.x - 32, y: laneEntry.y }, laneEntry),
+    buildCubicSegment(laneEntry, { x: laneEntry.x + 40, y: laneEntry.y }, { x: laneExit.x - 40, y: laneExit.y }, laneExit),
+    buildCubicSegment(laneExit, { x: laneExit.x + 32, y: laneExit.y }, { x: target.x - 32, y: target.y }, target),
+  ]);
+}
+
+function buildEdgeRouteGeometry(edge: DiagramEdge, segments: CubicSegment[]): EdgeRouteGeometry {
+  return {
+    from: edge.from,
+    to: edge.to,
+    route: edge.route,
+    segments,
+    totalLength: segments.reduce((sum, segment) => sum + segment.totalLength, 0),
+    path: routePath(segments),
+  };
+}
+
+function buildCubicSegment(
+  source: Point,
+  sourceControl: Point,
+  targetControl: Point,
+  target: Point,
+): CubicSegment {
+  const segment: CubicSegment = {
+    source,
+    sourceControl,
+    targetControl,
+    target,
+    lengthTable: [{ t: 0, length: 0 }],
+    totalLength: 0,
+  };
+  let previous = source;
+  let totalLength = 0;
+
+  for (let index = 1; index <= BEZIER_LENGTH_SAMPLES; index += 1) {
+    const t = index / BEZIER_LENGTH_SAMPLES;
+    const point = cubicBezierPoint(segment, t);
+    totalLength += pointDistance(previous, point);
+    segment.lengthTable.push({ t, length: totalLength });
+    previous = point;
+  }
+
+  segment.totalLength = totalLength;
+  return segment;
+}
+
+function cubicBezierPoint(segment: CubicSegment, t: number): Point {
+  const inv = 1 - t;
+  return {
+    x:
+      inv * inv * inv * segment.source.x +
+      3 * inv * inv * t * segment.sourceControl.x +
+      3 * inv * t * t * segment.targetControl.x +
+      t * t * t * segment.target.x,
+    y:
+      inv * inv * inv * segment.source.y +
+      3 * inv * inv * t * segment.sourceControl.y +
+      3 * inv * t * t * segment.targetControl.y +
+      t * t * t * segment.target.y,
+  };
+}
+
+function pointAtRouteProgress(route: EdgeRouteGeometry, progress: number): Point {
+  const targetLength = route.totalLength * clamp(progress, 0, 1);
+  let traversed = 0;
+
+  for (const segment of route.segments) {
+    const nextTraversed = traversed + segment.totalLength;
+    if (targetLength <= nextTraversed) {
+      const segmentProgress = segment.totalLength <= 0 ? 0 : (targetLength - traversed) / segment.totalLength;
+      return pointAtSegmentProgress(segment, segmentProgress);
+    }
+    traversed = nextTraversed;
+  }
+
+  return route.segments.at(-1)?.target ?? { x: 0, y: 0 };
+}
+
+function pointAtSegmentProgress(segment: CubicSegment, progress: number): Point {
+  const targetLength = segment.totalLength * clamp(progress, 0, 1);
+  if (segment.totalLength <= 0) return cubicBezierPoint(segment, progress);
+
+  let previous = segment.lengthTable[0];
+  for (let index = 1; index < segment.lengthTable.length; index += 1) {
+    const current = segment.lengthTable[index];
+    if (current.length < targetLength) {
+      previous = current;
+      continue;
+    }
+
+    const lengthSpan = current.length - previous.length;
+    const localProgress = lengthSpan <= 0 ? 0 : (targetLength - previous.length) / lengthSpan;
+    const t = previous.t + (current.t - previous.t) * localProgress;
+    return cubicBezierPoint(segment, t);
+  }
+
+  return segment.target;
+}
+
+function routePath(segments: CubicSegment[]): string {
+  return segments
+    .map((segment, index) => {
+      const start = index === 0 ? `M${segment.source.x},${segment.source.y} ` : "";
+      return `${start}C${segment.sourceControl.x},${segment.sourceControl.y} ${segment.targetControl.x},${segment.targetControl.y} ${segment.target.x},${segment.target.y}`;
+    })
+    .join(" ");
+}
+
+function pointDistance(a: Point, b: Point): number {
+  return Math.hypot(b.x - a.x, b.y - a.y);
+}
+
+function boundsForNodes(nodes: DiagramNode[]): Bounds | null {
+  if (!nodes.length) return null;
+  return nodes.reduce((bounds, node) => {
+    const next = nodeBounds(node);
+    return {
+      left: Math.min(bounds.left, next.left),
+      right: Math.max(bounds.right, next.right),
+      top: Math.min(bounds.top, next.top),
+      bottom: Math.max(bounds.bottom, next.bottom),
+    };
+  }, nodeBounds(nodes[0]));
+}
+
+function bypassLaneY(source: Point, target: Point, agentBounds: Bounds): number {
+  const averageY = (source.y + target.y) / 2;
+  const topLane = Math.min(source.y, target.y, agentBounds.top) - BYPASS_LANE_GAP;
+  const bottomLane = Math.max(source.y, target.y, agentBounds.bottom) + BYPASS_LANE_GAP;
+
+  if (topLane >= MIN_BYPASS_Y) {
+    const topCost = Math.abs(averageY - topLane);
+    const bottomCost = Math.abs(averageY - bottomLane);
+    return topCost <= bottomCost ? topLane : bottomLane;
+  }
+
+  return bottomLane;
+}
+
+function addStaticNode(addNode: (node: DiagramNodeInput) => void, target?: TrafficFlowEditTarget) {
+  addNode({ key: "static-response", label: "Static", subLabel: "Generated", column: 9, kind: "upstream", editTargets: target ? [target] : [] });
+}
+
+function addUpstreamNode(addNode: (node: DiagramNodeInput) => void, target?: TrafficFlowEditTarget) {
+  addNode({ key: "upstream", label: "Upstream", subLabel: "Origin", column: 9, kind: "upstream", editTargets: target ? [target] : [] });
+}
+
+function addRedirectNode(route: PublicRoute, addNode: (node: DiagramNodeInput) => void) {
+  addNode({
+    key: redirectKey(route.id),
+    label: "Redirect",
+    subLabel: redirectNodeSubLabel(route),
+    column: 6,
+    kind: "redirect",
+    editTargets: [routeEditTarget(route)],
+  });
+}
+
+function yPosition(index: number, total: number): number {
+  if (total <= 1) return 236;
+  const visibleRows = Math.min(total, 4);
+  const centeringOffset = Math.max(0, (4 - visibleRows) * ROW_GAP * 0.5);
+  return MIN_CENTER_Y + centeringOffset + index * ROW_GAP;
+}
+
+function dedupeEdges(edges: DiagramEdge[]): DiagramEdge[] {
+  const byKey = new Map<string, DiagramEdge>();
+  for (const edge of edges) {
+    const key = edgeKey(edge.from, edge.to);
+    const existing = byKey.get(key);
+    if (!existing || edgeRoutePriority(edge.route) > edgeRoutePriority(existing.route)) {
+      byKey.set(key, edge);
+    }
+  }
+  return [...byKey.values()];
+}
+
+function edgeRoutePriority(route: DiagramEdgeRoute): number {
+  switch (route) {
+    case "intermediate-bypass": return 2;
+    case "agent-bypass": return 1;
+    default: return 0;
+  }
+}
+
+function dedupeEditTargets(targets: TrafficFlowEditTarget[]): TrafficFlowEditTarget[] {
+  const byKey = new Map<string, TrafficFlowEditTarget>();
+  for (const target of targets) {
+    byKey.set(`${target.kind}:${target.id}`, target);
+  }
+  return [...byKey.values()];
+}
+
+function agentNodeStatus(agent: Agent | undefined): AgentNodeStatus {
+  if (!agent) return { state: "unknown", label: "Unknown" };
+  if (!agent.enabled) return { state: "disabled", label: "Disabled" };
+  if (agent.connected) return { state: "connected", label: "Connected" };
+  return { state: "offline", label: "Offline" };
+}
+
+function agentsMatchingTarget(target: PublicRouteTarget, agents: readonly Agent[]): Agent[] {
+  return agentsMatchingTargetSelector(target, agents);
+}
+
+function mergeAgentStatus(existing: AgentNodeStatus | undefined, next: AgentNodeStatus | undefined): AgentNodeStatus | undefined {
+  if (!existing) return next;
+  if (!next) return existing;
+  if (existing.state === "unknown" && next.state !== "unknown") return next;
+  return existing;
+}
+
+function mergeCacheStatus(existing: CacheNodeStatus | undefined, next: CacheNodeStatus | undefined): CacheNodeStatus | undefined {
+  if (!existing) return next;
+  if (!next) return existing;
+  return cacheTonePriority(next.tone) > cacheTonePriority(existing.tone) ? next : existing;
+}
+
+function kindOrder(kind: TrafficNodeKind): number {
+  switch (kind) {
+    case "ingress": return 0;
+    case "listener": return 1;
+    case "waf": return 2;
+    case "rate-limit": return 3;
+    case "traffic-shaper": return 4;
+    case "route": return 5;
+    case "target": return 6;
+    case "redirect": return 6;
+    case "cache": return 7;
+    case "agent": return 8;
+    case "upstream": return 9;
+    case "response": return 10;
+    default: return 99;
+  }
+}
+
+function routeLabel(hostPattern: string, pathPrefix: string, id: bigint): string {
+  const parts = [hostPattern, pathPrefix].filter(Boolean);
+  return parts.length ? parts.join(" ") : `Route ${id.toString()}`;
+}
+
+function listenerEditTarget(id: bigint | string | number, label: string, subLabel?: string): TrafficFlowEditTarget {
+  return { kind: "listener", id: id.toString(), label, subLabel };
+}
+
+function routeEditTarget(route: PublicRoute): TrafficFlowEditTarget {
+  return routeEditTargetByID(route.id, routeLabel(route.hostPattern, route.pathPrefix, route.id), `P${route.priority.toString()}`);
+}
+
+function routeEditTargetByID(id: bigint | string | number, label: string, subLabel?: string): TrafficFlowEditTarget {
+  return { kind: "route", id: id.toString(), label, subLabel };
+}
+
+function targetEditTarget(id: bigint | string | number, label: string, subLabel?: string): TrafficFlowEditTarget {
+  return { kind: "target", id: id.toString(), label, subLabel };
+}
+
+function agentEditTarget(id: bigint | string | number, label: string, subLabel?: string): TrafficFlowEditTarget {
+  return { kind: "agent", id: id.toString(), label, subLabel };
+}
+
+function trafficShaperEditTarget(id: bigint | string | number, label: string, subLabel?: string): TrafficFlowEditTarget {
+  return { kind: "traffic-shaper", id: id.toString(), label, subLabel };
+}
+
+function wafEditTarget(id: bigint | string | number, label: string, subLabel?: string): TrafficFlowEditTarget {
+  return { kind: "waf", id: id.toString(), label, subLabel };
+}
+
+function cacheEditTarget(id: bigint | string | number, label: string, subLabel?: string): TrafficFlowEditTarget {
+  return { kind: "cache", id: id.toString(), label, subLabel };
+}
+
+function targetTypeLabel(request: TraceRequest): string {
+  if (requestTargetType(request) === PublicRouteTargetType.STATIC) return "Static";
+  if (requestTargetTransport(request) === PublicRouteTargetTransport.AGENT) return "Agent selected";
+  return "Direct";
+}
+
+function requestTargetID(request: TraceRequest): bigint {
+  return request.routeTargetId;
+}
+
+function requestTargetLabel(request: TraceRequest): string {
+  const id = requestTargetID(request);
+  return request.routeTargetName || `Target ${id.toString()}`;
+}
+
+function requestTargetType(request: TraceRequest): PublicRouteTargetType {
+  return request.routeTargetType || PublicRouteTargetType.UNSPECIFIED;
+}
+
+function requestTargetTransport(request: TraceRequest): PublicRouteTargetTransport {
+  return request.routeTargetTransport || PublicRouteTargetTransport.UNSPECIFIED;
+}
+
+function redirectNodeSubLabel(route: PublicRoute): string {
+  const status = Number(route.redirectStatusCode || 302);
+  return `${status} ${redirectModeShortLabel(route.redirectTargetMode)}`;
+}
+
+function redirectModeShortLabel(mode: PublicRouteRedirectTargetMode): string {
+  switch (mode) {
+    case PublicRouteRedirectTargetMode.EXTERNAL_ORIGIN_KEEP_PATH:
+      return "origin";
+    case PublicRouteRedirectTargetMode.ABSOLUTE_URL:
+      return "url";
+    case PublicRouteRedirectTargetMode.SAME_HOST_PATH:
+      return "same-host";
+    default:
+      return "redirect";
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/web/management/src/lib/trafficFlowGraph.test.ts
+++ b/web/management/src/lib/trafficFlowGraph.test.ts
@@ -23,11 +23,11 @@ import {
   targetKey,
   TrafficRequestPathCache,
 } from "@/lib/trafficFlowLayout";
-import { buildTrafficFlowDiagramLayout } from "@/lib/trafficFlowDiagramLayout";
+import { buildTrafficFlowGraph } from "@/lib/trafficFlowGraph";
 import { newTraceRequest } from "@/lib/trafficTraceStore";
 import type { TraceRequest } from "@/types/trafficTrace";
 
-describe("trafficFlowDiagramLayout", () => {
+describe("trafficFlowGraph", () => {
   test("generates listener, route, and target nodes from config", () => {
     const config = configWith({
       listeners: [listener()],
@@ -170,7 +170,7 @@ describe("trafficFlowDiagramLayout", () => {
 function buildLayout(config: GetPublicProxyConfigResponse, requests: TraceRequest[]) {
   const index = createTrafficFlowConfigIndex(config);
   const cache = new TrafficRequestPathCache();
-  return buildTrafficFlowDiagramLayout({
+  return buildTrafficFlowGraph({
     config,
     requests,
     configIndex: index,

--- a/web/management/src/lib/trafficFlowGraph.ts
+++ b/web/management/src/lib/trafficFlowGraph.ts
@@ -44,7 +44,7 @@ import {
   type DiagramNodeInput,
   type EdgeRouteGeometry,
   type Point,
-  type TrafficFlowDiagramLayout,
+  type TrafficFlowGraph,
   type TrafficNodeKind,
   type VisualTokenCacheTone,
 } from "@/lib/trafficFlowModel";
@@ -61,12 +61,12 @@ import {
 import type { TrafficFlowEditTarget } from "@/types/trafficFlowEdit";
 import type { TraceRequest } from "@/types/trafficTrace";
 
-export function buildTrafficFlowDiagramLayout(input: {
+export function buildTrafficFlowGraph(input: {
   config: GetPublicProxyConfigResponse | null;
   requests: readonly TraceRequest[];
   configIndex: TrafficFlowConfigIndex;
   requestPath: (request: TraceRequest) => TrafficRequestPathCacheEntry;
-}): TrafficFlowDiagramLayout {
+}): TrafficFlowGraph {
   const nodes = new Map<string, Omit<DiagramNode, "x" | "y">>();
   const edges: DiagramEdge[] = [];
 
@@ -324,7 +324,7 @@ export function buildTrafficFlowDiagramLayout(input: {
   return { nodes: positioned, nodeByKey, edges: uniqueEdges };
 }
 
-export function buildTrafficFlowEdgeRoutes(layout: TrafficFlowDiagramLayout): Map<string, EdgeRouteGeometry> {
+export function buildTrafficFlowEdgeRoutes(layout: TrafficFlowGraph): Map<string, EdgeRouteGeometry> {
   const routes = new Map<string, EdgeRouteGeometry>();
   for (const edge of layout.edges) {
     const sourceNode = layout.nodeByKey.get(edge.from);
@@ -581,7 +581,7 @@ function buildDefaultBezierRoute(edge: DiagramEdge, source: Point, target: Point
   ]);
 }
 
-function bypassBoundsForEdge(layout: TrafficFlowDiagramLayout, edge: DiagramEdge): Bounds | null {
+function bypassBoundsForEdge(layout: TrafficFlowGraph, edge: DiagramEdge): Bounds | null {
   if (edge.route === "agent-bypass") {
     return boundsForNodes(layout.nodes.filter((node) => node.kind === "agent" && node.key !== edge.from && node.key !== edge.to));
   }

--- a/web/management/src/lib/trafficFlowModel.ts
+++ b/web/management/src/lib/trafficFlowModel.ts
@@ -1,0 +1,132 @@
+import type { MotionPlan } from "@/lib/trafficMotion";
+import type { TrafficFlowEditTarget } from "@/types/trafficFlowEdit";
+import type { TraceRequest } from "@/types/trafficTrace";
+
+export type TrafficNodeKind = "ingress" | "listener" | "waf" | "rate-limit" | "traffic-shaper" | "cache" | "route" | "target" | "redirect" | "agent" | "upstream" | "response";
+
+export type AgentNodeStatus = {
+  state: "connected" | "offline" | "disabled" | "unknown";
+  label: string;
+};
+
+export type CacheNodeTone = "hit" | "miss" | "bypass" | "stored" | "lookup" | "neutral";
+
+export type CacheNodeStatus = {
+  label: string;
+  tone: CacheNodeTone;
+};
+
+export type TrafficNodeData = {
+  label: string;
+  subLabel: string;
+  kind: TrafficNodeKind;
+  editTargets: TrafficFlowEditTarget[];
+  agentStatus?: AgentNodeStatus;
+  cacheStatus?: CacheNodeStatus;
+};
+
+export type DiagramNode = TrafficNodeData & {
+  key: string;
+  column: number;
+  x: number;
+  y: number;
+};
+
+export type DiagramNodeInput = Omit<DiagramNode, "x" | "y" | "editTargets"> & {
+  editTargets?: TrafficFlowEditTarget[];
+};
+
+export type DiagramEdgeRoute = "default" | "agent-bypass" | "intermediate-bypass";
+
+export type DiagramEdge = {
+  from: string;
+  to: string;
+  route: DiagramEdgeRoute;
+};
+
+export type TrafficFlowDiagramLayout = {
+  nodes: DiagramNode[];
+  nodeByKey: Map<string, DiagramNode>;
+  edges: DiagramEdge[];
+};
+
+export type Point = { x: number; y: number };
+
+export type CubicSegment = {
+  source: Point;
+  sourceControl: Point;
+  targetControl: Point;
+  target: Point;
+  lengthTable: Array<{ t: number; length: number }>;
+  totalLength: number;
+};
+
+export type EdgeRouteGeometry = {
+  from: string;
+  to: string;
+  route: DiagramEdgeRoute;
+  segments: CubicSegment[];
+  totalLength: number;
+  path: string;
+};
+
+export type Bounds = {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+};
+
+export type VisualTokenStatus = "in-flight" | "success" | "client-error" | "server-error" | "failed";
+export type VisualTokenCacheTone = "hit" | "miss" | "bypass" | "stored" | "";
+
+export type VisualToken = {
+  requestId: string;
+  request: TraceRequest;
+  path: string[];
+  label: string;
+  motionPlan: MotionPlan;
+  currentDistance: number;
+  targetDistance: number;
+  startedAt: number;
+  updatedAt: number;
+  durationMs: number;
+  finishedAt: number | null;
+  status: VisualTokenStatus;
+  cacheTone: VisualTokenCacheTone;
+  skipped: boolean;
+};
+
+export type CacheStorePulse = {
+  requestId: string;
+  startedAt: number;
+};
+
+export const NODE_WIDTH = 152;
+export const NODE_HEIGHT = 58;
+export const COLUMN_X = [0, 190, 380, 570, 760, 950, 1140, 1330, 1520, 1710, 1900];
+export const ROW_GAP = 92;
+export const MIN_CENTER_Y = 92;
+export const CACHE_SIDE_CENTER_Y = MIN_CENTER_Y;
+export const FLOW_ID = "traffic-flow-diagram";
+export const EDGE_CURVATURE = 0.25;
+export const BEZIER_LENGTH_SAMPLES = 32;
+export const BYPASS_LANE_GAP = 54;
+export const BYPASS_X_GAP = 24;
+export const MIN_BYPASS_Y = 28;
+
+export const MIN_PLAYBACK_MS = 1800;
+export const MAX_PLAYBACK_MS = 6000;
+export const BASE_PLAYBACK_MS = 1200;
+export const PER_HOP_MS = 450;
+export const LOW_BURST_THRESHOLD = 12;
+export const HIGH_BURST_THRESHOLD = 40;
+export const MAX_RENDERED_TOKENS_NORMAL = 36;
+export const MAX_RENDERED_TOKENS_STRESSED = 16;
+export const FRAME_STRESS_MS = 40;
+export const FRAME_RECOVERY_MS = 20;
+export const FRAME_RECOVERY_COUNT = 12;
+export const COMPLETION_HOLD_MS = 2000;
+export const COMPLETION_FADE_MS = 650;
+export const CACHE_PROXIMITY_PX = 40;
+export const CACHE_STORE_PULSE_MS = 900;

--- a/web/management/src/lib/trafficFlowModel.ts
+++ b/web/management/src/lib/trafficFlowModel.ts
@@ -44,7 +44,7 @@ export type DiagramEdge = {
   route: DiagramEdgeRoute;
 };
 
-export type TrafficFlowDiagramLayout = {
+export type TrafficFlowGraph = {
   nodes: DiagramNode[];
   nodeByKey: Map<string, DiagramNode>;
   edges: DiagramEdge[];

--- a/web/management/src/views/AgentHealth.vue
+++ b/web/management/src/views/AgentHealth.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { computed, h, inject, ref, watch } from "vue";
-import type { ComputedRef } from "vue";
 import { NButton, NButtonGroup, NCheckbox, NDataTable, NInput, NModal, NTag } from "naive-ui";
 import type { DataTableColumns } from "naive-ui";
 import { Ban as BanIcon } from "@lucide/vue";
@@ -14,6 +13,7 @@ import { useManagementClient } from "@/composables/useManagementClient";
 import DisabledHint from "@/components/DisabledHint.vue";
 import EmptyState from "@/components/EmptyState.vue";
 import AgentEditorModal from "@/components/editors/AgentEditorModal.vue";
+import { dashboardKey, isBusyKey, publicProxyConfigKey, runManagementActionKey } from "@/composables/managementContextKeys";
 import { useConfirmDialog } from "@/composables/useConfirmDialog";
 import { AGENT_ID_SYSTEM_LABEL_KEY, userAgentLabelPairs } from "@/lib/agentLabels";
 import {
@@ -38,18 +38,15 @@ import type {
   Agent,
   AgentConnectionSession,
   AgentUptimeSummary,
-  GetDashboardResponse,
-  GetPublicProxyConfigResponse,
 } from "@/gen/proto/p2pstream/v1/management_pb";
 
 const managementClient = useManagementClient();
 
-type Runner = (action: () => Promise<void>) => Promise<boolean>;
 
-const dashboard = inject<ComputedRef<GetDashboardResponse | null>>("dashboard");
-const publicProxyConfig = inject<ComputedRef<GetPublicProxyConfigResponse | null>>("publicProxyConfig");
-const runManagementAction = inject<Runner>("runManagementAction");
-const isBusy = inject<ComputedRef<boolean>>("isBusy");
+const dashboard = inject(dashboardKey, computed(() => null));
+const publicProxyConfig = inject(publicProxyConfigKey, computed(() => null));
+const runManagementAction = inject(runManagementActionKey);
+const isBusy = inject(isBusyKey, computed(() => false));
 
 const { confirm } = useConfirmDialog();
 const status = computed(() => dashboard?.value?.status ?? null);

--- a/web/management/src/views/Overview.vue
+++ b/web/management/src/views/Overview.vue
@@ -1,16 +1,14 @@
 <script setup lang="ts">
 import { computed, inject, ref } from "vue";
-import type { ComputedRef } from "vue";
 import { NButton, NButtonGroup, NDataTable } from "naive-ui";
 import type { DataTableColumns } from "naive-ui";
+import { dashboardKey, publicProxyConfigKey } from "@/composables/managementContextKeys";
 import {
   ProxyState,
   PublicRouteTargetTransport,
   PublicRouteTargetType,
   type DashboardProxyDimensionSummary,
   type DashboardTrafficBucket,
-  type GetDashboardResponse,
-  type GetPublicProxyConfigResponse,
 } from "@/gen/proto/p2pstream/v1/management_pb";
 import {
   bytesPerSecond,
@@ -35,8 +33,8 @@ import {
 
 type HotspotTab = "listeners" | "targets" | "routes" | "agents";
 
-const dashboard = inject<ComputedRef<GetDashboardResponse | null>>("dashboard");
-const publicProxyConfig = inject<ComputedRef<GetPublicProxyConfigResponse | null>>("publicProxyConfig");
+const dashboard = inject(dashboardKey, computed(() => null));
+const publicProxyConfig = inject(publicProxyConfigKey, computed(() => null));
 
 const selectedWindowLabel = ref("1h");
 const activeHotspotTab = ref<HotspotTab>("listeners");

--- a/web/management/src/views/SettingsApiTokens.vue
+++ b/web/management/src/views/SettingsApiTokens.vue
@@ -6,19 +6,25 @@ import { Trash2 as TrashIcon } from "@lucide/vue";
 import { NButton, NCheckbox, NDataTable, NDatePicker, NInput, NModal, NTag } from "naive-ui";
 import type { DataTableColumns } from "naive-ui";
 import { computed, h, inject, onMounted, reactive, ref, watch } from "vue";
-import type { ComputedRef } from "vue";
+import {
+  isBusyKey,
+  selectedEnvironmentBlockedKey,
+  selectedEnvironmentIdKey,
+  selectedEnvironmentLabelKey,
+} from "@/composables/managementContextKeys";
 import { useManagementClient } from "@/composables/useManagementClient";
 import DisabledHint from "@/components/DisabledHint.vue";
 import { useConfirmDialog } from "@/composables/useConfirmDialog";
 import { BUSY_REASON } from "@/lib/disabledReasons";
 import { modalCardStyle, naiveTagType } from "@/lib/naiveUi";
 import type { ManagementAccessToken } from "@/gen/proto/p2pstream/v1/management_pb";
+import { messageFromError } from "@/lib/errors";
 
 const managementClient = useManagementClient();
-const isBusy = inject<ComputedRef<boolean>>("isBusy", computed(() => false));
-const selectedEnvironmentId = inject<ComputedRef<string>>("selectedEnvironmentId", computed(() => "0"));
-const selectedEnvironmentLabel = inject<ComputedRef<string>>("selectedEnvironmentLabel", computed(() => "Local"));
-const selectedEnvironmentBlocked = inject<ComputedRef<string>>("selectedEnvironmentBlocked", computed(() => ""));
+const isBusy = inject(isBusyKey, computed(() => false));
+const selectedEnvironmentId = inject(selectedEnvironmentIdKey, computed(() => "0"));
+const selectedEnvironmentLabel = inject(selectedEnvironmentLabelKey, computed(() => "Local"));
+const selectedEnvironmentBlocked = inject(selectedEnvironmentBlockedKey, computed(() => ""));
 const revokeTokenDialog = useConfirmDialog();
 
 const tokens = ref<ManagementAccessToken[]>([]);
@@ -246,9 +252,6 @@ function formatDate(value: bigint | undefined): string {
   return new Date(Number(value)).toLocaleString();
 }
 
-function messageFromError(err: unknown): string {
-  return err instanceof Error ? err.message : "Request failed";
-}
 
 function tokenRowKey(token: ManagementAccessToken): string {
   return token.id.toString();

--- a/web/management/src/views/SettingsEnvironments.vue
+++ b/web/management/src/views/SettingsEnvironments.vue
@@ -7,9 +7,9 @@ import { Trash2 as TrashIcon } from "@lucide/vue";
 import { NButton, NButtonGroup, NCheckbox, NDataTable, NInput, NInputNumber, NModal, NSelect, NTag, useNotification } from "naive-ui";
 import type { DataTableColumns } from "naive-ui";
 import { computed, h, inject, onMounted, reactive, ref } from "vue";
-import type { ComputedRef } from "vue";
 import { localManagementClient } from "@/api/managementClient";
 import DisabledHint from "@/components/DisabledHint.vue";
+import { environmentsKey, isBusyKey, reloadEnvironmentsKey } from "@/composables/managementContextKeys";
 import { useConfirmDialog } from "@/composables/useConfirmDialog";
 import { BUSY_REASON } from "@/lib/disabledReasons";
 import { modalCardStyle, naiveTagType } from "@/lib/naiveUi";
@@ -23,10 +23,11 @@ import {
   EnvironmentTransport,
   EnvironmentTrustState,
 } from "@/gen/proto/p2pstream/v1/management_pb";
+import { messageFromError } from "@/lib/errors";
 
-const environments = inject<ComputedRef<Environment[]>>("environments", computed(() => []));
-const reloadEnvironments = inject<(() => Promise<void>) | undefined>("reloadEnvironments", undefined);
-const isBusy = inject<ComputedRef<boolean>>("isBusy", computed(() => false));
+const environments = inject(environmentsKey, computed(() => []));
+const reloadEnvironments = inject(reloadEnvironmentsKey, undefined);
+const isBusy = inject(isBusyKey, computed(() => false));
 const confirmDialog = useConfirmDialog();
 const notification = useNotification();
 
@@ -525,9 +526,6 @@ function formatDate(value: bigint | undefined): string {
   return new Date(Number(value)).toLocaleString();
 }
 
-function messageFromError(err: unknown): string {
-  return err instanceof Error ? err.message : "Request failed";
-}
 
 function environmentRowKey(environment: Environment): string {
   return environment.id.toString();

--- a/web/management/src/views/Traffic.vue
+++ b/web/management/src/views/Traffic.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { computed, h, inject, onBeforeUnmount, onMounted, ref, shallowRef, watch } from "vue";
-import type { ComputedRef } from "vue";
 import { NButton, NButtonGroup, NCheckbox, NDataTable } from "naive-ui";
 import type { DataTableColumns } from "naive-ui";
+import { dashboardKey, publicProxyConfigKey, selectedEnvironmentIdKey } from "@/composables/managementContextKeys";
 import { useManagementClient } from "@/composables/useManagementClient";
 import DisabledHint from "@/components/DisabledHint.vue";
 import PublicProxyEditorHost from "@/components/editors/PublicProxyEditorHost.vue";
@@ -16,18 +16,17 @@ import type { TraceRenderStats, TraceRequest, TraceRequestView } from "@/types/t
 import { emptyTraceRenderStats } from "@/types/trafficTrace";
 import type {
   DashboardWindowSummary,
-  GetDashboardResponse,
-  GetPublicProxyConfigResponse,
   TrafficTraceEvent,
   TrafficTraceSettings,
 } from "@/gen/proto/p2pstream/v1/management_pb";
 import { TrafficTraceLevel } from "@/gen/proto/p2pstream/v1/management_pb";
+import { messageFromError } from "@/lib/errors";
 
 const managementClient = useManagementClient();
 
-const dashboard = inject<ComputedRef<GetDashboardResponse | null>>("dashboard");
-const publicProxyConfig = inject<ComputedRef<GetPublicProxyConfigResponse | null>>("publicProxyConfig");
-const selectedEnvironmentId = inject<ComputedRef<string>>("selectedEnvironmentId", computed(() => "0"));
+const dashboard = inject(dashboardKey, computed(() => null));
+const publicProxyConfig = inject(publicProxyConfigKey, computed(() => null));
+const selectedEnvironmentId = inject(selectedEnvironmentIdKey, computed(() => "0"));
 
 const trafficWindows = computed(() => dashboard?.value?.windows ?? []);
 const config = computed(() => publicProxyConfig?.value ?? null);
@@ -344,9 +343,6 @@ function streamStateLabel(): string {
   return "Idle";
 }
 
-function messageFromError(err: unknown): string {
-  return err instanceof Error ? err.message : "Request failed";
-}
 
 onMounted(() => {
   window.addEventListener("pagehide", handlePageHide);


### PR DESCRIPTION
## Summary
- Extract public config behavior behind a dedicated internal service.\n- Keep App RPC handlers as thin auth/delegation wrappers.

## Verification
- Covered by final stack verification:
  - `make verify`
  - `make docker-test`
  - `make docker-smoke`
  - `cd web/management && bun run e2e`