### PR TITLE
Refine management frontend navigation and styling

### DIFF
--- a/web/management/bun.lock
+++ b/web/management/bun.lock
@@ -15,7 +15,6 @@
         "@vue-flow/core": "^1.48.2",
         "codemirror": "^6.0.2",
         "naive-ui": "^2.44.1",
-        "tailwindcss": "^4.2.4",
         "vue": "^3.5.35",
         "vue-router": "5.1.0",
       },
@@ -23,7 +22,6 @@
         "@bufbuild/protoc-gen-es": "^2.12.0",
         "@connectrpc/protoc-gen-connect-es": "^1.7.0",
         "@playwright/test": "^1",
-        "@tailwindcss/vite": "^4.2.4",
         "@vitejs/plugin-vue": "^6.0.6",
         "typescript": "^6.0.3",
         "vite": "^8.0.10",
@@ -162,36 +160,6 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.13", "", {}, "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA=="],
 
-    "@tailwindcss/node": ["@tailwindcss/node@4.2.4", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.4" } }, "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA=="],
-
-    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.4", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.4", "@tailwindcss/oxide-darwin-arm64": "4.2.4", "@tailwindcss/oxide-darwin-x64": "4.2.4", "@tailwindcss/oxide-freebsd-x64": "4.2.4", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4", "@tailwindcss/oxide-linux-arm64-musl": "4.2.4", "@tailwindcss/oxide-linux-x64-gnu": "4.2.4", "@tailwindcss/oxide-linux-x64-musl": "4.2.4", "@tailwindcss/oxide-wasm32-wasi": "4.2.4", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4", "@tailwindcss/oxide-win32-x64-msvc": "4.2.4" } }, "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q=="],
-
-    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.2.4", "", { "os": "android", "cpu": "arm64" }, "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g=="],
-
-    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg=="],
-
-    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg=="],
-
-    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.2.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw=="],
-
-    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA=="],
-
-    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw=="],
-
-    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g=="],
-
-    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA=="],
-
-    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA=="],
-
-    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.2.4", "", { "dependencies": { "@emnapi/core": "^1.8.1", "@emnapi/runtime": "^1.8.1", "@emnapi/wasi-threads": "^1.1.0", "@napi-rs/wasm-runtime": "^1.1.1", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw=="],
-
-    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.2.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ=="],
-
-    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.4", "", { "os": "win32", "cpu": "x64" }, "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw=="],
-
-    "@tailwindcss/vite": ["@tailwindcss/vite@4.2.4", "", { "dependencies": { "@tailwindcss/node": "4.2.4", "@tailwindcss/oxide": "4.2.4", "tailwindcss": "4.2.4" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw=="],
-
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@types/jsesc": ["@types/jsesc@2.5.1", "", {}, "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw=="],
@@ -300,8 +268,6 @@
 
     "emmet": ["emmet@2.4.11", "", { "dependencies": { "@emmetio/abbreviation": "^2.3.3", "@emmetio/css-abbreviation": "^2.1.8" } }, "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ=="],
 
-    "enhanced-resolve": ["enhanced-resolve@5.21.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA=="],
-
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
@@ -313,8 +279,6 @@
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
-    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
@@ -402,10 +366,6 @@
 
     "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
 
-    "tailwindcss": ["tailwindcss@4.2.4", "", {}, "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA=="],
-
-    "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
-
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "treemate": ["treemate@0.3.11", "", {}, "sha512-M8RGFoKtZ8dF+iwJfAJTOH/SM4KluKOKRJpjCMhI8bG3qB74zrFoArKZ62ll0Fr3mqkMJiQOmWYkdYgDeITYQg=="],
@@ -453,18 +413,6 @@
     "@connectrpc/protoc-gen-connect-es/@bufbuild/protobuf": ["@bufbuild/protobuf@1.10.1", "", {}, "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ=="],
 
     "@connectrpc/protoc-gen-connect-es/@bufbuild/protoplugin": ["@bufbuild/protoplugin@1.10.1", "", { "dependencies": { "@bufbuild/protobuf": "1.10.1", "@typescript/vfs": "^1.4.0", "typescript": "4.5.2" } }, "sha512-LaSbfwabAFIvbVnbn8jWwElRoffCIxhVraO8arliVwWupWezHLXgqPHEYLXZY/SsAR+/YsFBQJa8tAGtNPJyaQ=="],
-
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
-
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
-
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
-
-    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" }, "bundled": true }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
-
-    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
-
-    "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@vue-macros/common/@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.33", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/compiler-core": "3.5.33", "@vue/compiler-dom": "3.5.33", "@vue/compiler-ssr": "3.5.33", "@vue/shared": "3.5.33", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.10", "source-map-js": "^1.2.1" } }, "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA=="],
 

--- a/web/management/e2e/traffic-flow.spec.ts
+++ b/web/management/e2e/traffic-flow.spec.ts
@@ -5,7 +5,7 @@ test("renders the traffic flow diagram through the management page", async ({ pa
   const baseURL = testInfo.project.use.baseURL as string;
   await authenticate(page, baseURL);
 
-  await page.goto("/#/traffic");
+  await page.goto("/#/monitor/traffic");
   await expect(page.getByRole("heading", { name: "Traffic Flow", exact: true })).toBeVisible();
 
   const diagram = page.locator(".traffic-flow-shell");
@@ -13,4 +13,37 @@ test("renders the traffic flow diagram through the management page", async ({ pa
   await expect(diagram.locator(".traffic-flow-node-ingress")).toBeVisible();
   await expect(diagram.locator(".traffic-flow-node-response")).toBeVisible();
   expect(await diagram.locator(".traffic-flow-node").count()).toBeGreaterThanOrEqual(2);
+});
+
+test("routes monitor traffic and diagnostics subpages", async ({ page }, testInfo) => {
+  const baseURL = testInfo.project.use.baseURL as string;
+  await authenticate(page, baseURL);
+
+  await page.goto("/#/monitor");
+  await expect(page).toHaveURL(/#\/monitor\/traffic$/);
+  const monitorNav = page.getByRole("link", { name: "Monitor" });
+  await expect(monitorNav).toHaveClass(/app-nav__link--active/);
+  await expect(page.getByRole("heading", { name: "Traffic Flow", exact: true })).toBeVisible();
+  await expect(page.locator(".traffic-flow-shell")).toBeVisible();
+
+  await page.locator(".monitor-tabs").getByText("Diagnostics", { exact: true }).click();
+  await expect(page).toHaveURL(/#\/monitor\/diagnostics$/);
+  await expect(monitorNav).toHaveClass(/app-nav__link--active/);
+  await expect(page.getByRole("heading", { name: "Diagnostics", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Status Codes", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Recent Samples", exact: true })).toBeVisible();
+});
+
+test("removed legacy traffic and diagnostics URLs show not found", async ({ page }, testInfo) => {
+  const baseURL = testInfo.project.use.baseURL as string;
+  await authenticate(page, baseURL);
+  const legacyHashPath = (pageName: "traffic" | "diagnostics") => `/#/${pageName}`;
+
+  await page.goto(legacyHashPath("traffic"));
+  await expect(page.getByText("Page not found", { exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Traffic Flow", exact: true })).toBeHidden();
+
+  await page.goto(legacyHashPath("diagnostics"));
+  await expect(page.getByText("Page not found", { exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Diagnostics", exact: true })).toBeHidden();
 });

--- a/web/management/package.json
+++ b/web/management/package.json
@@ -25,7 +25,6 @@
     "@vue-flow/core": "^1.48.2",
     "codemirror": "^6.0.2",
     "naive-ui": "^2.44.1",
-    "tailwindcss": "^4.2.4",
     "vue": "^3.5.35",
     "vue-router": "5.1.0"
   },
@@ -33,7 +32,6 @@
     "@bufbuild/protoc-gen-es": "^2.12.0",
     "@connectrpc/protoc-gen-connect-es": "^1.7.0",
     "@playwright/test": "^1",
-    "@tailwindcss/vite": "^4.2.4",
     "@vitejs/plugin-vue": "^6.0.6",
     "typescript": "^6.0.3",
     "vite": "^8.0.10",

--- a/web/management/src/ManagementApp.vue
+++ b/web/management/src/ManagementApp.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { RefreshCw as RefreshIcon } from "@lucide/vue";
-import { NAlert, NButton, NCard, NForm, NFormItem, NInput, NSelect, NSkeleton, useMessage, useNotification } from "naive-ui";
+import { NAlert, NButton, NCard, NForm, NFormItem, NInput, NModal, NSelect, NSkeleton, useMessage, useNotification } from "naive-ui";
 import { computed, onMounted, provide } from "vue";
 import { useRoute } from "vue-router";
 import { managementClient } from "@/api/managementClient";
@@ -60,16 +60,21 @@ const {
   stopAutoRefresh,
 } = dashboardRefresh;
 
-const tabs = [
+type NavTab = {
+  path: string;
+  label: string;
+  activePrefix?: string;
+};
+
+const tabs: NavTab[] = [
   { path: "/overview", label: "Overview" },
-  { path: "/diagnostics", label: "Diagnostics" },
-  { path: "/traffic", label: "Traffic" },
-  { path: "/proxy", label: "Proxy" },
-  { path: "/agent", label: "Agents" },
-  { path: "/policies", label: "Traffic Policy" },
+  { path: "/monitor/traffic", label: "Monitor", activePrefix: "/monitor" },
+  { path: "/proxy/routes", label: "Proxy", activePrefix: "/proxy" },
+  { path: "/agent", label: "Agents", activePrefix: "/agent" },
+  { path: "/policies/rate-limits", label: "Traffic Policy", activePrefix: "/policies" },
   { path: "/templates", label: "Templates" },
   { path: "/tls", label: "TLS" },
-  { path: "/settings", label: "Settings" },
+  { path: "/settings", label: "Settings", activePrefix: "/settings" },
 ];
 
 const sourceOfferHref = "/.well-known/p2pstream/source";
@@ -86,7 +91,15 @@ const refreshDisabledReason = computed(() => {
   return "";
 });
 const busyDisabledReason = computed(() => isBusy.value ? BUSY_REASON : "");
-const canShowRouteContent = computed(() => Boolean(dashboard.value) || route.path.startsWith("/settings"));
+const canShowRouteContent = computed(() =>
+  Boolean(dashboard.value) || route.path.startsWith("/settings") || route.name === "not-found",
+);
+
+function isNavTabActive(tab: NavTab): boolean {
+  if (route.path === tab.path) return true;
+  if (!tab.activePrefix) return false;
+  return route.path === tab.activePrefix || route.path.startsWith(`${tab.activePrefix}/`);
+}
 
 // Provide state to views
 provide(dashboardKey, computed(() => dashboard.value));
@@ -176,31 +189,31 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="min-h-screen bg-[var(--app-bg)] text-[var(--app-text)]">
-    <header class="sticky top-0 z-50 border-b border-[var(--app-border)] bg-[var(--app-shell)]/95 backdrop-blur-xl">
-      <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div class="flex h-16 items-center justify-between">
-          <div class="flex items-center gap-4">
-            <div class="flex items-center gap-2">
-              <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-[var(--app-accent)] text-white shadow-sm">
-                <div class="h-3.5 w-3.5 rotate-45 rounded-[2px] border-2 border-white"></div>
+  <div class="app-shell">
+    <header class="app-header">
+      <div class="app-header__inner">
+        <div class="app-header__bar">
+          <div class="app-brand">
+            <div class="app-brand__group">
+              <div class="app-brand__mark">
+                <div class="app-brand__diamond"></div>
               </div>
-              <span class="text-xl font-semibold tracking-normal">p2pstream</span>
+              <span class="app-brand__name">p2pstream</span>
             </div>
-            <div class="hidden h-6 w-px bg-[var(--app-border)] sm:block"></div>
-            <div v-if="currentUser" class="hidden sm:flex items-center gap-2">
-              <span class="text-sm font-medium text-[var(--app-text-muted)]">{{ currentUser.username }}</span>
+            <div class="app-brand__divider"></div>
+            <div v-if="currentUser" class="app-user">
+              <span>{{ currentUser.username }}</span>
             </div>
           </div>
 
-          <div class="flex items-center gap-3">
-            <label v-if="currentUser" class="hidden items-center gap-2 text-xs font-semibold uppercase tracking-normal text-[var(--app-text-muted)] md:flex">
+          <div class="app-header__actions">
+            <label v-if="currentUser" class="app-env-label">
               Environment
               <NSelect
                 v-model:value="selectedEnvironmentId"
                 data-testid="environment-select"
                 size="small"
-                class="w-52"
+                class="app-env-select"
                 :options="environmentSelectOptions"
                 :title="`Selected environment: ${selectedEnvironmentLabel}`"
               />
@@ -209,7 +222,7 @@ onMounted(() => {
               :href="sourceOfferHref"
               :title="sourceOfferTitle"
               :aria-label="sourceOfferTitle"
-              class="inline-flex text-sm font-medium text-[var(--app-text-muted)] transition-colors hover:text-[var(--app-text)]"
+              class="app-source-link"
               target="_blank"
               rel="noreferrer"
             >
@@ -227,7 +240,7 @@ onMounted(() => {
                 @click="loadDashboard"
               >
                 <template #icon>
-                  <RefreshIcon class="h-3.5 w-3.5" />
+                  <RefreshIcon class="icon-sm" />
                 </template>
               </NButton>
             </DisabledHint>
@@ -245,14 +258,14 @@ onMounted(() => {
         </div>
       </div>
 
-      <div v-if="currentUser && !isLoading && !setupState?.setupRequired" class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <nav class="flex gap-2 overflow-x-auto no-scrollbar pb-2">
+      <div v-if="currentUser && !isLoading && !setupState?.setupRequired" class="app-header__nav-wrap">
+        <nav class="app-nav no-scrollbar">
           <router-link
             v-for="tab in tabs"
             :key="tab.path"
             :to="tab.path"
-            class="rounded-full px-3 py-1.5 text-sm font-medium transition-colors"
-            active-class="bg-[var(--app-accent-soft)] text-[var(--app-accent)]"
+            class="app-nav__link"
+            :class="{ 'app-nav__link--active': isNavTabActive(tab) }"
           >
             {{ tab.label }}
           </router-link>
@@ -260,26 +273,26 @@ onMounted(() => {
       </div>
     </header>
 
-    <main class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-      <NAlert v-if="error" type="error" class="mb-6" :bordered="false">
+    <main class="app-main">
+      <NAlert v-if="error" type="error" class="margin-bottom-xl" :bordered="false">
         {{ error }}
       </NAlert>
-      <NAlert v-if="selectedEnvironmentBlocked" type="warning" class="mb-6" :bordered="false">
+      <NAlert v-if="selectedEnvironmentBlocked" type="warning" class="margin-bottom-xl" :bordered="false">
         {{ selectedEnvironmentBlocked }}
       </NAlert>
 
-      <div v-if="isLoading" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-        <div v-for="i in 4" :key="i" class="app-card p-6">
-          <NSkeleton text width="40%" height="0.75rem" class="mb-3" />
+      <div v-if="isLoading" class="layout-grid space-2xl mq-sm-cols-two mq-lg-cols-four">
+        <NCard v-for="i in 4" :key="i" :bordered="true">
+          <NSkeleton text width="40%" height="0.75rem" class="margin-bottom-md" />
           <NSkeleton text width="70%" height="1.5rem" />
-        </div>
+        </NCard>
       </div>
 
-      <div v-else-if="setupState?.setupRequired && setupState.setupAvailable" class="max-w-md mx-auto py-12">
-        <NCard :bordered="false" class="shadow-sm">
-          <h2 class="mb-2 text-2xl font-semibold tracking-normal">Setup Admin</h2>
-          <p class="mb-6 text-sm text-[var(--app-text-muted)]">Create the primary administrator account.</p>
-          <form class="grid gap-4" @submit.prevent="submitSetup">
+      <div v-else-if="setupState?.setupRequired && setupState.setupAvailable" class="max-auth-width centered-block pad-y-4xl">
+        <NCard :bordered="false" class="surface-shadow">
+          <h2 class="margin-bottom-sm copy-2xl weight-semibold letter-normal">Setup Admin</h2>
+          <p class="margin-bottom-xl copy-sm muted-text">Create the primary administrator account.</p>
+          <form class="layout-grid space-lg" @submit.prevent="submitSetup">
             <NForm :model="setupForm">
               <NFormItem label="Username" path="username">
                 <NInput v-model:value="setupForm.username" autocomplete="username" />
@@ -288,30 +301,30 @@ onMounted(() => {
                 <NInput v-model:value="setupForm.password" type="password" autocomplete="new-password" minlength="12" />
               </NFormItem>
             </NForm>
-            <NButton type="primary" attr-type="submit" class="mt-4 w-full" :loading="isBusy">
+            <NButton type="primary" attr-type="submit" class="margin-top-lg fill-width" :loading="isBusy">
               Complete Setup
             </NButton>
           </form>
         </NCard>
       </div>
 
-      <div v-else-if="setupState?.setupRequired" class="max-w-xl mx-auto py-12">
-        <NCard :bordered="false" class="shadow-sm">
-          <div class="mb-3 inline-flex rounded-full border border-red-200 bg-red-50 px-2.5 py-1 text-xs font-semibold text-red-600 dark:border-red-900/50 dark:bg-red-500/10 dark:text-red-300">
+      <div v-else-if="setupState?.setupRequired" class="max-panel-width centered-block pad-y-4xl">
+        <NCard :bordered="false" class="surface-shadow">
+          <div class="status-lock-pill margin-bottom-md">
             Setup locked
           </div>
-          <h2 class="mb-2 text-2xl font-semibold tracking-normal">Restart required</h2>
-          <p class="break-words text-sm leading-6 text-[var(--app-text-muted)]">
+          <h2 class="margin-bottom-sm copy-2xl weight-semibold letter-normal">Restart required</h2>
+          <p class="wrap-anywhere copy-sm line-relaxed muted-text">
             {{ setupState.setupUnavailableReason || "Setup window expired; restart the server to retry setup." }}
           </p>
         </NCard>
       </div>
 
-      <div v-else-if="!currentUser && !isLoading" class="max-w-md mx-auto py-12">
-        <NCard :bordered="false" class="shadow-sm">
-          <h2 class="mb-2 text-2xl font-semibold tracking-normal">Login</h2>
-          <p class="mb-6 text-sm text-[var(--app-text-muted)]">Enter your credentials to access the dashboard.</p>
-          <form class="grid gap-4" @submit.prevent="submitLogin">
+      <div v-else-if="!currentUser && !isLoading" class="max-auth-width centered-block pad-y-4xl">
+        <NCard :bordered="false" class="surface-shadow">
+          <h2 class="margin-bottom-sm copy-2xl weight-semibold letter-normal">Login</h2>
+          <p class="margin-bottom-xl copy-sm muted-text">Enter your credentials to access the dashboard.</p>
+          <form class="layout-grid space-lg" @submit.prevent="submitLogin">
             <NForm :model="loginForm">
               <NFormItem label="Username" path="username">
                 <NInput v-model:value="loginForm.username" autocomplete="username" />
@@ -320,7 +333,7 @@ onMounted(() => {
                 <NInput v-model:value="loginForm.password" type="password" autocomplete="current-password" />
               </NFormItem>
             </NForm>
-            <NButton type="primary" attr-type="submit" class="mt-4 w-full" :loading="isBusy">
+            <NButton type="primary" attr-type="submit" class="margin-top-lg fill-width" :loading="isBusy">
               Continue
             </NButton>
           </form>
@@ -330,32 +343,32 @@ onMounted(() => {
       <router-view v-else-if="canShowRouteContent"></router-view>
     </main>
 
-    <div
-      v-if="isLogoutConfirmOpen && currentUser"
-      class="fixed inset-0 z-[80] flex items-center justify-center bg-black/40 px-4 backdrop-blur-sm"
-      role="presentation"
-      @click.self="cancelLogout"
+    <NModal
+      :show="isLogoutConfirmOpen && Boolean(currentUser)"
+      :mask-closable="!isBusy"
+      @update:show="(show) => { if (!show) cancelLogout(); }"
     >
-      <section
-        class="w-full max-w-md rounded-xl border border-[var(--app-border)] bg-[var(--app-panel)] p-6 shadow-2xl shadow-black/10"
+      <NCard
+        class="logout-card"
+        :bordered="false"
         role="dialog"
         aria-modal="true"
         aria-labelledby="logout-confirm-title"
         aria-describedby="logout-confirm-description"
       >
-        <div class="mb-5">
-          <div class="mb-3 inline-flex rounded-full border border-[var(--app-border)] px-2.5 py-1 text-xs font-semibold text-[var(--app-text-muted)]">
+        <div class="margin-bottom-xl">
+          <div class="margin-bottom-md inline-row round-full framed frame-standard pad-x-smd pad-y-xs copy-xs weight-semibold muted-text">
             Session
           </div>
-          <h2 id="logout-confirm-title" class="mb-2 text-xl font-semibold tracking-normal text-[var(--app-text)]">
+          <h2 id="logout-confirm-title" class="margin-bottom-sm copy-xl weight-semibold letter-normal base-text">
             Log out of p2pstream?
           </h2>
-          <p id="logout-confirm-description" class="text-sm leading-6 text-[var(--app-text-muted)]">
+          <p id="logout-confirm-description" class="copy-sm line-relaxed muted-text">
             Your current session will end and dashboard data will be cleared from this browser view.
           </p>
         </div>
 
-        <div class="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+        <div class="layout-row layout-column-reverse space-md mq-sm-row mq-sm-end">
           <DisabledHint :disabled="Boolean(busyDisabledReason)" :reason="busyDisabledReason">
             <NButton
               secondary
@@ -376,18 +389,7 @@ onMounted(() => {
             </NButton>
           </DisabledHint>
         </div>
-      </section>
-    </div>
+      </NCard>
+    </NModal>
   </div>
 </template>
-
-<style>
-nav a:not(.router-link-active) {
-  color: var(--app-text-muted);
-}
-
-nav a:not(.router-link-active):hover {
-  background: var(--app-panel-muted);
-  color: var(--app-text);
-}
-</style>

--- a/web/management/src/components/EmptyState.vue
+++ b/web/management/src/components/EmptyState.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Plus as PlusIcon } from "@lucide/vue";
-import { NButton } from "naive-ui";
+import { NButton, NEmpty } from "naive-ui";
 
 defineProps<{
   title: string;
@@ -14,18 +14,41 @@ defineEmits<{
 </script>
 
 <template>
-  <div class="flex flex-col items-center justify-center gap-3 px-5 py-10 text-center">
-    <p class="text-sm font-medium text-[var(--app-text-muted)]">{{ title }}</p>
-    <p v-if="description" class="max-w-sm text-xs text-[var(--app-text-muted)]">{{ description }}</p>
-    <NButton
-      v-if="actionLabel"
-      secondary
-      size="small"
-      class="mt-1"
-      @click="$emit('action')"
-    >
-      <template #icon><PlusIcon class="h-3.5 w-3.5" /></template>
-      {{ actionLabel }}
-    </NButton>
-  </div>
+  <NEmpty :description="title" size="small" class="empty-state">
+    <template v-if="description || actionLabel" #extra>
+      <div class="empty-state__extra">
+        <p v-if="description" class="empty-state__description">{{ description }}</p>
+        <NButton
+          v-if="actionLabel"
+          secondary
+          size="small"
+          @click="$emit('action')"
+        >
+          <template #icon><PlusIcon class="icon-sm" /></template>
+          {{ actionLabel }}
+        </NButton>
+      </div>
+    </template>
+  </NEmpty>
 </template>
+
+<style scoped>
+.empty-state {
+  padding: 2.5rem 1.25rem;
+}
+
+.empty-state__extra {
+  display: grid;
+  justify-items: center;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.empty-state__description {
+  max-width: 24rem;
+  margin: 0;
+  color: var(--app-text-muted);
+  font-size: 0.75rem;
+  text-align: center;
+}
+</style>

--- a/web/management/src/components/TrafficFlowDiagram.vue
+++ b/web/management/src/components/TrafficFlowDiagram.vue
@@ -96,6 +96,7 @@ const { fitView, viewport } = useVueFlow(FLOW_ID);
 const configIndex = computed(() => createTrafficFlowConfigIndex(props.config));
 const requestPathCache = new TrafficRequestPathCache();
 const tokenMotionPlanCache = new Map<string, MotionPlan>();
+const flowShellRef = ref<HTMLElement | null>(null);
 const visualTokens = ref<VisualToken[]>([]);
 const cacheStorePulses = ref<CacheStorePulse[]>([]);
 const rafNow = ref(typeof performance === "undefined" ? Date.now() : performance.now());
@@ -106,6 +107,8 @@ const seenCacheStorePulseRequestIds = new Set<string>();
 let rafId: number | null = null;
 let didInitialFit = false;
 let frameStressState = resetFrameStressState();
+let resizeObserver: ResizeObserver | null = null;
+let resizeFitTimer: number | null = null;
 
 const layout = computed(() => buildTrafficFlowGraph({
   config: props.config,
@@ -312,7 +315,6 @@ watch(
   () => {
     requestPathCache.clear();
     tokenMotionPlanCache.clear();
-    void nextTick(() => fitDiagram(180));
   },
   { flush: "post" },
 );
@@ -333,10 +335,25 @@ watch(
 
 onMounted(() => {
   document.addEventListener("visibilitychange", handleVisibilityChange);
+  if (typeof ResizeObserver !== "undefined" && flowShellRef.value) {
+    resizeObserver = new ResizeObserver(scheduleDiagramFit);
+    resizeObserver.observe(flowShellRef.value);
+  } else {
+    window.addEventListener("resize", scheduleDiagramFit);
+  }
 });
 
 onBeforeUnmount(() => {
   document.removeEventListener("visibilitychange", handleVisibilityChange);
+  if (resizeObserver) {
+    resizeObserver.disconnect();
+  } else {
+    window.removeEventListener("resize", scheduleDiagramFit);
+  }
+  if (resizeFitTimer !== null) {
+    window.clearTimeout(resizeFitTimer);
+    resizeFitTimer = null;
+  }
   stopAnimationLoop();
 });
 
@@ -568,6 +585,17 @@ function fitDiagram(duration = 240) {
   void fitView({ padding: 0.18, duration, maxZoom: 1.1 });
 }
 
+function scheduleDiagramFit() {
+  if (!flowNodes.value.length) return;
+  if (resizeFitTimer !== null) {
+    window.clearTimeout(resizeFitTimer);
+  }
+  resizeFitTimer = window.setTimeout(() => {
+    resizeFitTimer = null;
+    void nextTick(() => fitDiagram(160));
+  }, 80);
+}
+
 function handleNodeClick(event: NodeMouseEvent) {
   const data = event.node.data as TrafficNodeData | undefined;
   const targets = data?.editTargets ?? [];
@@ -599,7 +627,7 @@ function clamp(value: number, min: number, max: number): number {
 </script>
 
 <template>
-  <div class="traffic-flow-shell" :class="{ 'traffic-flow-stressed': isAnimationStressed }">
+  <div ref="flowShellRef" class="traffic-flow-shell" :class="{ 'traffic-flow-stressed': isAnimationStressed }">
     <div class="flow-status">
       <span>{{ visualTokens.length }} rendered</span>
       <span v-if="skippedVisualizations" class="flow-overflow">+{{ skippedVisualizations }} not rendered</span>
@@ -620,7 +648,7 @@ function clamp(value: number, min: number, max: number): number {
       :zoom-on-scroll="true"
       :zoom-on-pinch="true"
       :zoom-on-double-click="false"
-      :min-zoom="0.35"
+      :min-zoom="0.16"
       :max-zoom="1.4"
       :fit-view-on-init="true"
       :delete-key-code="null"

--- a/web/management/src/components/TrafficTraceDetailsModal.vue
+++ b/web/management/src/components/TrafficTraceDetailsModal.vue
@@ -35,15 +35,15 @@ const showHeaders = computed(() => props.level >= TrafficTraceLevel.HEADERS);
 const showDebug = computed(() => props.level >= TrafficTraceLevel.DEBUG);
 
 function statusClass(status: bigint, stage: TrafficTraceStage): string {
-  if (stage === TrafficTraceStage.FAILED) return "text-red-400";
-  if (stage === TrafficTraceStage.WAF_BLOCKED) return "text-red-400";
-  if (stage === TrafficTraceStage.WAF_CAPTCHA_CHALLENGED || stage === TrafficTraceStage.WAF_WAITING_ROOM) return "text-amber-400";
-  if (stage === TrafficTraceStage.RATE_LIMITED) return "text-amber-400";
+  if (stage === TrafficTraceStage.FAILED) return "trace-status--error";
+  if (stage === TrafficTraceStage.WAF_BLOCKED) return "trace-status--error";
+  if (stage === TrafficTraceStage.WAF_CAPTCHA_CHALLENGED || stage === TrafficTraceStage.WAF_WAITING_ROOM) return "trace-status--warning";
+  if (stage === TrafficTraceStage.RATE_LIMITED) return "trace-status--warning";
   const code = Number(status);
-  if (code >= 500) return "text-red-400";
-  if (code >= 400) return "text-amber-400";
-  if (code >= 200) return "text-green-400";
-  return "text-(--app-text-muted)";
+  if (code >= 500) return "trace-status--error";
+  if (code >= 400) return "trace-status--warning";
+  if (code >= 200) return "trace-status--success";
+  return "trace-status--muted";
 }
 
 function stageLabel(stage: TrafficTraceStage): string {
@@ -152,13 +152,13 @@ function entries(mapValue: Record<string, string> | undefined): Array<[string, s
     :bordered="false"
     size="huge"
   >
-    <div v-if="request" class="space-y-6">
-      <section class="grid gap-3 sm:grid-cols-2">
-        <div class="trace-field sm:col-span-2">
+    <div v-if="request" class="stack-lg">
+      <section class="layout-grid space-md mq-sm-cols-two">
+        <div class="trace-field mq-sm-span-two">
           <span>Request</span>
-          <strong class="break-all font-mono">{{ request.requestId }}</strong>
+          <strong class="wrap-anywhere mono-text">{{ request.requestId }}</strong>
         </div>
-        <p v-if="request.sampledEventCount > 0" class="rounded-md border border-amber-900/60 bg-amber-950/20 px-3 py-2 text-xs text-amber-300 sm:col-span-2">
+        <p v-if="request.sampledEventCount > 0" class="round-md framed warning-border warning-surface pad-x-md pad-y-sm copy-xs warning-text mq-sm-span-two">
           Some intermediate trace events were omitted while the UI was under load. {{ numberLabel(request.sampledEventCount) }} events were sampled for this request.
         </p>
         <div class="trace-field">
@@ -171,9 +171,9 @@ function entries(mapValue: Record<string, string> | undefined): Array<[string, s
             {{ request.statusCode ? request.statusCode.toString() : stageLabel(request.stage) }}
           </strong>
         </div>
-        <div class="trace-field sm:col-span-2">
+        <div class="trace-field mq-sm-span-two">
           <span>Path</span>
-          <strong class="break-all font-mono">{{ request.path || "/" }}</strong>
+          <strong class="wrap-anywhere mono-text">{{ request.path || "/" }}</strong>
         </div>
         <div class="trace-field">
           <span>Duration</span>
@@ -185,7 +185,7 @@ function entries(mapValue: Record<string, string> | undefined): Array<[string, s
         </div>
       </section>
 
-      <section class="grid gap-3 sm:grid-cols-2">
+      <section class="layout-grid space-md mq-sm-cols-two">
         <div class="trace-field">
           <span>Listener</span>
           <strong>{{ request.listenerName || (request.listenerId ? `#${request.listenerId.toString()}` : "-") }}</strong>
@@ -202,29 +202,29 @@ function entries(mapValue: Record<string, string> | undefined): Array<[string, s
           <span>Agent</span>
           <strong>{{ request.agentName || request.agentPublicId || "-" }}</strong>
         </div>
-        <div v-if="request.rateLimitRuleId" class="trace-field sm:col-span-2">
+        <div v-if="request.rateLimitRuleId" class="trace-field mq-sm-span-two">
           <span>Rate limit</span>
           <strong>
             {{ request.rateLimitRuleName || `#${request.rateLimitRuleId.toString()}` }}
-            <span class="text-(--app-text-muted)">/ {{ rateLimitAlgorithmLabel(request.rateLimitAlgorithm) }}</span>
+            <span class="muted-text">/ {{ rateLimitAlgorithmLabel(request.rateLimitAlgorithm) }}</span>
           </strong>
         </div>
-        <div v-if="request.wafRuleId" class="trace-field sm:col-span-2">
+        <div v-if="request.wafRuleId" class="trace-field mq-sm-span-two">
           <span>WAF</span>
           <strong>
             {{ request.wafRuleName || `#${request.wafRuleId.toString()}` }}
-            <span class="text-(--app-text-muted)">
+            <span class="muted-text">
               / {{ wafActionLabel(request.wafAction) }}
               / {{ wafActivationLabel(request.wafActivationMode) }}
               <template v-if="request.wafChallengeKind"> / {{ request.wafChallengeKind }}</template>
             </span>
           </strong>
         </div>
-        <div v-if="request.trafficShaperRuleId" class="trace-field sm:col-span-2">
+        <div v-if="request.trafficShaperRuleId" class="trace-field mq-sm-span-two">
           <span>Traffic shaper</span>
           <strong>
             {{ request.trafficShaperRuleName || `#${request.trafficShaperRuleId.toString()}` }}
-            <span class="text-(--app-text-muted)">
+            <span class="muted-text">
               / {{ trafficShaperScopeLabel(request.trafficShaperBudgetScope) }}
               / up {{ formatRate(request.trafficShaperUploadBytesPerSecond) }}
               / down {{ formatRate(request.trafficShaperDownloadBytesPerSecond) }}
@@ -234,14 +234,14 @@ function entries(mapValue: Record<string, string> | undefined): Array<[string, s
         </div>
       </section>
 
-      <section v-if="showDetailed" class="grid gap-3 sm:grid-cols-2">
+      <section v-if="showDetailed" class="layout-grid space-md mq-sm-cols-two">
         <div class="trace-field">
           <span>Host</span>
-          <strong class="break-all font-mono">{{ request.host || "-" }}</strong>
+          <strong class="wrap-anywhere mono-text">{{ request.host || "-" }}</strong>
         </div>
         <div class="trace-field">
           <span>Query</span>
-          <strong class="break-all font-mono">{{ request.query || "-" }}</strong>
+          <strong class="wrap-anywhere mono-text">{{ request.query || "-" }}</strong>
         </div>
         <div class="trace-field">
           <span>Target type</span>
@@ -251,17 +251,17 @@ function entries(mapValue: Record<string, string> | undefined): Array<[string, s
           <span>Transport</span>
           <strong>{{ routeTargetTransportLabel(request.routeTargetTransport) }}</strong>
         </div>
-        <div class="trace-field sm:col-span-2">
+        <div class="trace-field mq-sm-span-two">
           <span>Target origin</span>
-          <strong class="break-all font-mono">{{ request.targetOrigin || "-" }}</strong>
+          <strong class="wrap-anywhere mono-text">{{ request.targetOrigin || "-" }}</strong>
         </div>
-        <div class="trace-field sm:col-span-2">
+        <div class="trace-field mq-sm-span-two">
           <span>Error kind</span>
           <strong>{{ request.errorKind || "-" }}</strong>
         </div>
       </section>
 
-      <section v-if="showHeaders" class="grid gap-4 lg:grid-cols-2">
+      <section v-if="showHeaders" class="layout-grid space-lg mq-lg-cols-two">
         <div class="trace-panel">
           <h4>Request headers</h4>
           <dl v-if="entries(latestEvent?.requestHeaders).length">
@@ -284,7 +284,7 @@ function entries(mapValue: Record<string, string> | undefined): Array<[string, s
         </div>
       </section>
 
-      <section v-if="showDebug" class="grid gap-4 lg:grid-cols-2">
+      <section v-if="showDebug" class="layout-grid space-lg mq-lg-cols-two">
         <div class="trace-field">
           <span>Request bytes</span>
           <strong>{{ formatBytes(request.requestBytes) }}</strong>
@@ -293,7 +293,7 @@ function entries(mapValue: Record<string, string> | undefined): Array<[string, s
           <span>Response bytes</span>
           <strong>{{ formatBytes(request.responseBytes) }}</strong>
         </div>
-        <div class="trace-panel lg:col-span-2">
+        <div class="trace-panel mq-lg-span-two">
           <h4>Debug attributes</h4>
           <dl v-if="entries(latestEvent?.debugAttributes).length">
             <template v-for="[name, value] in entries(latestEvent?.debugAttributes)" :key="name">
@@ -307,11 +307,11 @@ function entries(mapValue: Record<string, string> | undefined): Array<[string, s
 
       <section class="trace-panel">
         <h4>Lifecycle</h4>
-        <div class="divide-y divide-[var(--app-border-subtle)]">
-          <div v-for="event in request.events" :key="event.sequence.toString()" class="grid gap-2 py-2 text-xs sm:grid-cols-[10rem_1fr_6rem]">
-            <span class="text-(--app-text-muted)">{{ formatDate(event.occurredAtUnixMillis) }}</span>
-            <span class="font-medium text-[var(--app-text)]">{{ stageLabel(event.stage) }}</span>
-            <span class="text-right font-mono text-(--app-text-muted)">{{ formatDuration(event.durationMs) }}</span>
+        <div class="divided-list">
+          <div v-for="event in request.events" :key="event.sequence.toString()" class="layout-grid space-sm pad-y-sm copy-xs mq-sm-trace-event">
+            <span class="muted-text">{{ formatDate(event.occurredAtUnixMillis) }}</span>
+            <span class="weight-medium base-text">{{ stageLabel(event.stage) }}</span>
+            <span class="align-right-text mono-text muted-text">{{ formatDuration(event.durationMs) }}</span>
           </div>
         </div>
       </section>

--- a/web/management/src/components/editors/AgentEditorModal.vue
+++ b/web/management/src/components/editors/AgentEditorModal.vue
@@ -147,54 +147,54 @@ defineExpose({ openCreate, openEdit, close });
     :bordered="false"
     size="huge"
   >
-    <form data-testid="agent-editor-form" @submit.prevent="submitAgent" class="grid max-h-[calc(100vh-9rem)] gap-5 overflow-y-auto pr-1">
-      <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+    <form data-testid="agent-editor-form" @submit.prevent="submitAgent" class="layout-grid max-modal-height space-xl scroll-y pad-right-xs">
+      <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
         Name
         <NInput v-model:value="agentForm.name" size="small" required />
       </label>
       <NCheckbox v-model:checked="agentForm.enabled">
         Enabled
       </NCheckbox>
-      <section data-testid="agent-user-labels" class="grid gap-3 rounded-lg border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-4">
-        <div class="flex items-center justify-between gap-3">
+      <section data-testid="agent-user-labels" class="layout-grid space-md round-lg framed frame-standard muted-bg pad-lg">
+        <div class="layout-row align-center spread-items space-md">
           <div>
-            <h4 class="text-sm font-semibold text-[var(--app-text)]">User Labels</h4>
-            <p class="mt-1 text-xs leading-5 text-[var(--app-text-muted)]">Use labels such as site=home-lab or role=app to select agents from route targets.</p>
+            <h4 class="copy-sm weight-semibold base-text">User Labels</h4>
+            <p class="margin-top-xs copy-xs line-normal muted-text">Use labels such as site=home-lab or role=app to select agents from route targets.</p>
           </div>
           <NButton secondary size="small" @click="addLabel">
-            <template #icon><PlusIcon class="h-3.5 w-3.5" /></template>
+            <template #icon><PlusIcon class="icon-sm icon-sm" /></template>
             Add Label
           </NButton>
         </div>
-        <div v-if="agentForm.labels.length" class="grid gap-2">
-          <div v-for="(label, index) in agentForm.labels" :key="label.id" data-testid="agent-label-row" class="grid gap-3 rounded-md border border-[var(--app-border-subtle)] bg-[var(--app-panel)] p-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] sm:items-end">
-            <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <div v-if="agentForm.labels.length" class="layout-grid space-sm">
+          <div v-for="(label, index) in agentForm.labels" :key="label.id" data-testid="agent-label-row" class="layout-grid space-md round-md framed frame-subtle panel-bg pad-md mq-sm-two-auto mq-sm-align-end">
+            <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
               Key
               <NInput v-model:value="label.key" data-testid="agent-label-key" size="small" placeholder="site" required />
             </label>
-            <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+            <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
               Value
               <NInput v-model:value="label.value" data-testid="agent-label-value" size="small" placeholder="home-lab" />
             </label>
-            <NButton type="error" secondary size="small" aria-label="Remove label" title="Remove label" class="self-end" @click="removeLabel(index)">
-              <template #icon><TrashIcon class="h-3.5 w-3.5" /></template>
+            <NButton type="error" secondary size="small" aria-label="Remove label" title="Remove label" class="self-align-end" @click="removeLabel(index)">
+              <template #icon><TrashIcon class="icon-sm icon-sm" /></template>
             </NButton>
           </div>
         </div>
-        <NEmpty v-else size="small" description="No user labels configured" class="rounded-md border border-dashed border-[var(--app-border)] bg-[var(--app-panel)] px-3 py-3" />
+        <NEmpty v-else size="small" description="No user labels configured" class="round-md framed dashed-border frame-standard panel-bg pad-x-md pad-y-md" />
       </section>
-      <section v-if="agentForm.systemLabels.length" data-testid="agent-system-labels" class="grid gap-3 rounded-lg border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-4">
+      <section v-if="agentForm.systemLabels.length" data-testid="agent-system-labels" class="layout-grid space-md round-lg framed frame-standard muted-bg pad-lg">
         <div>
-          <h4 class="text-sm font-semibold text-[var(--app-text)]">System Labels</h4>
-          <p class="mt-1 text-xs leading-5 text-[var(--app-text-muted)]">System labels are read-only and can be used for exact-agent target selectors.</p>
+          <h4 class="copy-sm weight-semibold base-text">System Labels</h4>
+          <p class="margin-top-xs copy-xs line-normal muted-text">System labels are read-only and can be used for exact-agent target selectors.</p>
         </div>
-        <div class="flex flex-wrap gap-2">
-          <NTag v-for="label in agentForm.systemLabels" :key="label.id" data-testid="agent-system-label" size="small" :bordered="true" class="font-mono">
+        <div class="layout-row wrap-items space-sm">
+          <NTag v-for="label in agentForm.systemLabels" :key="label.id" data-testid="agent-system-label" size="small" :bordered="true" class="mono-text">
             {{ label.key }}={{ label.value }}
           </NTag>
         </div>
       </section>
-      <div class="mt-4 flex justify-end gap-3">
+      <div class="margin-top-lg layout-row align-end-row space-md">
         <NButton secondary @click="close">Cancel</NButton>
         <DisabledHint :disabled="Boolean(agentSubmitDisabledReason)" :reason="agentSubmitDisabledReason">
           <NButton type="primary" attr-type="submit" :disabled="Boolean(agentSubmitDisabledReason)">

--- a/web/management/src/components/editors/PolicyMatchGroupEditor.vue
+++ b/web/management/src/components/editors/PolicyMatchGroupEditor.vue
@@ -125,15 +125,15 @@ function valuePlaceholder(condition: PolicyMatchConditionForm): string {
         Not
       </NCheckbox>
       <NButton secondary size="small" @click="addCondition(group)">
-        <PlusIcon class="h-3.5 w-3.5" />
+        <PlusIcon class="icon-sm icon-sm" />
         <span>Condition</span>
       </NButton>
       <NButton secondary size="small" @click="addGroup(group)">
-        <PlusIcon class="h-3.5 w-3.5" />
+        <PlusIcon class="icon-sm icon-sm" />
         <span>Group</span>
       </NButton>
       <NButton v-if="!root" type="error" size="small" aria-label="Remove group" title="Remove group" @click="emit('remove')">
-        <template #icon><TrashIcon class="h-3.5 w-3.5" /></template>
+        <template #icon><TrashIcon class="icon-sm icon-sm" /></template>
       </NButton>
     </div>
 
@@ -173,7 +173,7 @@ function valuePlaceholder(condition: PolicyMatchConditionForm): string {
           Not
         </NCheckbox>
         <NButton type="error" size="small" aria-label="Remove condition" title="Remove condition" @click="removeCondition(group, index)">
-          <template #icon><TrashIcon class="h-3.5 w-3.5" /></template>
+          <template #icon><TrashIcon class="icon-sm icon-sm" /></template>
         </NButton>
       </div>
     </div>

--- a/web/management/src/components/editors/PublicCacheRuleEditorModal.vue
+++ b/web/management/src/components/editors/PublicCacheRuleEditorModal.vue
@@ -429,32 +429,32 @@ defineExpose({ openCreate, openEdit, close });
     :bordered="false"
     size="huge"
   >
-    <form class="grid max-h-[calc(100vh-9rem)] gap-5 overflow-y-auto pr-1" @submit.prevent="submitRule">
-      <section class="grid gap-4 sm:grid-cols-4">
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)] sm:col-span-2">
+    <form class="layout-grid max-modal-height space-xl scroll-y pad-right-xs" @submit.prevent="submitRule">
+      <section class="layout-grid space-lg mq-sm-cols-four">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text mq-sm-span-two">
           Name
           <NInput v-model:value="form.name" size="small" required />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Priority
           <NInputNumber v-model:value="form.priority" size="small" required />
         </label>
-        <NCheckbox v-model:checked="form.enabled" class="self-end">
+        <NCheckbox v-model:checked="form.enabled" class="self-align-end">
           Enabled
         </NCheckbox>
       </section>
 
       <PublicPolicyMatchEditor :form="form.match" />
 
-      <section class="grid gap-4 rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-4">
-        <h4 class="text-sm font-semibold text-[var(--app-text)]">Cache behavior</h4>
-        <p class="text-xs leading-5 text-[var(--app-text-muted)]">
+      <section class="layout-grid space-lg round-md framed frame-standard muted-bg pad-lg">
+        <h4 class="copy-sm weight-semibold base-text">Cache behavior</h4>
+        <p class="copy-xs line-normal muted-text">
           Authorization requests are always bypassed. Cookie requests are cached only when this rule allows them. Responses with Set-Cookie, no-store, private, or no-cache are never cached.
         </p>
-        <NCheckbox v-model:checked="form.allowCookieRequests" class="rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-3">
-          <span class="grid gap-1">
-            <span class="font-medium text-[var(--app-text)]">Cache requests with Cookie headers</span>
-            <span class="text-xs leading-5 text-[var(--app-text-muted)]">
+        <NCheckbox v-model:checked="form.allowCookieRequests" class="round-md framed frame-standard muted-bg pad-md">
+          <span class="layout-grid space-2xs">
+            <span class="weight-medium base-text">Cache requests with Cookie headers</span>
+            <span class="copy-xs line-normal muted-text">
               Enable this only for public static asset rules. Cookie values are ignored and are never part of the cache key.
             </span>
           </span>
@@ -462,34 +462,34 @@ defineExpose({ openCreate, openEdit, close });
         <NCheckbox
           v-if="form.allowCookieRequests"
           v-model:checked="form.allowCookieRequestsAcknowledged"
-          class="rounded-md border border-[var(--app-border)] bg-[var(--app-panel)] p-3"
+          class="round-md framed frame-standard panel-bg pad-md"
         >
-          <span class="grid gap-1">
-            <span class="font-medium text-[var(--app-text)]">I understand Cookie is ignored in this cache key</span>
-            <span class="text-xs leading-5 text-[var(--app-text-muted)]">
+          <span class="layout-grid space-2xs">
+            <span class="weight-medium base-text">I understand Cookie is ignored in this cache key</span>
+            <span class="copy-xs line-normal muted-text">
               Only use this for responses that are identical for every visitor, even when the request includes cookies.
             </span>
           </span>
         </NCheckbox>
-        <div class="grid gap-4 sm:grid-cols-4">
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <div class="layout-grid space-lg mq-sm-cols-four">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             TTL mode
             <NSelect v-model:value="form.ttlMode" size="small" :options="ttlModeOptions" />
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Default TTL minutes
             <NInputNumber v-model:value="form.ttlMinutes" size="small" :min="1" />
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Scope
             <NSelect v-model:value="form.scope" size="small" :options="scopeOptions" />
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Max object MiB
             <NInputNumber v-model:value="form.maxObjectMiB" size="small" :min="1" />
           </label>
         </div>
-        <p class="text-xs leading-5 text-[var(--app-text-muted)]">
+        <p class="copy-xs line-normal muted-text">
           Responses with Set-Cookie, private/no-store/no-cache, Vary: Cookie, or Vary: Authorization are never stored, even when cookie requests are enabled above.
         </p>
       </section>
@@ -497,8 +497,8 @@ defineExpose({ openCreate, openEdit, close });
       <section class="cache-filter-section">
         <div class="cache-filter-header">
           <div>
-            <h4 class="text-sm font-semibold text-[var(--app-text)]">Keys and filters</h4>
-            <p class="mt-1 text-xs leading-5 text-[var(--app-text-muted)]">Empty route or target filters match every available target.</p>
+            <h4 class="copy-sm weight-semibold base-text">Keys and filters</h4>
+            <p class="margin-top-xs copy-xs line-normal muted-text">Empty route or target filters match every available target.</p>
           </div>
           <div class="cache-summary-chips" aria-label="Cache key summary">
             <span class="cache-summary-chip">{{ filterSelectionSummary }}</span>
@@ -512,7 +512,7 @@ defineExpose({ openCreate, openEdit, close });
         <div class="target-grid">
           <div class="target-panel">
             <div class="target-panel-head">
-              <div class="min-w-0">
+              <div class="min-width-zero">
                 <p class="panel-eyebrow">Routes</p>
                 <h5 class="panel-heading">{{ routeSelectionSummary }}</h5>
               </div>
@@ -536,7 +536,7 @@ defineExpose({ openCreate, openEdit, close });
 
           <div class="target-panel">
             <div class="target-panel-head">
-              <div class="min-w-0">
+              <div class="min-width-zero">
                 <p class="panel-eyebrow">Targets</p>
                 <h5 class="panel-heading">{{ targetSelectionSummary }}</h5>
               </div>
@@ -564,14 +564,14 @@ defineExpose({ openCreate, openEdit, close });
             <p class="panel-eyebrow">Query mode</p>
             <h5 class="panel-heading">{{ queryModeSummary }}</h5>
           </div>
-          <NRadioGroup v-model:value="form.queryMode" class="w-full" name="cache-query-mode" size="small">
+          <NRadioGroup v-model:value="form.queryMode" class="fill-width" name="cache-query-mode" size="small">
             <NRadioButton v-for="option in queryModeOptions" :key="option.value" :value="option.value" :label="option.label" />
           </NRadioGroup>
         </div>
 
         <div v-if="queryParamsEditorVisible" class="value-editor">
           <div class="value-editor-head">
-            <div class="min-w-0">
+            <div class="min-width-zero">
               <p class="panel-eyebrow">Query params</p>
               <h5 class="panel-heading">{{ normalizedQueryParams.length.toString() }} active</h5>
             </div>
@@ -590,7 +590,7 @@ defineExpose({ openCreate, openEdit, close });
         <div class="value-editor-grid">
           <div class="value-editor">
             <div class="value-editor-head">
-              <div class="min-w-0">
+              <div class="min-width-zero">
                 <p class="panel-eyebrow">Vary headers</p>
                 <h5 class="panel-heading">{{ normalizedVaryHeaders.length.toString() }} active</h5>
               </div>
@@ -608,7 +608,7 @@ defineExpose({ openCreate, openEdit, close });
 
           <div class="value-editor">
             <div class="value-editor-head">
-              <div class="min-w-0">
+              <div class="min-width-zero">
                 <p class="panel-eyebrow">Cache status codes</p>
                 <h5 class="panel-heading">{{ normalizedCacheStatusCodes.length.toString() }} active</h5>
               </div>
@@ -626,14 +626,14 @@ defineExpose({ openCreate, openEdit, close });
         </div>
 
         <NCheckbox v-model:checked="form.addCacheStatusHeader" class="cache-status-toggle">
-          <span class="min-w-0">
+          <span class="min-width-zero">
             <span class="toggle-title">Expose cache status</span>
             <span class="toggle-detail">X-p2pstream-Cache response header</span>
           </span>
         </NCheckbox>
       </section>
 
-      <div class="flex justify-end gap-3 border-t border-[var(--app-border)] pt-4">
+      <div class="layout-row align-end-row space-md divider-top frame-standard pad-top-lg">
         <NButton secondary attr-type="button" @click="close">Cancel</NButton>
         <NButton type="primary" attr-type="submit" :disabled="submitDisabled" :title="submitDisabledReason">
           {{ form.id ? 'Save Rule' : 'Create Rule' }}

--- a/web/management/src/components/editors/PublicListenerEditorModal.vue
+++ b/web/management/src/components/editors/PublicListenerEditorModal.vue
@@ -121,30 +121,30 @@ defineExpose({ openCreate, openEdit, close });
     :bordered="false"
     size="huge"
   >
-    <form @submit.prevent="submitListener" class="grid max-h-[calc(100vh-9rem)] gap-4 overflow-y-auto pr-1 sm:grid-cols-2">
-      <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+    <form @submit.prevent="submitListener" class="layout-grid max-modal-height space-lg scroll-y pad-right-xs mq-sm-cols-two">
+      <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
         Name
         <NInput v-model:value="listenerForm.name" size="small" required />
       </label>
-      <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+      <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
         Bind address
         <NInput v-model:value="listenerForm.bindAddress" size="small" placeholder="0.0.0.0" />
-        <p class="text-xs font-normal normal-case tracking-normal text-[var(--app-text-muted)]">Leave empty to bind on all interfaces.</p>
+        <p class="copy-xs weight-normal normal-text letter-normal muted-text">Leave empty to bind on all interfaces.</p>
       </label>
-      <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+      <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
         Port
         <NInputNumber v-model:value="listenerForm.port" size="small" :min="1" :max="65535" required />
-        <p class="text-xs font-normal normal-case tracking-normal text-[var(--app-text-muted)]">Ports below 1024 may require elevated privileges.</p>
+        <p class="copy-xs weight-normal normal-text letter-normal muted-text">Ports below 1024 may require elevated privileges.</p>
       </label>
-      <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+      <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
         Protocol
         <NSelect v-model:value="listenerForm.protocol" size="small" :options="protocolOptions" />
-        <p class="text-xs font-normal normal-case tracking-normal text-[var(--app-text-muted)]">Choose HTTPS to enable TLS termination.</p>
+        <p class="copy-xs weight-normal normal-text letter-normal muted-text">Choose HTTPS to enable TLS termination.</p>
       </label>
-      <NCheckbox v-model:checked="listenerForm.enabled" class="mt-2 sm:col-span-2">
+      <NCheckbox v-model:checked="listenerForm.enabled" class="margin-top-sm mq-sm-span-two">
         Enabled
       </NCheckbox>
-      <div class="sm:col-span-2 mt-4 flex justify-end gap-3">
+      <div class="mq-sm-span-two margin-top-lg layout-row align-end-row space-md">
         <NButton secondary @click="close">Cancel</NButton>
         <DisabledHint :disabled="Boolean(listenerSubmitDisabledReason)" :reason="listenerSubmitDisabledReason">
           <NButton

--- a/web/management/src/components/editors/PublicPolicyKeyPartsEditor.vue
+++ b/web/management/src/components/editors/PublicPolicyKeyPartsEditor.vue
@@ -51,17 +51,17 @@ function removeDisabledReason(): string {
 </script>
 
 <template>
-  <section class="grid gap-4 rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-4">
-    <div class="flex items-center justify-between gap-3">
-      <h4 class="text-sm font-semibold text-[var(--app-text)]">Key parts</h4>
+  <section class="layout-grid space-lg round-md framed frame-standard muted-bg pad-lg">
+    <div class="layout-row align-center spread-items space-md">
+      <h4 class="copy-sm weight-semibold base-text">Key parts</h4>
       <DisabledHint :disabled="Boolean(disabledReason)" :reason="disabledReason || ''">
         <NButton secondary size="small" :disabled="Boolean(disabledReason)" @click="addKeyPart">
           Add Key
         </NButton>
       </DisabledHint>
     </div>
-    <div class="grid gap-2">
-      <div v-for="(part, index) in keyParts" :key="index" class="grid gap-2 sm:grid-cols-[1fr_1fr_auto]">
+    <div class="layout-grid space-sm">
+      <div v-for="(part, index) in keyParts" :key="index" class="layout-grid space-sm mq-sm-two-auto">
         <NSelect v-model:value="part.source" size="small" :options="keySourceOptions" :disabled="Boolean(disabledReason)" />
         <DisabledHint full-width :disabled="Boolean(disabledReason || keyPartNameDisabledReason(part.source))" :reason="disabledReason || keyPartNameDisabledReason(part.source)">
           <NInput
@@ -81,7 +81,7 @@ function removeDisabledReason(): string {
             :disabled="Boolean(removeDisabledReason())"
             @click="removeKeyPart(index)"
           >
-            <template #icon><TrashIcon class="h-3.5 w-3.5" /></template>
+            <template #icon><TrashIcon class="icon-sm icon-sm" /></template>
           </NButton>
         </DisabledHint>
       </div>

--- a/web/management/src/components/editors/PublicRateLimitPreview.vue
+++ b/web/management/src/components/editors/PublicRateLimitPreview.vue
@@ -454,22 +454,22 @@ function clamp(value: number, min: number, max: number): number {
     aria-label="Rate limit behavior preview"
   >
     <div class="rate-preview-header">
-      <div class="min-w-0">
+      <div class="min-width-zero">
         <p class="rate-preview-title">{{ algorithmLabel }}</p>
         <p class="rate-preview-subtitle">{{ meterLabel }} / {{ rateLabel }}</p>
       </div>
       <div class="rate-preview-stats">
         <div>
           <span>Allowed</span>
-          <strong class="text-green-400">{{ allowedLabel }}</strong>
+          <strong class="success-text">{{ allowedLabel }}</strong>
         </div>
         <div>
           <span>Rejected</span>
-          <strong class="text-red-400">{{ rejectedLabel }}</strong>
+          <strong class="error-text">{{ rejectedLabel }}</strong>
         </div>
         <div>
           <span>Remaining</span>
-          <strong class="text-[var(--app-text)]">{{ remainingLabel }}</strong>
+          <strong class="base-text">{{ remainingLabel }}</strong>
         </div>
       </div>
     </div>

--- a/web/management/src/components/editors/PublicRateLimitRuleEditorModal.vue
+++ b/web/management/src/components/editors/PublicRateLimitRuleEditorModal.vue
@@ -228,23 +228,23 @@ defineExpose({ openCreate, openEdit, close });
     :bordered="false"
     size="huge"
   >
-    <form class="grid max-h-[calc(100vh-9rem)] gap-5 overflow-y-auto pr-1" @submit.prevent="submitRule">
-      <section class="grid gap-4 sm:grid-cols-4">
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)] sm:col-span-2">
+    <form class="layout-grid max-modal-height space-xl scroll-y pad-right-xs" @submit.prevent="submitRule">
+      <section class="layout-grid space-lg mq-sm-cols-four">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text mq-sm-span-two">
           Name
           <NInput v-model:value="form.name" size="small" required />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Priority
           <NInputNumber v-model:value="form.priority" size="small" required />
         </label>
-        <NCheckbox v-model:checked="form.enabled" class="self-end">
+        <NCheckbox v-model:checked="form.enabled" class="self-align-end">
           Enabled
         </NCheckbox>
       </section>
 
-      <section class="grid gap-4">
-        <NButtonGroup class="grid grid-cols-2 sm:grid-cols-4" size="small">
+      <section class="layout-grid space-lg">
+        <NButtonGroup class="layout-grid cols-two mq-sm-cols-four" size="small">
           <NButton
             v-for="option in algorithmOptions"
             :key="option.value"
@@ -254,18 +254,18 @@ defineExpose({ openCreate, openEdit, close });
             {{ option.label }}
           </NButton>
         </NButtonGroup>
-        <div class="grid gap-4 sm:grid-cols-3">
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <div class="layout-grid space-lg mq-sm-cols-three">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Limit
             <NInputNumber v-model:value="form.limit" size="small" :min="1" required />
-            <p class="text-xs font-normal normal-case tracking-normal text-[var(--app-text-muted)]">Max requests allowed per window.</p>
+            <p class="copy-xs weight-normal normal-text letter-normal muted-text">Max requests allowed per window.</p>
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Window seconds
             <NInputNumber v-model:value="form.windowSeconds" size="small" :min="1" :step="1" required />
-            <p class="text-xs font-normal normal-case tracking-normal text-[var(--app-text-muted)]">Duration of each rate limit window.</p>
+            <p class="copy-xs weight-normal normal-text letter-normal muted-text">Duration of each rate limit window.</p>
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Burst
             <DisabledHint full-width :disabled="Boolean(burstDisabledReason)" :reason="burstDisabledReason">
               <NInputNumber
@@ -291,22 +291,22 @@ defineExpose({ openCreate, openEdit, close });
 
       <PublicPolicyKeyPartsEditor :key-parts="form.keyParts" />
 
-      <section class="grid gap-4 rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-4">
-        <h4 class="text-sm font-semibold text-[var(--app-text)]">Denied response</h4>
-        <div class="grid gap-4 sm:grid-cols-3">
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+      <section class="layout-grid space-lg round-md framed frame-standard muted-bg pad-lg">
+        <h4 class="copy-sm weight-semibold base-text">Denied response</h4>
+        <div class="layout-grid space-lg mq-sm-cols-three">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Status
             <NInputNumber v-model:value="form.responseStatusCode" size="small" :min="400" :max="599" />
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)] sm:col-span-2">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text mq-sm-span-two">
             Content type
             <NInput v-model:value="form.responseContentType" size="small" />
           </label>
         </div>
-        <div class="grid gap-3 rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-3">
-          <div class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <div class="layout-grid space-md round-md framed frame-standard muted-bg pad-md">
+          <div class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Body source
-            <NButtonGroup class="grid grid-cols-2" size="small">
+            <NButtonGroup class="layout-grid cols-two" size="small">
               <NButton
                 :type="form.responseBodyMode === PublicResponseBodyMode.INLINE ? 'primary' : 'default'"
                 @click="form.responseBodyMode = PublicResponseBodyMode.INLINE"
@@ -321,7 +321,7 @@ defineExpose({ openCreate, openEdit, close });
               </NButton>
             </NButtonGroup>
           </div>
-          <label v-if="form.responseBodyMode === PublicResponseBodyMode.TEMPLATE" class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label v-if="form.responseBodyMode === PublicResponseBodyMode.TEMPLATE" class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Template
             <NSelect
               v-model:value="form.responseBodyTemplateId"
@@ -331,17 +331,17 @@ defineExpose({ openCreate, openEdit, close });
               :disabled="!genericTemplates.length"
             />
           </label>
-          <label v-else class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label v-else class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Body
-            <NInput v-model:value="form.responseBody" type="textarea" class="font-mono" :autosize="{ minRows: 4, maxRows: 8 }" />
+            <NInput v-model:value="form.responseBody" type="textarea" class="mono-text" :autosize="{ minRows: 4, maxRows: 8 }" />
           </label>
         </div>
-        <div class="grid gap-2">
-          <div class="flex items-center justify-between gap-3">
-            <span class="text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">Headers</span>
+        <div class="layout-grid space-sm">
+          <div class="layout-row align-center spread-items space-md">
+            <span class="copy-xs weight-medium label-case letter-wide muted-text">Headers</span>
             <NButton secondary size="small" @click="addResponseHeader">Add Header</NButton>
           </div>
-          <div v-for="(header, index) in form.responseHeaders" :key="index" class="grid gap-2 sm:grid-cols-[1fr_1fr_auto]">
+          <div v-for="(header, index) in form.responseHeaders" :key="index" class="layout-grid space-sm mq-sm-two-auto">
             <NInput v-model:value="header.name" size="small" placeholder="Name" />
             <NInput v-model:value="header.value" size="small" placeholder="Value" />
             <NButton
@@ -352,13 +352,13 @@ defineExpose({ openCreate, openEdit, close });
               title="Remove response header"
               @click="removeResponseHeader(index)"
             >
-              <template #icon><TrashIcon class="h-3.5 w-3.5" /></template>
+              <template #icon><TrashIcon class="icon-sm icon-sm" /></template>
             </NButton>
           </div>
         </div>
       </section>
 
-      <div class="flex justify-end gap-3">
+      <div class="layout-row align-end-row space-md">
         <NButton secondary @click="close">Cancel</NButton>
         <DisabledHint :disabled="submitDisabled" :reason="rateLimitSubmitDisabledReason">
           <NButton type="primary" attr-type="submit" :disabled="submitDisabled">

--- a/web/management/src/components/editors/PublicResponseTemplateEditorModal.vue
+++ b/web/management/src/components/editors/PublicResponseTemplateEditorModal.vue
@@ -181,21 +181,21 @@ defineExpose({ openCreate, openEdit, close });
     :bordered="false"
     size="huge"
   >
-    <form class="grid max-h-[calc(100vh-9rem)] gap-5 overflow-y-auto pr-1" @submit.prevent="submit">
-      <section class="grid gap-4 md:grid-cols-[1fr_14rem]">
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+    <form class="layout-grid max-modal-height space-xl scroll-y pad-right-xs" @submit.prevent="submit">
+      <section class="layout-grid space-lg response-template-form-grid">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Name
           <NInput v-model:value="form.name" size="small" required />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Kind
           <NSelect :value="form.kind" size="small" :options="kindOptions" @update:value="applyKind(Number($event) as PublicResponseTemplateKind)" />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Description
           <NInput v-model:value="form.description" size="small" />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Content type
           <NInput v-model:value="form.contentType" size="small" />
         </label>
@@ -203,7 +203,7 @@ defineExpose({ openCreate, openEdit, close });
 
       <HtmlTemplateEditor v-model="form.body" :kind="form.kind" :content-type="form.contentType" />
 
-      <div class="flex justify-end gap-3">
+      <div class="layout-row align-end-row space-md">
         <NButton secondary @click="close">Cancel</NButton>
         <DisabledHint :disabled="Boolean(disabledReason)" :reason="disabledReason">
           <NButton type="primary" attr-type="submit" :disabled="Boolean(disabledReason)">

--- a/web/management/src/components/editors/PublicRouteEditorModal.vue
+++ b/web/management/src/components/editors/PublicRouteEditorModal.vue
@@ -453,37 +453,37 @@ defineExpose({ openCreate, openEdit, openClone, close });
     :bordered="false"
     size="huge"
   >
-    <form class="grid max-h-[calc(100vh-9rem)] gap-5 overflow-y-auto pr-1" @submit.prevent="submitRoute">
-      <section class="grid gap-4 sm:grid-cols-4">
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+    <form class="layout-grid max-modal-height space-xl scroll-y pad-right-xs" @submit.prevent="submitRoute">
+      <section class="layout-grid space-lg mq-sm-cols-four">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Listener
           <NSelect v-model:value="routeForm.listenerId" size="small" :options="listenerOptions" required />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Action
           <NSelect v-model:value="routeForm.action" size="small" :options="routeActionOptions" />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Priority
           <NInputNumber v-model:value="routeForm.priority" size="small" required />
         </label>
-        <NCheckbox v-model:checked="routeForm.enabled" class="self-end">
+        <NCheckbox v-model:checked="routeForm.enabled" class="self-align-end">
           Enabled
         </NCheckbox>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Host pattern
           <NInput v-model:value="routeForm.hostPattern" size="small" placeholder="*.example.com" />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Path prefix
           <NInput v-model:value="routeForm.pathPrefix" size="small" placeholder="/" />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Path security
           <NSelect v-model:value="routeForm.pathSecurityMode" size="small" :options="pathSecurityModeOptions" />
-          <span class="normal-case tracking-normal">Compatibility mode is for upstreams that require encoded / or \ path identifiers.</span>
+          <span class="normal-text letter-normal">Compatibility mode is for upstreams that require encoded / or \ path identifiers.</span>
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Target balancing
           <NSelect
             v-model:value="routeForm.targetLoadBalancing"
@@ -492,21 +492,21 @@ defineExpose({ openCreate, openEdit, openClone, close });
             :disabled="routeIsRedirect"
           />
         </label>
-        <NCheckbox v-model:checked="routeForm.isDefault" class="self-end">
+        <NCheckbox v-model:checked="routeForm.isDefault" class="self-align-end">
           Default route
         </NCheckbox>
       </section>
 
-      <section v-if="routeIsRedirect" class="grid gap-4 rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-4 sm:grid-cols-4">
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+      <section v-if="routeIsRedirect" class="layout-grid space-lg round-md framed frame-standard muted-bg pad-lg mq-sm-cols-four">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Mode
           <NSelect v-model:value="routeForm.redirectTargetMode" size="small" :options="redirectTargetModeOptions" />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)] sm:col-span-2">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text mq-sm-span-two">
           Target
           <NInput v-model:value="routeForm.redirectTarget" size="small" :placeholder="redirectTargetPlaceholder(routeForm.redirectTargetMode)" required />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Status
           <NInputNumber v-model:value="routeForm.redirectStatusCode" size="small" :min="300" :max="399" />
         </label>
@@ -518,39 +518,39 @@ defineExpose({ openCreate, openEdit, openClone, close });
         </NCheckbox>
       </section>
 
-      <section v-else class="grid gap-4">
-        <div class="flex items-center justify-between gap-3">
-          <h4 class="text-sm font-semibold text-[var(--app-text)]">Targets</h4>
+      <section v-else class="layout-grid space-lg">
+        <div class="layout-row align-center spread-items space-md">
+          <h4 class="copy-sm weight-semibold base-text">Targets</h4>
           <NButton secondary size="small" attr-type="button" @click="addTarget">
-            <template #icon><PlusIcon class="h-3.5 w-3.5" /></template>
+            <template #icon><PlusIcon class="icon-sm icon-sm" /></template>
             Add Target
           </NButton>
         </div>
 
-        <div v-for="(target, index) in routeForm.targets" :key="`${target.id || 'new'}-${index}`" data-testid="route-target-row" class="grid gap-4 rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-4">
-          <div class="flex items-start justify-between gap-3">
-            <div class="grid flex-1 gap-4 sm:grid-cols-4">
-              <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <div v-for="(target, index) in routeForm.targets" :key="`${target.id || 'new'}-${index}`" data-testid="route-target-row" class="layout-grid space-lg round-md framed frame-standard muted-bg pad-lg">
+          <div class="layout-row align-start spread-items space-md">
+            <div class="layout-grid grow-fill space-lg mq-sm-cols-four">
+              <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
                 Name
                 <NInput v-model:value="target.name" size="small" required />
               </label>
-              <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+              <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
                 Type
                 <NSelect v-model:value="target.targetType" size="small" :options="targetTypeOptions" />
               </label>
-              <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+              <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
                 Priority group
                 <NInputNumber v-model:value="target.priorityGroup" size="small" :min="0" />
               </label>
-              <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+              <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
                 Weight
                 <NInputNumber v-model:value="target.weight" size="small" :min="1" />
               </label>
-              <label v-if="target.targetType === PublicRouteTargetType.PROXY" class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)] sm:col-span-2">
+              <label v-if="target.targetType === PublicRouteTargetType.PROXY" class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text mq-sm-span-two">
                 URL
                 <NInput v-model:value="target.url" size="small" placeholder="http://upstream:9000" required />
               </label>
-              <label v-if="target.targetType === PublicRouteTargetType.PROXY" class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+              <label v-if="target.targetType === PublicRouteTargetType.PROXY" class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
                 Transport
                 <NSelect
                   v-model:value="target.transport"
@@ -559,18 +559,18 @@ defineExpose({ openCreate, openEdit, openClone, close });
                   aria-label="Transport"
                 />
               </label>
-              <label v-if="target.targetType === PublicRouteTargetType.PROXY" class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+              <label v-if="target.targetType === PublicRouteTargetType.PROXY" class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
                 Header timeout ms
                 <NInputNumber v-model:value="target.responseHeaderTimeoutMillis" size="small" :min="1" />
               </label>
-              <div v-if="target.targetType === PublicRouteTargetType.PROXY && target.transport === PublicRouteTargetTransport.AGENT" class="grid gap-3 rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-3 sm:col-span-4">
-                <div class="flex flex-wrap items-start justify-between gap-3">
+              <div v-if="target.targetType === PublicRouteTargetType.PROXY && target.transport === PublicRouteTargetTransport.AGENT" class="layout-grid space-md round-md framed frame-standard muted-bg pad-md mq-sm-span-four">
+                <div class="layout-row wrap-items align-start spread-items space-md">
                   <div>
-                    <p class="text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">Agent selector</p>
-                    <p class="mt-1 text-xs leading-5 text-[var(--app-text-muted)]">All selector labels must match the same enabled agent.</p>
+                    <p class="copy-xs weight-medium label-case letter-wide muted-text">Agent selector</p>
+                    <p class="margin-top-xs copy-xs line-normal muted-text">All selector labels must match the same enabled agent.</p>
                   </div>
-                  <div class="grid gap-1.5">
-                    <span class="text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">Match exact agent</span>
+                  <div class="layout-grid space-xs">
+                    <span class="copy-xs weight-medium label-case letter-wide muted-text">Match exact agent</span>
                     <NSelect
                       :value="exactSelectorValue(target)"
                       :options="exactAgentOptions"
@@ -582,9 +582,9 @@ defineExpose({ openCreate, openEdit, openClone, close });
                     />
                   </div>
                 </div>
-                <div class="grid gap-2">
-                  <div v-for="(selector, selectorIndex) in target.selectorLabels" :key="selector.id" data-testid="target-selector-row" class="grid gap-2 sm:grid-cols-[1fr_1fr_auto]">
-                    <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+                <div class="layout-grid space-sm">
+                  <div v-for="(selector, selectorIndex) in target.selectorLabels" :key="selector.id" data-testid="target-selector-row" class="layout-grid space-sm mq-sm-two-auto">
+                    <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
                       Selector key
                       <NInput
                         v-model:value="selector.key"
@@ -594,7 +594,7 @@ defineExpose({ openCreate, openEdit, openClone, close });
                         :input-props="targetSelectorKeyInputProps"
                       />
                     </label>
-                    <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+                    <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
                       Selector value
                       <NInput
                         v-model:value="selector.value"
@@ -608,39 +608,39 @@ defineExpose({ openCreate, openEdit, openClone, close });
                       size="small"
                       aria-label="Remove selector label"
                       title="Remove selector label"
-                      class="self-end"
+                      class="self-align-end"
                       attr-type="button"
                       @click="removeSelectorLabel(target, selectorIndex)"
                     >
-                      <template #icon><TrashIcon class="h-3.5 w-3.5" /></template>
+                      <template #icon><TrashIcon class="icon-sm icon-sm" /></template>
                     </NButton>
                   </div>
                 </div>
-                <div class="flex flex-wrap items-center justify-between gap-3">
+                <div class="layout-row wrap-items align-center spread-items space-md">
                   <NButton secondary size="small" attr-type="button" @click="addSelectorLabel(target)">
-                    <template #icon><PlusIcon class="h-3.5 w-3.5" /></template>
+                    <template #icon><PlusIcon class="icon-sm icon-sm" /></template>
                     Add Selector
                   </NButton>
-                  <div data-testid="selector-match-preview" class="text-right text-xs leading-5">
-                    <p :class="matchingAgents(target).length ? 'text-[var(--app-text)]' : 'text-[var(--app-warning)]'">
+                  <div data-testid="selector-match-preview" class="align-right-text copy-xs line-normal">
+                    <p :class="matchingAgents(target).length ? 'base-text' : 'warning-text'">
                       Matches {{ matchingAgents(target).length }} enabled agents; {{ connectedMatchingAgents(target).length }} connected.
                     </p>
-                    <p v-if="matchingAgents(target).length" class="text-[var(--app-text-muted)]">
+                    <p v-if="matchingAgents(target).length" class="muted-text">
                       {{ matchingAgents(target).slice(0, 3).map((agent) => agentDisplayName(agent.id)).join(", ") }}
                       <span v-if="matchingAgents(target).length > 3">+{{ matchingAgents(target).length - 3 }} more</span>
                     </p>
-                    <p v-else class="text-[var(--app-warning)] opacity-80">No enabled agents currently match this selector.</p>
+                    <p v-else class="warning-text deemphasized">No enabled agents currently match this selector.</p>
                   </div>
                 </div>
               </div>
               <NCheckbox v-if="target.targetType === PublicRouteTargetType.PROXY" v-model:checked="target.tlsSkipVerify">
                 Skip TLS verify
               </NCheckbox>
-              <label v-if="target.targetType === PublicRouteTargetType.STATIC" class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+              <label v-if="target.targetType === PublicRouteTargetType.STATIC" class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
                 Status
                 <NInputNumber v-model:value="target.staticStatusCode" size="small" :min="100" :max="599" />
               </label>
-              <label v-if="target.targetType === PublicRouteTargetType.STATIC" class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)] sm:col-span-3">
+              <label v-if="target.targetType === PublicRouteTargetType.STATIC" class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text mq-sm-span-three">
                 Body
                 <NInput v-model:value="target.staticResponseBody" type="textarea" size="small" :autosize="{ minRows: 3, maxRows: 8 }" />
               </label>
@@ -649,13 +649,13 @@ defineExpose({ openCreate, openEdit, openClone, close });
               </NCheckbox>
             </div>
             <NButton type="error" size="small" aria-label="Remove target" title="Remove target" attr-type="button" @click="removeTarget(index)">
-              <template #icon><TrashIcon class="h-3.5 w-3.5" /></template>
+              <template #icon><TrashIcon class="icon-sm icon-sm" /></template>
             </NButton>
           </div>
         </div>
       </section>
 
-      <div class="mt-2 flex justify-end gap-3">
+      <div class="margin-top-sm layout-row align-end-row space-md">
         <NButton secondary attr-type="button" @click="close">Cancel</NButton>
         <DisabledHint :disabled="routeSubmitDisabled" :reason="routeSubmitDisabledReason">
           <NButton type="primary" attr-type="submit" :disabled="routeSubmitDisabled">

--- a/web/management/src/components/editors/PublicTrafficShaperRuleEditorModal.vue
+++ b/web/management/src/components/editors/PublicTrafficShaperRuleEditorModal.vue
@@ -191,23 +191,23 @@ defineExpose({ openCreate, openEdit, close });
     :bordered="false"
     size="huge"
   >
-    <form class="grid max-h-[calc(100vh-9rem)] gap-5 overflow-y-auto pr-1" @submit.prevent="submitRule">
-      <section class="grid gap-4 sm:grid-cols-4">
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)] sm:col-span-2">
+    <form class="layout-grid max-modal-height space-xl scroll-y pad-right-xs" @submit.prevent="submitRule">
+      <section class="layout-grid space-lg mq-sm-cols-four">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text mq-sm-span-two">
           Name
           <NInput v-model:value="form.name" size="small" required />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Priority
           <NInputNumber v-model:value="form.priority" size="small" required />
         </label>
-        <NCheckbox v-model:checked="form.enabled" class="self-end">
+        <NCheckbox v-model:checked="form.enabled" class="self-align-end">
           Enabled
         </NCheckbox>
       </section>
 
-      <section class="grid gap-4">
-        <NButtonGroup class="grid grid-cols-2" size="small">
+      <section class="layout-grid space-lg">
+        <NButtonGroup class="layout-grid cols-two" size="small">
           <NButton
             :type="form.budgetScope === PublicTrafficShaperBudgetScope.PER_KEY ? 'primary' : 'default'"
             @click="form.budgetScope = PublicTrafficShaperBudgetScope.PER_KEY"
@@ -222,32 +222,32 @@ defineExpose({ openCreate, openEdit, close });
           </NButton>
         </NButtonGroup>
 
-        <div class="grid gap-4 sm:grid-cols-5">
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <div class="layout-grid space-lg mq-sm-cols-five">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Upload KiB/s
             <NInputNumber v-model:value="form.uploadKibPerSecond" size="small" :min="0" :step="1" />
-            <p class="text-xs font-normal normal-case tracking-normal text-[var(--app-text-muted)]">Client-to-server bandwidth cap.</p>
+            <p class="copy-xs weight-normal normal-text letter-normal muted-text">Client-to-server bandwidth cap.</p>
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Download KiB/s
             <NInputNumber v-model:value="form.downloadKibPerSecond" size="small" :min="0" :step="1" />
-            <p class="text-xs font-normal normal-case tracking-normal text-[var(--app-text-muted)]">Server-to-client bandwidth cap.</p>
+            <p class="copy-xs weight-normal normal-text letter-normal muted-text">Server-to-client bandwidth cap.</p>
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Burst KiB
             <NInputNumber v-model:value="form.burstKib" size="small" :min="0" :step="1" />
-            <p class="text-xs font-normal normal-case tracking-normal text-[var(--app-text-muted)]">Extra data allowed in a burst before throttling.</p>
+            <p class="copy-xs weight-normal normal-text letter-normal muted-text">Extra data allowed in a burst before throttling.</p>
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Request free KiB
             <NInputNumber v-model:value="form.requestFreeKib" size="small" :min="0" :step="1" />
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Response free KiB
             <NInputNumber v-model:value="form.responseFreeKib" size="small" :min="0" :step="1" />
           </label>
         </div>
-        <p class="rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] px-3 py-2 text-xs text-[var(--app-text-muted)]">
+        <p class="round-md framed frame-standard muted-bg pad-x-md pad-y-sm copy-xs muted-text">
           A value of 0 leaves that direction unlimited. Free KiB are sent without delay and do not consume the shaper budget.
         </p>
       </section>
@@ -256,7 +256,7 @@ defineExpose({ openCreate, openEdit, close });
 
       <PublicPolicyKeyPartsEditor :key-parts="form.keyParts" :disabled-reason="keyPartsDisabledReason" />
 
-      <div class="mt-2 flex justify-end gap-3">
+      <div class="margin-top-sm layout-row align-end-row space-md">
         <NButton secondary @click="close">Cancel</NButton>
         <DisabledHint :disabled="submitDisabled" :reason="shaperSubmitDisabledReason">
           <NButton type="primary" attr-type="submit" :disabled="submitDisabled">

--- a/web/management/src/components/editors/PublicWafCaptchaProviderEditorModal.vue
+++ b/web/management/src/components/editors/PublicWafCaptchaProviderEditorModal.vue
@@ -135,24 +135,24 @@ defineExpose({ openCreate, openEdit, close });
     :bordered="false"
     size="huge"
   >
-    <form class="grid max-h-[calc(100vh-9rem)] gap-5 overflow-y-auto pr-1" @submit.prevent="submitProvider">
-      <section class="grid gap-4 sm:grid-cols-2">
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+    <form class="layout-grid max-modal-height space-xl scroll-y pad-right-xs" @submit.prevent="submitProvider">
+      <section class="layout-grid space-lg mq-sm-cols-two">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Name
           <NInput v-model:value="form.name" size="small" required />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Provider
           <NSelect v-model:value="form.providerType" size="small" :options="providerOptions" />
         </label>
       </section>
 
-      <section class="grid gap-4">
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+      <section class="layout-grid space-lg">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Site key
           <NInput v-model:value="form.siteKey" size="small" autocomplete="off" required />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Secret key
           <NInput
             v-model:value="form.secretKey"
@@ -167,7 +167,7 @@ defineExpose({ openCreate, openEdit, close });
         </NCheckbox>
       </section>
 
-      <div class="flex justify-end gap-3">
+      <div class="layout-row align-end-row space-md">
         <NButton secondary @click="close">Cancel</NButton>
         <DisabledHint :disabled="Boolean(submitDisabledReason)" :reason="submitDisabledReason">
           <NButton type="primary" attr-type="submit" :disabled="submitDisabled">

--- a/web/management/src/components/editors/PublicWafRuleEditorModal.vue
+++ b/web/management/src/components/editors/PublicWafRuleEditorModal.vue
@@ -490,23 +490,23 @@ defineExpose({ openCreate, openEdit, close });
     :bordered="false"
     size="huge"
   >
-    <form class="grid max-h-[calc(100vh-9rem)] gap-5 overflow-y-auto pr-1" @submit.prevent="submitRule">
-      <section class="grid gap-4 sm:grid-cols-4">
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)] sm:col-span-2">
+    <form class="layout-grid max-modal-height space-xl scroll-y pad-right-xs" @submit.prevent="submitRule">
+      <section class="layout-grid space-lg mq-sm-cols-four">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text mq-sm-span-two">
           Name
           <NInput v-model:value="form.name" size="small" required />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Priority
           <NInputNumber v-model:value="form.priority" size="small" required />
         </label>
-        <NCheckbox v-model:checked="form.enabled" class="self-end">
+        <NCheckbox v-model:checked="form.enabled" class="self-align-end">
           Enabled
         </NCheckbox>
       </section>
 
-      <section class="grid gap-4">
-        <NButtonGroup class="grid grid-cols-1 sm:grid-cols-3" size="small">
+      <section class="layout-grid space-lg">
+        <NButtonGroup class="layout-grid cols-one mq-sm-cols-three" size="small">
           <NButton
             v-for="option in actionOptions"
             :key="option.value"
@@ -517,8 +517,8 @@ defineExpose({ openCreate, openEdit, close });
             {{ option.label }}
           </NButton>
         </NButtonGroup>
-        <p class="text-xs leading-5 text-[var(--app-text-muted)]">{{ selectedActionDescription }}</p>
-        <NButtonGroup class="grid grid-cols-2" size="small">
+        <p class="copy-xs line-normal muted-text">{{ selectedActionDescription }}</p>
+        <NButtonGroup class="layout-grid cols-two" size="small">
           <NButton
             v-for="option in activationOptions"
             :key="option.value"
@@ -529,10 +529,10 @@ defineExpose({ openCreate, openEdit, close });
             {{ option.label }}
           </NButton>
         </NButtonGroup>
-        <div class="grid gap-1 border-l border-[var(--app-border)] pl-3">
-          <p class="text-xs font-semibold text-[var(--app-text)]">{{ selectedActivationTitle }}</p>
-          <p class="text-xs leading-5 text-[var(--app-text-muted)]">{{ selectedActivationDescription }}</p>
-          <p class="text-xs leading-5 text-[var(--app-text-muted)]">
+        <div class="layout-grid space-2xs divider-left frame-standard pad-left-md">
+          <p class="copy-xs weight-semibold base-text">{{ selectedActivationTitle }}</p>
+          <p class="copy-xs line-normal muted-text">{{ selectedActivationDescription }}</p>
+          <p class="copy-xs line-normal muted-text">
             WAF runs before rate limits, traffic shaping, routing, cache, and target forwarding. Lower priority numbers are evaluated first.
           </p>
         </div>
@@ -541,10 +541,10 @@ defineExpose({ openCreate, openEdit, close });
       <PublicPolicyMatchEditor :form="form.match" />
       <PublicPolicyKeyPartsEditor :key-parts="form.keyParts" />
 
-      <section v-if="form.action === PublicWafRuleAction.CAPTCHA" class="grid gap-4 rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-4">
-        <h4 class="text-sm font-semibold text-[var(--app-text)]">Captcha</h4>
-        <div class="grid gap-4 sm:grid-cols-2">
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+      <section v-if="form.action === PublicWafRuleAction.CAPTCHA" class="layout-grid space-lg round-md framed frame-standard muted-bg pad-lg">
+        <h4 class="copy-sm weight-semibold base-text">Captcha</h4>
+        <div class="layout-grid space-lg mq-sm-cols-two">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Provider
             <NSelect
               v-model:value="form.captchaProviderId"
@@ -553,166 +553,166 @@ defineExpose({ openCreate, openEdit, close });
               :placeholder="providers.length ? 'Select provider' : 'No captcha providers configured'"
               :disabled="!providers.length"
             />
-            <span v-if="!providers.length" class="text-xs normal-case tracking-normal text-[var(--app-text-muted)]">
+            <span v-if="!providers.length" class="copy-xs normal-text letter-normal muted-text">
               Add a captcha provider in the WAF section before creating a captcha rule.
             </span>
-            <span v-else-if="!enabledProviders.length" class="text-xs normal-case tracking-normal text-amber-400">
+            <span v-else-if="!enabledProviders.length" class="copy-xs normal-text letter-normal warning-text">
               All configured captcha providers are disabled.
             </span>
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Pass TTL minutes
             <NInputNumber v-model:value="form.captchaPassMinutes" size="small" :min="1" />
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)] sm:col-span-2">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text mq-sm-span-two">
             Page template
             <NSelect v-model:value="form.captchaPageTemplateId" size="small" :options="captchaTemplateOptions" />
           </label>
         </div>
       </section>
 
-      <section v-if="form.action === PublicWafRuleAction.WAITING_ROOM" class="grid gap-4 rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-4">
-        <h4 class="text-sm font-semibold text-[var(--app-text)]">Waiting room</h4>
-        <div class="grid gap-4 sm:grid-cols-5">
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+      <section v-if="form.action === PublicWafRuleAction.WAITING_ROOM" class="layout-grid space-lg round-md framed frame-standard muted-bg pad-lg">
+        <h4 class="copy-sm weight-semibold base-text">Waiting room</h4>
+        <div class="layout-grid space-lg mq-sm-cols-five">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Capacity
             <NInputNumber v-model:value="form.waitingRoomMaxAdmitted" size="small" :min="1" />
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Admit/sec
             <NInputNumber v-model:value="form.waitingRoomAdmissionRate" size="small" :min="1" />
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             TTL minutes
             <NInputNumber v-model:value="form.waitingRoomAdmissionTtlMinutes" size="small" :min="1" />
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Poll seconds
             <NInputNumber v-model:value="form.waitingRoomPollSeconds" size="small" :min="1" />
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Timeout minutes
             <NInputNumber v-model:value="form.waitingRoomTimeoutMinutes" size="small" :min="1" />
           </label>
         </div>
-        <div class="grid gap-4 sm:grid-cols-2">
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <div class="layout-grid space-lg mq-sm-cols-two">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Page title
             <NInput v-model:value="form.waitingRoomPageTitle" size="small" />
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Page body
             <NInput v-model:value="form.waitingRoomPageBody" size="small" />
           </label>
         </div>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Page template
           <NSelect v-model:value="form.waitingRoomPageTemplateId" size="small" :options="waitingRoomTemplateOptions" />
         </label>
       </section>
 
-      <section v-if="form.activationMode === PublicWafActivationMode.AUTOMATIC" class="grid gap-5 rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-4">
-        <div class="grid gap-1">
-          <h4 class="text-sm font-semibold text-[var(--app-text)]">Automatic trigger behavior</h4>
-          <p class="text-xs leading-5 text-[var(--app-text-muted)]">
+      <section v-if="form.activationMode === PublicWafActivationMode.AUTOMATIC" class="layout-grid space-xl round-md framed frame-standard muted-bg pad-lg">
+        <div class="layout-grid space-2xs">
+          <h4 class="copy-sm weight-semibold base-text">Automatic trigger behavior</h4>
+          <p class="copy-xs line-normal muted-text">
             These settings decide when the selected WAF action temporarily turns on for matching traffic.
             Enabled metrics are combined as OR conditions; disabled metrics are saved as 0 and ignored.
           </p>
         </div>
-        <div class="grid gap-3 sm:grid-cols-4">
-          <div v-for="step in automaticFlowSteps" :key="step.label" class="border-l border-[var(--app-border)] pl-3">
-            <p class="text-xs font-semibold text-[var(--app-text)]">{{ step.label }}</p>
-            <p class="mt-1 text-xs leading-5 text-[var(--app-text-muted)]">{{ step.body }}</p>
+        <div class="layout-grid space-md mq-sm-cols-four">
+          <div v-for="step in automaticFlowSteps" :key="step.label" class="divider-left frame-standard pad-left-md">
+            <p class="copy-xs weight-semibold base-text">{{ step.label }}</p>
+            <p class="margin-top-xs copy-xs line-normal muted-text">{{ step.body }}</p>
           </div>
         </div>
-        <div class="grid gap-4 sm:grid-cols-3">
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <div class="layout-grid space-lg mq-sm-cols-three">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Window seconds
             <NInputNumber v-model:value="form.triggers.requestWindowSeconds" size="small" :min="1" />
-            <p class="text-xs font-normal normal-case leading-5 tracking-normal text-[var(--app-text-muted)]">Rolling window used by request-volume metrics.</p>
+            <p class="copy-xs weight-normal normal-text line-normal letter-normal muted-text">Rolling window used by request-volume metrics.</p>
           </label>
         </div>
-        <div v-for="group in automaticTriggerGroups" :key="group.title" class="grid gap-3 rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-3">
-          <div class="grid gap-1">
-            <h5 class="text-xs font-semibold uppercase tracking-wider text-[var(--app-text-muted)]">{{ group.title }}</h5>
-            <p class="text-xs leading-5 text-[var(--app-text-muted)]">{{ group.body }}</p>
+        <div v-for="group in automaticTriggerGroups" :key="group.title" class="layout-grid space-md round-md framed frame-standard muted-bg pad-md">
+          <div class="layout-grid space-2xs">
+            <h5 class="copy-xs weight-semibold label-case letter-wide muted-text">{{ group.title }}</h5>
+            <p class="copy-xs line-normal muted-text">{{ group.body }}</p>
           </div>
-          <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          <div class="layout-grid space-md mq-md-cols-two mq-xl-cols-three">
             <div
               v-for="metric in group.metrics"
               :key="metric.key"
-              class="grid gap-3 rounded border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-3"
-              :class="form.triggers.metrics[metric.key].enabled ? 'border-[var(--app-border)]' : 'opacity-70'"
+              class="layout-grid space-md round-sm framed frame-standard muted-bg pad-md"
+              :class="form.triggers.metrics[metric.key].enabled ? 'frame-standard' : 'disabled-fade'"
             >
-              <div class="flex items-center justify-between gap-3">
+              <div class="layout-row align-center spread-items space-md">
                 <NCheckbox
-                  class="min-w-0"
+                  class="min-width-zero"
                   :checked="form.triggers.metrics[metric.key].enabled"
                   @update:checked="updateTriggerMetricEnabled(metric.key, $event)"
                 >
-                  <span class="truncate text-sm font-medium">{{ metric.label }}</span>
+                  <span class="clip-text copy-sm weight-medium">{{ metric.label }}</span>
                 </NCheckbox>
                 <span
-                  class="shrink-0 rounded border px-2 py-0.5 text-[0.68rem] font-semibold uppercase tracking-wider"
-                  :class="form.triggers.metrics[metric.key].enabled ? 'border-emerald-500/30 text-emerald-300' : 'border-[var(--app-border)] text-[var(--app-text-muted)]'"
+                  class="no-shrink round-sm framed pad-x-sm pad-y-2xs copy-2xs weight-semibold label-case letter-wide"
+                  :class="form.triggers.metrics[metric.key].enabled ? 'success-border success-text' : 'frame-standard muted-text'"
                 >
                   {{ form.triggers.metrics[metric.key].enabled ? 'Enabled' : 'Disabled' }}
                 </span>
               </div>
-              <div class="grid gap-1.5">
-                <div class="flex items-center gap-2">
+              <div class="layout-grid space-xs">
+                <div class="layout-row align-center space-sm">
                   <NInputNumber
                     v-model:value="form.triggers.metrics[metric.key].value"
                     size="small"
-                    class="min-w-0 flex-1"
+                    class="min-width-zero grow-fill"
                     :min="metric.min"
                     :max="metric.max"
                     :step="metric.step ?? 1"
                     :disabled="!form.triggers.metrics[metric.key].enabled"
                   />
-                  <span class="w-16 shrink-0 text-xs text-[var(--app-text-muted)]">{{ metric.unit }}</span>
+                  <span class="width-compact no-shrink copy-xs muted-text">{{ metric.unit }}</span>
                 </div>
-                <p class="text-xs leading-5 text-[var(--app-text-muted)]">{{ metric.body }}</p>
+                <p class="copy-xs line-normal muted-text">{{ metric.body }}</p>
               </div>
             </div>
           </div>
         </div>
-        <div class="grid gap-3 rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-3">
-          <div class="grid gap-1">
-            <h5 class="text-xs font-semibold uppercase tracking-wider text-[var(--app-text-muted)]">Activation timing</h5>
-            <p class="text-xs leading-5 text-[var(--app-text-muted)]">Timing controls prevent brief spikes from rapidly turning the rule on and off. They are not detection metrics.</p>
+        <div class="layout-grid space-md round-md framed frame-standard muted-bg pad-md">
+          <div class="layout-grid space-2xs">
+            <h5 class="copy-xs weight-semibold label-case letter-wide muted-text">Activation timing</h5>
+            <p class="copy-xs line-normal muted-text">Timing controls prevent brief spikes from rapidly turning the rule on and off. They are not detection metrics.</p>
           </div>
-          <div class="grid gap-4 sm:grid-cols-2">
-            <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <div class="layout-grid space-lg mq-sm-cols-two">
+            <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
               Minimum active seconds
               <NInputNumber v-model:value="form.triggers.minimumActiveSeconds" size="small" :min="1" />
-              <p class="text-xs font-normal normal-case leading-5 tracking-normal text-[var(--app-text-muted)]">Pressure must persist this long before the action begins.</p>
+              <p class="copy-xs weight-normal normal-text line-normal letter-normal muted-text">Pressure must persist this long before the action begins.</p>
             </label>
-            <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+            <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
               Quiet seconds
               <NInputNumber v-model:value="form.triggers.quietSeconds" size="small" :min="1" />
-              <p class="text-xs font-normal normal-case leading-5 tracking-normal text-[var(--app-text-muted)]">The action stays active this long after all pressure clears.</p>
+              <p class="copy-xs weight-normal normal-text line-normal letter-normal muted-text">The action stays active this long after all pressure clears.</p>
             </label>
           </div>
         </div>
       </section>
 
-      <section v-if="form.action === PublicWafRuleAction.BLOCK" class="grid gap-4 rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-4">
-        <h4 class="text-sm font-semibold text-[var(--app-text)]">Block response</h4>
-        <div class="grid gap-4 sm:grid-cols-3">
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+      <section v-if="form.action === PublicWafRuleAction.BLOCK" class="layout-grid space-lg round-md framed frame-standard muted-bg pad-lg">
+        <h4 class="copy-sm weight-semibold base-text">Block response</h4>
+        <div class="layout-grid space-lg mq-sm-cols-three">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Status
             <NInputNumber v-model:value="form.blockResponseStatusCode" size="small" :min="400" :max="599" />
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)] sm:col-span-2">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text mq-sm-span-two">
             Content type
             <NInput v-model:value="form.blockResponseContentType" size="small" />
           </label>
         </div>
-        <div class="grid gap-3 rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-3">
-          <div class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <div class="layout-grid space-md round-md framed frame-standard muted-bg pad-md">
+          <div class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Body source
-            <NButtonGroup class="grid grid-cols-2" size="small">
+            <NButtonGroup class="layout-grid cols-two" size="small">
               <NButton
                 attr-type="button"
                 :type="form.blockResponseBodyMode === PublicResponseBodyMode.INLINE ? 'primary' : 'default'"
@@ -729,7 +729,7 @@ defineExpose({ openCreate, openEdit, close });
               </NButton>
             </NButtonGroup>
           </div>
-          <label v-if="form.blockResponseBodyMode === PublicResponseBodyMode.TEMPLATE" class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label v-if="form.blockResponseBodyMode === PublicResponseBodyMode.TEMPLATE" class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Template
             <NSelect
               v-model:value="form.blockResponseTemplateId"
@@ -739,17 +739,17 @@ defineExpose({ openCreate, openEdit, close });
               :disabled="!genericTemplates.length"
             />
           </label>
-          <label v-else class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label v-else class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Body
-            <NInput v-model:value="form.blockResponseBody" type="textarea" class="font-mono" :autosize="{ minRows: 4, maxRows: 8 }" />
+            <NInput v-model:value="form.blockResponseBody" type="textarea" class="mono-text" :autosize="{ minRows: 4, maxRows: 8 }" />
           </label>
         </div>
-        <div class="grid gap-2">
-          <div class="flex items-center justify-between gap-3">
-            <span class="text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">Headers</span>
+        <div class="layout-grid space-sm">
+          <div class="layout-row align-center spread-items space-md">
+            <span class="copy-xs weight-medium label-case letter-wide muted-text">Headers</span>
             <NButton secondary size="small" attr-type="button" @click="addBlockHeader">Add Header</NButton>
           </div>
-          <div v-for="(header, index) in form.blockResponseHeaders" :key="index" class="grid gap-2 sm:grid-cols-[1fr_1fr_auto]">
+          <div v-for="(header, index) in form.blockResponseHeaders" :key="index" class="layout-grid space-sm mq-sm-two-auto">
             <NInput v-model:value="header.name" size="small" placeholder="Name" />
             <NInput v-model:value="header.value" size="small" placeholder="Value" />
             <NButton
@@ -761,13 +761,13 @@ defineExpose({ openCreate, openEdit, close });
               attr-type="button"
               @click="removeBlockHeader(index)"
             >
-              <template #icon><TrashIcon class="h-3.5 w-3.5" /></template>
+              <template #icon><TrashIcon class="icon-sm icon-sm" /></template>
             </NButton>
           </div>
         </div>
       </section>
 
-      <div class="flex justify-end gap-3">
+      <div class="layout-row align-end-row space-md">
         <NButton secondary attr-type="button" @click="close">Cancel</NButton>
         <DisabledHint :disabled="submitDisabled" :reason="submitDisabledReason">
           <NButton type="primary" attr-type="submit" :disabled="submitDisabled">

--- a/web/management/src/components/editors/TrafficFlowEditTargetChooser.vue
+++ b/web/management/src/components/editors/TrafficFlowEditTargetChooser.vue
@@ -55,8 +55,8 @@ function kindLabel(kind: TrafficFlowEditTarget["kind"]): string {
     :bordered="false"
     @update:show="emit('update:modelValue', $event)"
   >
-    <div class="grid gap-4">
-      <div class="grid gap-2">
+    <div class="layout-grid space-lg">
+      <div class="layout-grid space-sm">
         <NButton
           v-for="target in request?.targets ?? []"
           :key="`${target.kind}:${target.id}`"
@@ -64,11 +64,11 @@ function kindLabel(kind: TrafficFlowEditTarget["kind"]): string {
           class="target-choice"
           @click="selectTarget(target)"
         >
-          <span class="text-sm font-medium text-[var(--app-text)]">{{ target.label }}</span>
-          <span class="font-mono text-xs text-[var(--app-text-muted)]">{{ kindLabel(target.kind) }} #{{ target.id }}{{ target.subLabel ? ` / ${target.subLabel}` : "" }}</span>
+          <span class="copy-sm weight-medium base-text">{{ target.label }}</span>
+          <span class="mono-text copy-xs muted-text">{{ kindLabel(target.kind) }} #{{ target.id }}{{ target.subLabel ? ` / ${target.subLabel}` : "" }}</span>
         </NButton>
       </div>
-      <div class="flex justify-end">
+      <div class="layout-row align-end-row">
         <NButton secondary attr-type="button" @click="close">Cancel</NButton>
       </div>
     </div>

--- a/web/management/src/components/ui/MetricCard.vue
+++ b/web/management/src/components/ui/MetricCard.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { NCard } from "naive-ui";
+
 const props = withDefaults(defineProps<{
   label: string;
   value: string;
@@ -8,17 +10,35 @@ const props = withDefaults(defineProps<{
 });
 
 const toneClass = {
-  default: "text-[var(--app-text)]",
-  success: "text-emerald-600 dark:text-emerald-300",
-  warning: "text-amber-600 dark:text-amber-300",
-  error: "text-red-600 dark:text-red-300",
-  info: "text-blue-600 dark:text-sky-300",
+  default: "metric-card__value--default",
+  success: "metric-card__value--success",
+  warning: "metric-card__value--warning",
+  error: "metric-card__value--error",
+  info: "metric-card__value--info",
 }[props.tone];
 </script>
 
 <template>
-  <div class="app-card p-5">
-    <p class="text-xs font-semibold uppercase tracking-normal text-[var(--app-text-muted)]">{{ label }}</p>
-    <p class="mt-2 text-2xl font-semibold tracking-normal" :class="toneClass">{{ value }}</p>
-  </div>
+  <NCard :bordered="true" size="small" class="metric-card">
+    <p class="metric-card__label">{{ label }}</p>
+    <p class="metric-card__value" :class="toneClass">{{ value }}</p>
+  </NCard>
 </template>
+
+<style scoped>
+.metric-card__label {
+  margin: 0;
+  color: var(--app-text-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.metric-card__value {
+  margin: 0.5rem 0 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+</style>

--- a/web/management/src/components/ui/PageHeader.vue
+++ b/web/management/src/components/ui/PageHeader.vue
@@ -6,15 +6,15 @@ defineProps<{
 </script>
 
 <template>
-  <header class="mb-6 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-    <div class="min-w-0">
-      <h1 class="text-2xl font-semibold tracking-normal text-[var(--app-text)]">{{ title }}</h1>
-      <p v-if="description" class="mt-1 max-w-3xl text-sm leading-6 text-[var(--app-text-muted)]">
+  <header class="margin-bottom-xl layout-row layout-column space-lg mq-md-row mq-md-align-end mq-md-spread">
+    <div class="min-width-zero">
+      <h1 class="copy-2xl weight-semibold letter-normal base-text">{{ title }}</h1>
+      <p v-if="description" class="margin-top-xs max-content-lg copy-sm line-relaxed muted-text">
         {{ description }}
       </p>
       <slot />
     </div>
-    <div v-if="$slots.actions" class="flex flex-wrap items-center gap-2">
+    <div v-if="$slots.actions" class="layout-row wrap-items align-center space-sm">
       <slot name="actions" />
     </div>
   </header>

--- a/web/management/src/components/ui/SectionCard.vue
+++ b/web/management/src/components/ui/SectionCard.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { NCard } from "naive-ui";
+
 defineProps<{
   title?: string;
   description?: string;
@@ -7,18 +9,40 @@ defineProps<{
 </script>
 
 <template>
-  <section class="app-card overflow-hidden" :class="{ 'app-card-segmented': segmented }">
-    <div v-if="title || description || $slots.actions" class="app-card-header">
-      <div>
-        <h2 v-if="title" class="text-base font-semibold text-[var(--app-text)]">{{ title }}</h2>
-        <p v-if="description" class="mt-1 text-sm text-[var(--app-text-muted)]">{{ description }}</p>
+  <NCard :bordered="true" class="section-card" :class="{ 'section-card--segmented': segmented }">
+    <template v-if="title || description || $slots.actions" #header>
+      <div class="section-card__heading">
+        <h2 v-if="title" class="copy-base weight-semibold base-text">{{ title }}</h2>
+        <p v-if="description" class="margin-top-xs copy-sm muted-text">{{ description }}</p>
       </div>
-      <div v-if="$slots.actions" class="flex flex-wrap items-center gap-2">
+    </template>
+    <template v-if="$slots.actions" #header-extra>
+      <div class="section-card__actions">
         <slot name="actions" />
       </div>
-    </div>
-    <div class="app-card-body">
-      <slot />
-    </div>
-  </section>
+    </template>
+    <slot />
+  </NCard>
 </template>
+
+<style scoped>
+.section-card {
+  overflow: hidden;
+}
+
+.section-card__heading {
+  min-width: 0;
+}
+
+.section-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.section-card--segmented :deep(.n-card__content) {
+  background: var(--app-panel-muted);
+}
+</style>

--- a/web/management/src/lib/trafficTraceStore.ts
+++ b/web/management/src/lib/trafficTraceStore.ts
@@ -426,15 +426,15 @@ export function traceStageLabel(stage: TrafficTraceStage): string {
 }
 
 export function requestStatusClass(request: Pick<TraceRequest, "stage" | "statusCode">): string {
-  if (request.stage === TrafficTraceStage.FAILED) return "text-red-400";
-  if (request.stage === TrafficTraceStage.WAF_BLOCKED) return "text-red-400";
-  if (request.stage === TrafficTraceStage.WAF_CAPTCHA_CHALLENGED || request.stage === TrafficTraceStage.WAF_WAITING_ROOM) return "text-amber-400";
-  if (request.stage === TrafficTraceStage.RATE_LIMITED) return "text-amber-400";
+  if (request.stage === TrafficTraceStage.FAILED) return "trace-status--error";
+  if (request.stage === TrafficTraceStage.WAF_BLOCKED) return "trace-status--error";
+  if (request.stage === TrafficTraceStage.WAF_CAPTCHA_CHALLENGED || request.stage === TrafficTraceStage.WAF_WAITING_ROOM) return "trace-status--warning";
+  if (request.stage === TrafficTraceStage.RATE_LIMITED) return "trace-status--warning";
   const status = Number(request.statusCode);
-  if (status >= 500) return "text-red-400";
-  if (status >= 400) return "text-amber-400";
-  if (status >= 200) return "text-green-400";
-  return "text-[var(--app-text-muted)]";
+  if (status >= 500) return "trace-status--error";
+  if (status >= 400) return "trace-status--warning";
+  if (status >= 200) return "trace-status--success";
+  return "trace-status--muted";
 }
 
 export function traceFlowLabel(request: TraceRequest): string {

--- a/web/management/src/router.ts
+++ b/web/management/src/router.ts
@@ -2,6 +2,7 @@ import { createRouter, createWebHashHistory } from 'vue-router';
 import Overview from './views/Overview.vue';
 import Diagnostics from './views/Diagnostics.vue';
 import Traffic from './views/Traffic.vue';
+import Monitor from './views/Monitor.vue';
 import AgentHealth from './views/AgentHealth.vue';
 import Settings from './views/Settings.vue';
 import SettingsApiTokens from './views/SettingsApiTokens.vue';
@@ -10,13 +11,22 @@ import ProxyConfig from './views/ProxyConfig.vue';
 import TrafficPolicies from './views/TrafficPolicies.vue';
 import ResponseTemplates from './views/ResponseTemplates.vue';
 import TlsConfig from './views/TlsConfig.vue';
+import NotFound from './views/NotFound.vue';
 
 const routes = [
   { path: '/', redirect: '/overview' },
   { path: '/overview', name: 'overview', component: Overview },
-  { path: '/diagnostics', name: 'diagnostics', component: Diagnostics },
-  { path: '/traffic', name: 'traffic', component: Traffic },
-  { path: '/agent', name: 'agent', component: AgentHealth },
+  {
+    path: '/monitor',
+    component: Monitor,
+    redirect: '/monitor/traffic',
+    children: [
+      { path: 'traffic', name: 'monitor-traffic', component: Traffic },
+      { path: 'diagnostics', name: 'monitor-diagnostics', component: Diagnostics },
+      { path: ':pathMatch(.*)*', redirect: '/monitor/traffic' },
+    ],
+  },
+  { path: '/agent/:section(fleet|activity)?', name: 'agent', component: AgentHealth },
   {
     path: '/settings',
     component: Settings,
@@ -27,11 +37,16 @@ const routes = [
     ],
   },
   { path: '/environments', redirect: '/settings/environments' },
-  { path: '/proxy', name: 'proxy', component: ProxyConfig },
-  { path: '/policies', name: 'policies', component: TrafficPolicies },
+  { path: '/proxy', redirect: '/proxy/routes' },
+  { path: '/proxy/:section(routes|listeners)', name: 'proxy', component: ProxyConfig },
+  { path: '/proxy/:pathMatch(.*)*', redirect: '/proxy/routes' },
+  { path: '/policies', redirect: '/policies/rate-limits' },
+  { path: '/policies/:section(rate-limits|waf|cache|traffic-shaper)', name: 'policies', component: TrafficPolicies },
+  { path: '/policies/:pathMatch(.*)*', redirect: '/policies/rate-limits' },
   { path: '/templates', name: 'templates', component: ResponseTemplates },
   { path: '/tls', name: 'tls', component: TlsConfig },
-  { path: '/management', redirect: '/proxy' },
+  { path: '/management', redirect: '/proxy/routes' },
+  { path: '/:pathMatch(.*)*', name: 'not-found', component: NotFound },
 ];
 
 export const router = createRouter({

--- a/web/management/src/styles.css
+++ b/web/management/src/styles.css
@@ -1,7 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap');
 
-@import "tailwindcss";
-
 :root {
   color-scheme: light;
   --font-body: "IBM Plex Sans", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -19,6 +17,7 @@
   --app-success: #059669;
   --app-warning: #d97706;
   --app-error: #dc2626;
+  --app-info: #2563eb;
   --app-shadow: 0 16px 45px rgba(20, 32, 51, 0.08);
 }
 
@@ -38,152 +37,1598 @@
   --app-success: #10b981;
   --app-warning: #f59e0b;
   --app-error: #f87171;
+  --app-info: #38bdf8;
   --app-shadow: 0 18px 50px rgba(0, 0, 0, 0.28);
 }
 
-@layer base {
-  html {
-    min-height: 100%;
-    font-family: var(--font-body);
-    background: var(--app-bg);
-    color: var(--app-text);
-    letter-spacing: 0;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
-
-  body {
-    min-height: 100vh;
-    margin: 0;
-    background:
-      radial-gradient(circle at 18% -10%, color-mix(in srgb, var(--app-accent) 12%, transparent), transparent 28rem),
-      var(--app-bg);
-  }
-
-  #app {
-    min-height: 100vh;
-  }
-
-  code,
-  pre,
-  kbd,
-  samp {
-    font-family: var(--font-mono);
-  }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
-@layer components {
-  .app-card {
-    border: 1px solid var(--app-border);
-    border-radius: 10px;
-    background: var(--app-panel);
-    box-shadow: 0 1px 0 rgba(20, 32, 51, 0.02);
-    color: var(--app-text);
-  }
+html {
+  min-height: 100%;
+  font-family: var(--font-body);
+  background: var(--app-bg);
+  color: var(--app-text);
+  letter-spacing: 0;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
 
-  .app-card:hover {
-    border-color: color-mix(in srgb, var(--app-accent) 28%, var(--app-border));
-  }
+body {
+  min-height: 100vh;
+  margin: 0;
+  background: var(--app-bg);
+}
 
-  .app-card-header {
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+#app {
+  min-height: 100vh;
+}
+
+code,
+pre,
+kbd,
+samp {
+  font-family: var(--font-mono);
+}
+
+.app-shell {
+  min-height: 100vh;
+  background: var(--app-bg);
+  color: var(--app-text);
+}
+
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  border-bottom: 1px solid var(--app-border);
+  background: color-mix(in srgb, var(--app-shell) 95%, transparent);
+  backdrop-filter: blur(18px);
+}
+
+.app-header__inner,
+.app-header__nav-wrap,
+.app-main {
+  width: min(100%, 80rem);
+  margin-inline: auto;
+  padding-inline: 1rem;
+}
+
+.app-header__bar {
+  display: flex;
+  min-height: 4rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.app-brand,
+.app-brand__group,
+.app-user,
+.app-header__actions,
+.app-env-label {
+  display: flex;
+  align-items: center;
+}
+
+.app-brand {
+  min-width: 0;
+  gap: 1rem;
+}
+
+.app-brand__group,
+.app-user,
+.app-header__actions,
+.app-env-label {
+  gap: 0.5rem;
+}
+
+.app-brand__mark {
+  display: inline-flex;
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: var(--app-accent);
+  color: #ffffff;
+  box-shadow: 0 1px 2px rgba(20, 32, 51, 0.12);
+}
+
+.app-brand__diamond {
+  width: 0.875rem;
+  height: 0.875rem;
+  border: 2px solid currentColor;
+  border-radius: 2px;
+  transform: rotate(45deg);
+}
+
+.app-brand__name {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.app-brand__divider {
+  display: none;
+  width: 1px;
+  height: 1.5rem;
+  background: var(--app-border);
+}
+
+.app-source-link {
+  display: inline-flex;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--app-text-muted);
+  transition: color 0.15s ease;
+}
+
+.app-source-link:hover {
+  color: var(--app-text);
+}
+
+.app-env-label {
+  display: none;
+  color: var(--app-text-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.app-env-select {
+  width: 13rem;
+}
+
+.app-user {
+  display: none;
+  color: var(--app-text-muted);
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.app-nav {
+  display: flex;
+  gap: 0.5rem;
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+}
+
+.app-nav__link {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  color: var(--app-text-muted);
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 0.375rem 0.75rem;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.app-nav__link:hover {
+  background: var(--app-panel-muted);
+  color: var(--app-text);
+}
+
+.app-nav__link--active {
+  background: var(--app-accent-soft);
+  color: var(--app-accent);
+}
+
+.app-main {
+  padding-block: 2rem;
+}
+
+.auth-panel {
+  width: min(100%, 28rem);
+  margin-inline: auto;
+  padding-block: 3rem;
+}
+
+.auth-panel--wide {
+  width: min(100%, 36rem);
+}
+
+.logout-card {
+  width: min(calc(100vw - 2rem), 28rem);
+}
+
+.page-stack,
+.section-stack,
+.modal-form,
+.field-list {
+  display: grid;
+}
+
+.layout-grid {
+  display: grid;
+}
+
+.layout-row {
+  display: flex;
+}
+
+.layout-column {
+  display: flex;
+  flex-direction: column;
+}
+
+.layout-column-reverse {
+  display: flex;
+  flex-direction: column-reverse;
+}
+
+.wrap-items {
+  flex-wrap: wrap;
+}
+
+.align-center {
+  align-items: center;
+}
+
+.align-start {
+  align-items: flex-start;
+}
+
+.align-end {
+  align-items: flex-end;
+}
+
+.spread-items {
+  justify-content: space-between;
+}
+
+.align-end-row {
+  justify-content: flex-end;
+}
+
+.align-center-row {
+  justify-content: center;
+}
+
+.self-align-end {
+  align-self: flex-end;
+}
+
+.flow-box {
+  display: block;
+}
+
+.display-none {
+  display: none;
+}
+
+.page-stack {
+  gap: 2rem;
+}
+
+.section-stack {
+  gap: 1.5rem;
+}
+
+.modal-form {
+  max-height: calc(100vh - 9rem);
+  gap: 1.25rem;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.modal-form--compact {
+  gap: 1rem;
+}
+
+.field-list {
+  gap: 0.5rem;
+}
+
+.field-stack {
+  display: grid;
+  gap: 0.375rem;
+  color: var(--app-text-muted);
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+}
+
+.field-stack__hint,
+.field-hint {
+  color: var(--app-text-muted);
+  font-size: 0.75rem;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.5;
+  text-transform: none;
+}
+
+.form-grid,
+.summary-grid,
+.content-grid,
+.list-grid,
+.card-grid,
+.trace-grid,
+.editor-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.form-grid--tight,
+.summary-grid--tight,
+.content-grid--tight {
+  gap: 0.75rem;
+}
+
+.form-grid--loose,
+.content-grid--loose {
+  gap: 1.5rem;
+}
+
+.inline-fields {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.page-toolbar,
+.section-toolbar,
+.row-toolbar,
+.list-row,
+.action-row,
+.action-row-reverse,
+.inline-row,
+.inline-row-wrap,
+.split-row,
+.panel-heading,
+.value-editor-head,
+.target-panel-head,
+.preview-header,
+.rate-preview-header,
+.match-head {
+  display: flex;
+}
+
+.page-toolbar {
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.page-toolbar__body,
+.section-toolbar__body {
+  min-width: 0;
+}
+
+.page-toolbar__actions,
+.section-toolbar__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.section-toolbar,
+.row-toolbar,
+.split-row,
+.panel-heading,
+.value-editor-head,
+.target-panel-head,
+.preview-header,
+.rate-preview-header,
+.match-head {
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.panel-heading {
+  align-items: flex-start;
+}
+
+.inline-row {
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.inline-row-wrap {
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.list-row {
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+}
+
+.list-row__body {
+  min-width: 0;
+}
+
+.list-row__title-line {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.list-row__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.action-row {
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.action-row-reverse {
+  flex-direction: column-reverse;
+  gap: 0.75rem;
+}
+
+.centered-block {
+  margin-inline: auto;
+}
+
+.center-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.min-width-zero {
+  min-width: 0;
+}
+
+.fill-width {
+  width: 100%;
+}
+
+.fit-width {
+  width: fit-content;
+}
+
+.no-shrink {
+  flex-shrink: 0;
+}
+
+.grow-fill {
+  flex: 1 1 auto;
+}
+
+.hide-overflow {
+  overflow: hidden;
+}
+
+.scroll-x {
+  overflow-x: auto;
+}
+
+.scroll-y {
+  overflow-y: auto;
+}
+
+.scroll-any {
+  overflow: auto;
+}
+
+.clip-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wrap-anywhere {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.preserve-lines {
+  white-space: pre-wrap;
+}
+
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+.no-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.surface-card {
+  min-width: 0;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: var(--app-panel);
+  color: var(--app-text);
+}
+
+.surface-card--muted {
+  background: var(--app-panel-muted);
+}
+
+.surface-card--segmented .surface-card__body {
+  background: var(--app-panel-muted);
+}
+
+.surface-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--app-border-subtle);
+  padding: 1rem 1.25rem;
+}
+
+.surface-card__body {
+  padding: 1.25rem;
+}
+
+.surface-section {
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  background: var(--app-panel-muted);
+  padding: 1rem;
+}
+
+.surface-section--panel {
+  background: var(--app-panel);
+}
+
+.divider-bottom {
+  border-bottom: 1px solid var(--app-border);
+}
+
+.divider-top {
+  border-top: 1px solid var(--app-border);
+}
+
+.divider-left {
+  border-left: 1px solid var(--app-border);
+  padding-left: 0.75rem;
+}
+
+.divided-list > * + * {
+  border-top: 1px solid var(--app-border-subtle);
+}
+
+.warning-panel,
+.error-panel {
+  border-radius: 6px;
+  padding: 0.75rem;
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.warning-panel {
+  border: 1px solid color-mix(in srgb, var(--app-warning) 40%, var(--app-border));
+  background: color-mix(in srgb, var(--app-warning) 9%, var(--app-panel));
+  color: var(--app-warning);
+}
+
+.error-panel {
+  border: 1px solid color-mix(in srgb, var(--app-error) 40%, var(--app-border));
+  background: color-mix(in srgb, var(--app-error) 9%, var(--app-panel));
+  color: var(--app-error);
+}
+
+.muted-text {
+  color: var(--app-text-muted);
+}
+
+.base-text {
+  color: var(--app-text);
+}
+
+.accent-text {
+  color: var(--app-accent);
+}
+
+.success-text {
+  color: var(--app-success);
+}
+
+.warning-text {
+  color: var(--app-warning);
+}
+
+.error-text {
+  color: var(--app-error);
+}
+
+.info-text {
+  color: var(--app-info);
+}
+
+.white-text {
+  color: #ffffff;
+}
+
+.copy-micro {
+  font-size: 0.6875rem;
+}
+
+.copy-xs {
+  font-size: 0.75rem;
+}
+
+.copy-sm {
+  font-size: 0.875rem;
+}
+
+.copy-base {
+  font-size: 1rem;
+}
+
+.copy-lg {
+  font-size: 1.125rem;
+}
+
+.copy-xl {
+  font-size: 1.25rem;
+}
+
+.copy-2xl {
+  font-size: 1.5rem;
+}
+
+.weight-normal {
+  font-weight: 400;
+}
+
+.weight-medium {
+  font-weight: 500;
+}
+
+.weight-semibold {
+  font-weight: 600;
+}
+
+.weight-bold {
+  font-weight: 700;
+}
+
+.label-text {
+  color: var(--app-text-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+}
+
+.label-text--strong {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.normal-text {
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.mono-text {
+  font-family: var(--font-mono);
+}
+
+.line-normal {
+  line-height: 1.5;
+}
+
+.line-relaxed {
+  line-height: 1.65;
+}
+
+.align-right-text {
+  text-align: right;
+}
+
+.align-center-text {
+  text-align: center;
+}
+
+.code-block {
+  display: block;
+  max-width: 100%;
+  overflow: auto;
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
+  background: var(--app-panel-muted);
+  color: var(--app-text);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1.5;
+  padding: 1rem;
+}
+
+.inline-code {
+  display: inline-block;
+  max-width: 100%;
+  overflow-x: auto;
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
+  background: var(--app-panel-muted);
+  color: var(--app-text);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1.5;
+  padding: 0.5rem 0.75rem;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--app-border);
+  border-radius: 999px;
+  color: var(--app-text-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.625rem;
+}
+
+.status-lock-pill {
+  display: inline-flex;
+  align-items: center;
+  border-color: color-mix(in srgb, var(--app-error) 40%, var(--app-border));
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--app-error) 8%, var(--app-panel));
+  color: var(--app-error);
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.625rem;
+}
+
+.stat-label,
+.metric-label {
+  color: var(--app-text-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.stat-value,
+.metric-value-text {
+  color: var(--app-text);
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.stat-detail,
+.metric-detail {
+  color: var(--app-text-muted);
+  font-size: 0.75rem;
+}
+
+.metric-card__value--default {
+  color: var(--app-text);
+}
+
+.trace-status--muted {
+  color: var(--app-text-muted);
+}
+
+.metric-card__value--success,
+.trace-status--success {
+  color: var(--app-success);
+}
+
+.metric-card__value--warning,
+.trace-status--warning {
+  color: var(--app-warning);
+}
+
+.metric-card__value--error,
+.trace-status--error {
+  color: var(--app-error);
+}
+
+.metric-card__value--info {
+  color: var(--app-info);
+}
+
+.icon-sm {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.icon-md {
+  width: 1rem;
+  height: 1rem;
+}
+
+.icon-box-sm {
+  width: 2rem;
+  height: 2rem;
+}
+
+.blurred-secret {
+  display: inline-block;
+  user-select: none;
+  filter: blur(4px);
+}
+
+.max-auth {
+  width: min(100%, 28rem);
+}
+
+.max-content-sm {
+  max-width: 18rem;
+}
+
+.max-content-md {
+  max-width: 22rem;
+}
+
+.max-content-lg {
+  max-width: 42rem;
+}
+
+.max-content-xl {
+  max-width: 48rem;
+}
+
+.max-height-sm {
+  max-height: 16.25rem;
+}
+
+.max-height-md {
+  max-height: 22.5rem;
+}
+
+.indent-left {
+  padding-left: 0.75rem;
+}
+
+.pad-xs {
+  padding: 0.25rem;
+}
+
+.pad-sm {
+  padding: 0.5rem;
+}
+
+.pad-md {
+  padding: 0.75rem;
+}
+
+.pad-lg {
+  padding: 1rem;
+}
+
+.pad-xl {
+  padding: 1.25rem;
+}
+
+.pad-2xl {
+  padding: 1.5rem;
+}
+
+.pad-x-sm {
+  padding-inline: 0.5rem;
+}
+
+.pad-x-md {
+  padding-inline: 0.75rem;
+}
+
+.pad-x-lg {
+  padding-inline: 1rem;
+}
+
+.pad-x-xl {
+  padding-inline: 1.25rem;
+}
+
+.pad-y-xs {
+  padding-block: 0.25rem;
+}
+
+.pad-y-sm {
+  padding-block: 0.5rem;
+}
+
+.pad-y-md {
+  padding-block: 0.75rem;
+}
+
+.pad-y-lg {
+  padding-block: 1rem;
+}
+
+.pad-y-xl {
+  padding-block: 1.25rem;
+}
+
+.pad-top-lg {
+  padding-top: 1rem;
+}
+
+.pad-bottom-md {
+  padding-bottom: 0.75rem;
+}
+
+.margin-top-2xs {
+  margin-top: 0.125rem;
+}
+
+.margin-top-xs {
+  margin-top: 0.25rem;
+}
+
+.margin-top-sm {
+  margin-top: 0.5rem;
+}
+
+.margin-top-md {
+  margin-top: 0.75rem;
+}
+
+.margin-top-lg {
+  margin-top: 1rem;
+}
+
+.margin-bottom-sm {
+  margin-bottom: 0.5rem;
+}
+
+.margin-bottom-md {
+  margin-bottom: 0.75rem;
+}
+
+.margin-bottom-lg {
+  margin-bottom: 1rem;
+}
+
+.margin-bottom-xl {
+  margin-bottom: 1.5rem;
+}
+
+.space-2xs {
+  gap: 0.125rem;
+}
+
+.space-xs {
+  gap: 0.375rem;
+}
+
+.space-sm {
+  gap: 0.5rem;
+}
+
+.space-md {
+  gap: 0.75rem;
+}
+
+.space-lg {
+  gap: 1rem;
+}
+
+.space-xl {
+  gap: 1.25rem;
+}
+
+.space-2xl {
+  gap: 1.5rem;
+}
+
+.stack-md > * + * {
+  margin-top: 1rem;
+}
+
+.stack-lg > * + * {
+  margin-top: 1.5rem;
+}
+
+.stack-xl > * + * {
+  margin-top: 2rem;
+}
+
+.round-sm {
+  border-radius: 4px;
+}
+
+.round-md {
+  border-radius: 6px;
+}
+
+.round-lg {
+  border-radius: 8px;
+}
+
+.round-xl {
+  border-radius: 12px;
+}
+
+.round-full {
+  border-radius: 999px;
+}
+
+.framed {
+  border: 1px solid var(--app-border);
+}
+
+.framed-subtle {
+  border: 1px solid var(--app-border-subtle);
+}
+
+.framed-dashed {
+  border: 1px dashed var(--app-border);
+}
+
+.muted-bg {
+  background: var(--app-panel-muted);
+}
+
+.panel-bg {
+  background: var(--app-panel);
+}
+
+.accent-bg {
+  background: var(--app-accent);
+}
+
+.accent-soft-bg {
+  background: var(--app-accent-soft);
+}
+
+.transparent-bg {
+  background: transparent;
+}
+
+.surface-shadow {
+  box-shadow: 0 1px 2px rgba(20, 32, 51, 0.08);
+}
+
+.dialog-shadow {
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.14);
+}
+
+.disabled-fade {
+  opacity: 0.7;
+}
+
+.interactive-cursor {
+  cursor: pointer;
+}
+
+.no-select {
+  user-select: none;
+}
+
+.secret-blur {
+  filter: blur(4px);
+}
+
+.app-bg {
+  background: var(--app-bg);
+}
+
+.width-env-select {
+  width: 13rem;
+}
+
+.width-hairline {
+  width: 1px;
+}
+
+.width-compact {
+  width: 4rem;
+}
+
+.height-divider {
+  height: 1.5rem;
+}
+
+.height-control {
+  height: 2.5rem;
+}
+
+.min-screen {
+  min-height: 100vh;
+}
+
+.max-modal-height {
+  max-height: calc(100vh - 9rem);
+}
+
+.max-auth-width {
+  max-width: 28rem;
+}
+
+.max-panel-width {
+  max-width: 36rem;
+}
+
+.max-shell-width {
+  max-width: 80rem;
+}
+
+.max-token-width {
+  max-width: 18rem;
+}
+
+.max-trace-width {
+  max-width: 22rem;
+}
+
+.max-full {
+  max-width: 100%;
+}
+
+.min-code-height {
+  min-height: 3rem;
+}
+
+.backdrop-overlay {
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.glass-blur {
+  backdrop-filter: blur(18px);
+}
+
+.glass-blur-soft {
+  backdrop-filter: blur(4px);
+}
+
+.important-muted-button {
+  border-color: var(--app-border) !important;
+  background: transparent !important;
+  color: var(--app-text-muted) !important;
+}
+
+.important-muted-button:hover {
+  border-color: var(--app-text-muted) !important;
+}
+
+.important-muted-text {
+  color: var(--app-text-muted) !important;
+}
+
+.important-muted-frame {
+  border-color: var(--app-border) !important;
+}
+
+.important-transparent-bg {
+  background: transparent !important;
+}
+
+.warning-surface {
+  border-color: color-mix(in srgb, var(--app-warning) 40%, var(--app-border));
+  background: color-mix(in srgb, var(--app-warning) 9%, var(--app-panel));
+  color: var(--app-warning);
+}
+
+.error-surface {
+  border-color: color-mix(in srgb, var(--app-error) 40%, var(--app-border));
+  background: color-mix(in srgb, var(--app-error) 9%, var(--app-panel));
+  color: var(--app-error);
+}
+
+.success-border {
+  border-color: color-mix(in srgb, var(--app-success) 36%, var(--app-border));
+}
+
+.accent-frame {
+  border-color: var(--app-accent);
+}
+
+.warning-border {
+  border-color: color-mix(in srgb, var(--app-warning) 40%, var(--app-border));
+}
+
+.error-border {
+  border-color: color-mix(in srgb, var(--app-error) 40%, var(--app-border));
+}
+
+.frame-standard {
+  border-color: var(--app-border);
+}
+
+.frame-subtle {
+  border-color: var(--app-border-subtle);
+}
+
+.frame-transparent {
+  border-color: transparent;
+}
+
+.dashed-border {
+  border-style: dashed;
+}
+
+.letter-normal {
+  letter-spacing: 0;
+}
+
+.letter-wide {
+  letter-spacing: 0.025em;
+}
+
+.letter-widest {
+  letter-spacing: 0.08em;
+}
+
+.label-case {
+  text-transform: uppercase;
+}
+
+.deemphasized {
+  opacity: 0.8;
+}
+
+.vertical-middle {
+  vertical-align: middle;
+}
+
+.rotate-diamond {
+  transform: rotate(45deg);
+}
+
+.round-2px {
+  border-radius: 2px;
+}
+
+.pad-x-2xs {
+  padding-inline: 0.25rem;
+}
+
+.pad-x-xs {
+  padding-inline: 0.375rem;
+}
+
+.pad-x-smd {
+  padding-inline: 0.625rem;
+}
+
+.pad-y-2xs {
+  padding-block: 0.125rem;
+}
+
+.pad-y-smd {
+  padding-block: 0.375rem;
+}
+
+.pad-y-2xl {
+  padding-block: 2rem;
+}
+
+.pad-y-3xl {
+  padding-block: 2.5rem;
+}
+
+.pad-y-4xl {
+  padding-block: 3rem;
+}
+
+.pad-right-xs {
+  padding-right: 0.25rem;
+}
+
+.pad-bottom-sm {
+  padding-bottom: 0.5rem;
+}
+
+.pad-left-md {
+  padding-left: 0.75rem;
+}
+
+.margin-bottom-xs {
+  margin-bottom: 0.25rem;
+}
+
+.margin-bottom-2xl {
+  margin-bottom: 2rem;
+}
+
+.copy-2xs {
+  font-size: 0.6875rem;
+}
+
+.copy-3xs {
+  font-size: 0.625rem;
+}
+
+.base-border-bottom {
+  border-bottom: 2px solid var(--app-border);
+}
+
+.overlay-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+}
+
+.sticky-top {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+}
+
+.inset-fill {
+  inset: 0;
+}
+
+.layout-transition {
+  transition: color 0.15s ease, background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.hover-base-text:hover {
+  color: var(--app-text);
+}
+
+.cols-one {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.cols-two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.cols-four {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.settings-token-grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.response-template-form-grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+@media (min-width: 640px) {
+  .app-brand__divider,
+  .app-user {
     display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 1rem;
-    border-bottom: 1px solid var(--app-border-subtle);
-    padding: 1rem 1.25rem;
   }
 
-  .app-card-body {
-    padding: 1.25rem;
+  .app-header__inner,
+  .app-header__nav-wrap,
+  .app-main {
+    padding-inline: 1.5rem;
   }
 
-  .app-card-segmented .app-card-body {
-    background: var(--app-panel-muted);
+  .form-grid--two,
+  .summary-grid--two,
+  .content-grid--two,
+  .trace-grid--two,
+  .mq-sm-cols-two {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .app-card-title {
-    margin-bottom: 0.5rem;
-    color: var(--app-text-muted);
-    font-size: 0.8125rem;
-    font-weight: 600;
-    letter-spacing: 0;
+  .form-grid--three,
+  .summary-grid--three,
+  .content-grid--three,
+  .mq-sm-cols-three {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
-  .app-card-value {
-    color: var(--app-text);
-    font-size: 1.5rem;
-    font-weight: 650;
-    letter-spacing: 0;
+  .form-grid--four,
+  .summary-grid--four,
+  .content-grid--four,
+  .mq-sm-cols-four {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
-  .app-control {
-    width: 100%;
-    border: 1px solid var(--app-border);
-    border-radius: 8px;
-    background: var(--app-panel);
-    color: var(--app-text);
-    padding: 0.5rem 0.75rem;
-    transition: border-color 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
+  .form-grid--five,
+  .summary-grid--five,
+  .content-grid--five,
+  .mq-sm-cols-five {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
   }
 
-  .app-control:focus {
-    border-color: var(--app-accent);
-    box-shadow: 0 0 0 3px var(--app-accent-soft);
-    outline: none;
+  .span-two,
+  .mq-sm-span-two {
+    grid-column: span 2 / span 2;
   }
 
-  .app-control:disabled,
-  .app-control[aria-disabled="true"] {
-    border-color: var(--app-border-subtle);
-    background: var(--app-panel-muted);
-    color: var(--app-text-muted);
-    cursor: not-allowed;
-    opacity: 0.7;
+  .span-three,
+  .mq-sm-span-three {
+    grid-column: span 3 / span 3;
   }
 
-  select.app-control,
-  .app-control:is(select) {
-    appearance: none;
-    -webkit-appearance: none;
-    background-image: linear-gradient(45deg, transparent 50%, var(--app-text-muted) 50%), linear-gradient(135deg, var(--app-text-muted) 50%, transparent 50%);
-    background-position: calc(100% - 16px) 52%, calc(100% - 11px) 52%;
-    background-repeat: no-repeat;
-    background-size: 5px 5px, 5px 5px;
-    padding-right: 2.25rem;
+  .span-four,
+  .mq-sm-span-four {
+    grid-column: span 4 / span 4;
   }
 
-  select.app-control option {
-    background: var(--app-panel);
-    color: var(--app-text);
+  .inline-fields--action {
+    grid-template-columns: 1fr auto;
   }
 
-  .app-warning-panel {
-    border: 1px solid color-mix(in srgb, var(--app-warning) 36%, var(--app-border));
-    border-radius: 6px;
-    background: color-mix(in srgb, var(--app-warning) 9%, var(--app-panel));
-    color: var(--app-warning);
+  .inline-fields--two-action {
+    grid-template-columns: 1fr 1fr auto;
   }
 
-  .app-error-panel {
-    border: 1px solid color-mix(in srgb, var(--app-error) 36%, var(--app-border));
-    border-radius: 6px;
-    background: color-mix(in srgb, var(--app-error) 9%, var(--app-panel));
-    color: var(--app-error);
+  .mq-sm-one-auto {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .mq-sm-two-auto {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+  }
+
+  .mq-sm-trace-event {
+    grid-template-columns: 10rem minmax(0, 1fr) 6rem;
+  }
+
+  .inline-fields--label-action {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+  }
+
+  .action-row-reverse {
+    flex-direction: row;
+    justify-content: flex-end;
+  }
+
+  .mq-sm-row {
+    display: flex;
+    flex-direction: row;
+  }
+
+  .mq-sm-flow-box {
+    display: block;
+  }
+
+  .mq-sm-align-center {
+    align-items: center;
+  }
+
+  .mq-sm-align-end {
+    align-items: flex-end;
+  }
+
+  .mq-sm-end {
+    justify-content: flex-end;
+  }
+
+  .mq-sm-pad-x-lg {
+    padding-inline: 1.5rem;
   }
 }
 
-@layer utilities {
-  .no-scrollbar::-webkit-scrollbar {
-    display: none;
+@media (min-width: 768px) {
+  .app-env-label {
+    display: flex;
   }
 
-  .no-scrollbar {
-    -ms-overflow-style: none;
-    scrollbar-width: none;
+  .page-toolbar {
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: space-between;
   }
 
-  .text-balance {
-    text-wrap: balance;
+  .content-grid--md-two,
+  .form-grid--md-two,
+  .mq-md-cols-two {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .mq-md-cols-three {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .response-template-form-grid {
+    grid-template-columns: minmax(0, 1fr) 14rem;
+  }
+
+  .row-on-md,
+  .mq-md-row {
+    flex-direction: row;
+  }
+
+  .mq-md-align-end {
+    align-items: flex-end;
+  }
+
+  .mq-md-spread {
+    justify-content: space-between;
+  }
+}
+
+@media (min-width: 1024px) {
+  .app-header__inner,
+  .app-header__nav-wrap,
+  .app-main {
+    padding-inline: 2rem;
+  }
+
+  .list-row--actions {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .list-row__actions {
+    justify-content: flex-end;
+  }
+
+  .content-grid--lg-two,
+  .form-grid--lg-two,
+  .mq-lg-cols-two {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .content-grid--lg-three,
+  .summary-grid--lg-three,
+  .mq-lg-cols-three {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .content-grid--lg-four,
+  .summary-grid--lg-four,
+  .mq-lg-cols-four {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .wide-list-row,
+  .mq-lg-one-auto {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .mq-lg-end {
+    justify-content: flex-end;
+  }
+
+  .mq-lg-row {
+    flex-direction: row;
+  }
+
+  .mq-lg-align-end {
+    align-items: flex-end;
+  }
+
+  .mq-lg-spread {
+    justify-content: space-between;
+  }
+
+  .mq-lg-span-two {
+    grid-column: span 2 / span 2;
+  }
+
+  .settings-token-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.25fr);
+  }
+
+  .mq-lg-pad-x-xl {
+    padding-inline: 2rem;
+  }
+}
+
+@media (min-width: 1280px) {
+  .summary-grid--xl-three,
+  .content-grid--xl-three,
+  .mq-xl-cols-three {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .summary-grid--xl-four,
+  .content-grid--xl-four,
+  .mq-xl-cols-four {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .summary-grid--xl-five,
+  .content-grid--xl-five,
+  .mq-xl-cols-five {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
   }
 }

--- a/web/management/src/views/AgentHealth.vue
+++ b/web/management/src/views/AgentHealth.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, h, inject, ref, watch } from "vue";
-import { NButton, NButtonGroup, NCheckbox, NDataTable, NInput, NModal, NTag } from "naive-ui";
+import { useRoute, useRouter } from "vue-router";
+import { NAlert, NButton, NCheckbox, NDataTable, NInput, NModal, NTab, NTabs, NTag } from "naive-ui";
 import type { DataTableColumns } from "naive-ui";
 import { Ban as BanIcon } from "@lucide/vue";
 import { Check as CheckIcon } from "@lucide/vue";
@@ -41,7 +42,25 @@ import type {
 } from "@/gen/proto/p2pstream/v1/management_pb";
 
 const managementClient = useManagementClient();
+const route = useRoute();
+const router = useRouter();
 
+const agentSections = [
+  {
+    key: "fleet",
+    label: "Fleet",
+    path: "/agent",
+    description: "Fleet state, availability, selectors, and agent lifecycle actions.",
+  },
+  {
+    key: "activity",
+    label: "Activity",
+    path: "/agent/activity",
+    description: "Runtime pressure, process metrics, and recent connection sessions.",
+  },
+] as const;
+
+type AgentSectionKey = typeof agentSections[number]["key"];
 
 const dashboard = inject(dashboardKey, computed(() => null));
 const publicProxyConfig = inject(publicProxyConfigKey, computed(() => null));
@@ -59,14 +78,78 @@ const uptimeSummaries = computed(() => dashboard?.value?.agentUptimeSummaries ??
 const uptimeByAgentId = computed(() => agentUptimeSummaryById(uptimeSummaries.value));
 const recentAgentConnections = computed(() => dashboard?.value?.recentAgentConnections ?? []);
 const enabledAgents = computed(() => agents.value.filter((agent) => agent.enabled).length);
+const totalAgents = computed(() => agents.value.length);
+const disabledAgents = computed(() => Math.max(0, totalAgents.value - enabledAgents.value));
 const connectedAgentCount = computed(() => uptimeSummaries.value.length
   ? uptimeSummaries.value.filter((summary) => summary.connected).length
   : agents.value.filter((agent) => agent.connected).length);
+const offlineEnabledAgents = computed(() => Math.max(0, enabledAgents.value - connectedAgentCount.value));
 const activeAgentRequests = computed(() => agents.value.reduce((sum, agent) => sum + Number(agent.activeRequests || 0n), 0));
 const fleetUptime = computed(() => fleetUptimePercent(uptimeSummaries.value));
 const longestCurrentUptimeMillis = computed(() => Math.max(0, ...uptimeSummaries.value.map((summary) => Number(summary.currentUptimeMillis || 0n))));
 const recentDisconnects = computed(() => recentDisconnectCount(recentAgentConnections.value, dashboard?.value?.generatedAtUnixMillis ?? BigInt(Date.now())));
 const retentionDaysLabel = computed(() => `${(dashboard?.value?.retentionDays ?? 30n).toString()}d`);
+const connectedAgentPercent = computed(() => {
+  if (!enabledAgents.value) return 0;
+  return Math.round((connectedAgentCount.value / enabledAgents.value) * 100);
+});
+const connectedAgentPercentStyle = computed(() => ({
+  width: `${Math.min(100, Math.max(0, connectedAgentPercent.value))}%`,
+}));
+const fleetStatusType = computed<"success" | "warning" | "error" | "default">(() => {
+  if (!totalAgents.value) return "default";
+  if (connectedAgentCount.value === enabledAgents.value && enabledAgents.value > 0) return "success";
+  if (connectedAgentCount.value === 0 && enabledAgents.value > 0) return "error";
+  return "warning";
+});
+const fleetStatusLabel = computed(() => {
+  if (!totalAgents.value) return "No agents";
+  if (connectedAgentCount.value === enabledAgents.value && enabledAgents.value > 0) return "Healthy";
+  if (connectedAgentCount.value === 0 && enabledAgents.value > 0) return "Disconnected";
+  return "Degraded";
+});
+const fleetSummary = computed(() => {
+  if (!totalAgents.value) return "Create an agent to connect private upstreams to this proxy.";
+  if (!enabledAgents.value) return `${totalAgents.value} registered, all disabled.`;
+  if (!offlineEnabledAgents.value) return `${connectedAgentPercent.value}% of enabled agents are connected.`;
+  return `${offlineEnabledAgents.value} enabled agent${offlineEnabledAgents.value === 1 ? "" : "s"} offline.`;
+});
+const runtimeMetrics = computed(() => [
+  {
+    label: "Memory sys",
+    value: `${bigIntLabel(status.value?.latestAgentStats?.memorySysMb)} MB`,
+    detail: "latest sample",
+  },
+  {
+    label: "Goroutines",
+    value: bigIntLabel(status.value?.latestAgentStats?.numGoroutine),
+    detail: "latest sample",
+  },
+  {
+    label: "Active requests",
+    value: activeAgentRequests.value.toString(),
+    detail: "across agents",
+  },
+  {
+    label: "Avg memory",
+    value: `${bigIntLabel(oneHourWindow.value?.agentAvgMemoryMb)} MB`,
+    detail: "1h window",
+  },
+  {
+    label: "Max memory",
+    value: `${bigIntLabel(dayWindow.value?.agentMaxMemoryMb)} MB`,
+    detail: "24h window",
+  },
+  {
+    label: "Max goroutines",
+    value: bigIntLabel(dayWindow.value?.agentMaxGoroutines),
+    detail: "24h window",
+  },
+]);
+const activeAgentSection = computed<AgentSectionKey>(() => normalizeAgentSection(route.params.section));
+const activeAgentSectionMeta = computed(() =>
+  agentSections.find((section) => section.key === activeAgentSection.value) ?? agentSections[0],
+);
 
 const agentEditor = ref<InstanceType<typeof AgentEditorModal> | null>(null);
 const rotateAgentToConfirm = ref<Agent | null>(null);
@@ -89,6 +172,8 @@ const uninstallReleaseRepository = ref(defaultReleaseRepository());
 const uninstallCopyLabel = ref("Copy");
 let setupCopyReset: number | undefined;
 let uninstallCopyReset: number | undefined;
+
+const sessionPagination = { pageSize: 12 };
 
 const busyDisabledReason = computed(() => isBusy?.value ? BUSY_REASON : "");
 const normalizedManagementUrl = computed(() => normalizeSetupManagementUrl(setupManagementUrl.value));
@@ -131,117 +216,153 @@ const uninstallSnippet = computed(() => {
   if (uninstallSnippetError.value) return "";
   return buildUninstallSnippet();
 });
+
+function normalizeAgentSection(value: unknown): AgentSectionKey {
+  const section = Array.isArray(value) ? value[0] : value;
+  return section === "activity" ? "activity" : "fleet";
+}
+
+async function selectAgentSection(value: string | number) {
+  const section = agentSections.find((item) => item.key === value);
+  if (!section || section.key === activeAgentSection.value) return;
+  await router.push(section.path);
+}
+
 const agentColumns = computed<DataTableColumns<Agent>>(() => [
   {
     title: "Agent",
     key: "agent",
-    minWidth: 280,
-    render: (agent) => h("div", [
-      h("p", { class: "font-medium text-[var(--app-text)]" }, agent.name),
-      h("p", { class: "font-mono text-xs text-[var(--app-text-muted)]" }, agent.publicId),
-      h("div", { class: "mt-2 flex flex-wrap gap-1.5" }, [
+    minWidth: 340,
+    render: (agent) => h("div", { class: "agent-cell" }, [
+      h("div", { class: "agent-cell__header" }, [
+        h("span", { class: "agent-cell__name" }, agent.name),
+        !agent.enabled ? h(NTag, { size: "small", bordered: false, type: "warning" }, { default: () => "Disabled" }) : null,
+      ]),
+      h("p", { class: "agent-cell__id mono-text" }, agent.publicId),
+      h("div", { class: "agent-cell__labels" }, [
         ...agentUserLabels(agent).map((label) => h(
           NTag,
-          { key: label.id, size: "small", bordered: true, class: "font-mono" },
+          { key: label.id, size: "small", bordered: true, class: "mono-text" },
           { default: () => `${label.key}=${label.value}` },
         )),
-        !agentUserLabels(agent).length ? h("span", { class: "text-xs text-[var(--app-text-muted)]" }, "No user labels") : null,
+        !agentUserLabels(agent).length ? h("span", { class: "copy-xs muted-text" }, "No user labels") : null,
       ]),
-      h("code", { class: "mt-1 block break-all font-mono text-[11px] text-[var(--app-text-muted)]" }, exactAgentSelector(agent)),
+      h("div", { class: "agent-selector" }, [
+        h("span", { class: "agent-selector__label" }, "Selector"),
+        h("code", { class: "agent-selector__value mono-text" }, exactAgentSelector(agent)),
+      ]),
     ]),
   },
   {
     title: "State",
     key: "state",
-    width: 160,
-    render: (agent) => h("div", { class: "flex items-center gap-2" }, [
-      h(NTag, { size: "small", bordered: false, type: agentConnected(agent) ? "success" : "warning" }, { default: () => agentConnected(agent) ? "Connected" : "Offline" }),
-      !agent.enabled ? h(NTag, { size: "small", bordered: false, type: "warning" }, { default: () => "Disabled" }) : null,
+    width: 190,
+    render: (agent) => h("div", { class: "agent-state-cell" }, [
+      h("div", { class: "agent-state-cell__status" }, [
+        h("span", { class: ["agent-state-dot", agentConnected(agent) ? "agent-state-dot--connected" : "agent-state-dot--offline"] }),
+        h("span", { class: "weight-semibold base-text" }, agentConnected(agent) ? "Connected" : "Offline"),
+      ]),
+      h("p", { class: "margin-top-xs mono-text copy-xs muted-text" }, currentAgentDuration(agent)),
+      h("p", { class: "copy-xs muted-text" }, currentAgentDurationKind(agent)),
     ]),
   },
   {
-    title: "Current",
-    key: "current",
-    width: 150,
-    render: (agent) => h("div", [
-      h("p", { class: "font-mono text-xs text-[var(--app-text)]" }, currentAgentDuration(agent)),
-      h("p", { class: "mt-1 text-xs text-[var(--app-text-muted)]" }, currentAgentDurationKind(agent)),
+    title: "Reliability",
+    key: "reliability",
+    width: 230,
+    render: (agent) => h("div", { class: "agent-compact-stack" }, [
+      h("p", { class: "agent-metric-line" }, [
+        h("span", { class: "muted-text" }, "Uptime"),
+        h("strong", { class: "mono-text base-text" }, agentUptimePercentLabel(agent)),
+      ]),
+      h("p", { class: "agent-metric-line" }, [
+        h("span", { class: "muted-text" }, "Connections"),
+        h("strong", { class: "mono-text base-text" }, agentConnectionCounts(agent)),
+      ]),
+      h("p", { class: "agent-subline mono-text muted-text" }, `Last up ${formatDate(agentLastConnected(agent))}`),
+      h("p", { class: "agent-subline mono-text muted-text" }, `Last down ${formatDate(agentLastDisconnected(agent))}`),
     ]),
   },
   {
-    title: "Uptime",
-    key: "uptime",
-    width: 150,
-    render: (agent) => h("div", [
-      h("p", { class: "font-mono text-xs text-[var(--app-text)]" }, agentUptimePercentLabel(agent)),
-      h("p", { class: "mt-1 text-xs text-[var(--app-text-muted)]" }, `connections ${agentConnectionCounts(agent)}`),
-    ]),
-  },
-  { title: "Last Connected", key: "lastConnected", width: 190, render: (agent) => h("span", { class: "font-mono text-xs" }, formatDate(agentLastConnected(agent))) },
-  { title: "Last Disconnected", key: "lastDisconnected", width: 190, render: (agent) => h("span", { class: "font-mono text-xs" }, formatDate(agentLastDisconnected(agent))) },
-  {
-    title: "Active Requests",
-    key: "activeRequests",
-    width: 170,
-    render: (agent) => h("div", [
-      h("p", { class: "font-mono text-xs text-[var(--app-text)]" }, agent.activeRequests.toString()),
-      agent.latestStats
-        ? h("p", { class: "mt-1 font-mono text-xs text-[var(--app-text-muted)]" }, `${bigIntLabel(agent.latestStats.memorySysMb)} MB / ${bigIntLabel(agent.latestStats.numGoroutine)} goroutines`)
-        : null,
+    title: "Runtime",
+    key: "runtime",
+    width: 210,
+    render: (agent) => h("div", { class: "agent-compact-stack" }, [
+      h("p", { class: "agent-metric-line" }, [
+        h("span", { class: "muted-text" }, "Active"),
+        h("strong", { class: "mono-text base-text" }, agent.activeRequests.toString()),
+      ]),
+      ...(agent.latestStats
+        ? [
+            h("p", { class: "agent-metric-line" }, [
+              h("span", { class: "muted-text" }, "Memory"),
+              h("strong", { class: "mono-text base-text" }, `${bigIntLabel(agent.latestStats.memorySysMb)} MB`),
+            ]),
+            h("p", { class: "agent-metric-line" }, [
+              h("span", { class: "muted-text" }, "Goroutines"),
+              h("strong", { class: "mono-text base-text" }, bigIntLabel(agent.latestStats.numGoroutine)),
+            ]),
+          ]
+        : [h("p", { class: "copy-xs muted-text" }, "No runtime sample")]),
     ]),
   },
   {
     title: "Actions",
     key: "actions",
-    width: 260,
+    width: 230,
     align: "right",
-    render: (agent) => h("div", { class: "flex justify-end gap-2" }, [
+    render: (agent) => h("div", { class: "agent-row-actions" }, [
       h(DisabledHint, { disabled: Boolean(busyDisabledReason.value), reason: busyDisabledReason.value }, {
         default: () => h(NButton, {
           secondary: true,
+          circle: true,
           size: "small",
           "aria-label": agent.enabled ? "Disable agent" : "Enable agent",
           title: agent.enabled ? "Disable agent" : "Enable agent",
           disabled: Boolean(busyDisabledReason.value),
           onClick: () => void setAgentEnabled(agent, !agent.enabled),
-        }, { icon: () => agent.enabled ? h(BanIcon, { class: "h-3.5 w-3.5" }) : h(CheckIcon, { class: "h-3.5 w-3.5" }) }),
+        }, { icon: () => agent.enabled ? h(BanIcon, { class: "icon-sm" }) : h(CheckIcon, { class: "icon-sm" }) }),
       }),
       h(DisabledHint, { disabled: Boolean(busyDisabledReason.value), reason: busyDisabledReason.value }, {
         default: () => h(NButton, {
           secondary: true,
+          circle: true,
           size: "small",
           "aria-label": "Rotate token",
           title: "Rotate token",
           disabled: Boolean(busyDisabledReason.value),
           onClick: () => rotateAgentToken(agent),
-        }, { icon: () => h(RefreshIcon, { class: "h-3.5 w-3.5" }) }),
+        }, { icon: () => h(RefreshIcon, { class: "icon-sm" }) }),
       }),
       h(DisabledHint, { disabled: Boolean(busyDisabledReason.value), reason: busyDisabledReason.value }, {
         default: () => h(NButton, {
           secondary: true,
+          circle: true,
           size: "small",
           "aria-label": "Edit agent",
           title: "Edit agent",
           disabled: Boolean(busyDisabledReason.value),
           onClick: () => editAgent(agent),
-        }, { icon: () => h(PencilIcon, { class: "h-3.5 w-3.5" }) }),
+        }, { icon: () => h(PencilIcon, { class: "icon-sm" }) }),
       }),
       h(NButton, {
         secondary: true,
+        circle: true,
         size: "small",
         "aria-label": "Show uninstall command",
         title: "Show uninstall command",
         onClick: () => openUninstallModal(agent),
-      }, { icon: () => h(TimesCircleIcon, { class: "h-3.5 w-3.5" }) }),
+      }, { icon: () => h(TimesCircleIcon, { class: "icon-sm" }) }),
       h(DisabledHint, { disabled: Boolean(deleteAgentDisabledReason(agent)), reason: deleteAgentDisabledReason(agent) }, {
         default: () => h(NButton, {
           type: "error",
+          circle: true,
           size: "small",
           "aria-label": "Delete agent",
           title: "Delete agent",
           disabled: Boolean(deleteAgentDisabledReason(agent)),
           onClick: () => void deleteAgent(agent),
-        }, { icon: () => h(TrashIcon, { class: "h-3.5 w-3.5" }) }),
+        }, { icon: () => h(TrashIcon, { class: "icon-sm" }) }),
       }),
     ]),
   },
@@ -252,13 +373,13 @@ const sessionColumns = computed<DataTableColumns<AgentConnectionSession>>(() => 
     key: "agent",
     minWidth: 220,
     render: (session) => h("div", [
-      h("p", { class: "font-medium text-[var(--app-text)]" }, sessionAgentLabel(session)),
-      sessionAgentDetail(session) ? h("p", { class: "font-mono text-xs text-[var(--app-text-muted)]" }, sessionAgentDetail(session)) : null,
+      h("p", { class: "weight-medium base-text" }, sessionAgentLabel(session)),
+      sessionAgentDetail(session) ? h("p", { class: "mono-text copy-xs muted-text" }, sessionAgentDetail(session)) : null,
     ]),
   },
-  { title: "Started", key: "started", width: 190, render: (session) => h("span", { class: "font-mono text-xs" }, formatDate(session.connectedAtUnixMillis)) },
-  { title: "Ended", key: "ended", width: 190, render: (session) => h("span", { class: "font-mono text-xs" }, session.active ? "-" : formatDate(session.disconnectedAtUnixMillis)) },
-  { title: "Duration", key: "duration", width: 150, render: (session) => h("span", { class: "font-mono text-xs" }, formatLongDuration(session.durationMillis)) },
+  { title: "Started", key: "started", width: 190, render: (session) => h("span", { class: "mono-text copy-xs" }, formatDate(session.connectedAtUnixMillis)) },
+  { title: "Ended", key: "ended", width: 190, render: (session) => h("span", { class: "mono-text copy-xs" }, session.active ? "-" : formatDate(session.disconnectedAtUnixMillis)) },
+  { title: "Duration", key: "duration", width: 150, render: (session) => h("span", { class: "mono-text copy-xs" }, formatLongDuration(session.durationMillis)) },
   {
     title: "State",
     key: "state",
@@ -599,73 +720,97 @@ async function copyUninstallSnippet() {
 </script>
 
 <template>
-  <div v-if="dashboard && status" class="space-y-8">
-    <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-      <div>
-        <h3 class="text-xl font-bold mb-2">Agents</h3>
-        <p class="text-[var(--app-text-muted)] text-sm">Registered agents, connection state, and recent runtime metrics.</p>
+  <div v-if="dashboard && status" class="agent-page stack-xl">
+    <div class="agent-page__header">
+      <div class="min-width-zero">
+        <div class="agent-title-row">
+          <h3 class="copy-xl weight-bold">Agents</h3>
+          <NTag size="small" :bordered="false" :type="fleetStatusType">{{ fleetStatusLabel }}</NTag>
+        </div>
+        <p class="muted-text copy-sm">{{ activeAgentSectionMeta.description }}</p>
       </div>
       <DisabledHint :disabled="Boolean(busyDisabledReason)" :reason="busyDisabledReason">
-        <NButton secondary size="small" :disabled="Boolean(busyDisabledReason)" @click="openAddAgentModal">
-          <template #icon><PlusIcon class="h-3.5 w-3.5" /></template>
+        <NButton type="primary" size="small" :disabled="Boolean(busyDisabledReason)" @click="openAddAgentModal">
+          <template #icon><PlusIcon class="icon-sm" /></template>
           Add Agent
         </NButton>
       </DisabledHint>
     </div>
 
-    <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-      <div class="app-card p-5">
-        <p class="app-card-title">Connected Agents</p>
-        <span class="app-card-value">{{ connectedAgentCount }}/{{ enabledAgents }}</span>
-        <p class="mt-2 text-xs text-[var(--app-text-muted)]">connected / enabled</p>
-      </div>
-      <div class="app-card p-5">
-        <p class="app-card-title">Fleet Uptime</p>
-        <span class="app-card-value">{{ formatPercent(fleetUptime) }}</span>
-        <p class="mt-2 text-xs text-[var(--app-text-muted)]">{{ retentionDaysLabel }} retention</p>
-      </div>
-      <div class="app-card p-5">
-        <p class="app-card-title">Longest Current Uptime</p>
-        <span class="app-card-value">{{ formatLongDuration(longestCurrentUptimeMillis) }}</span>
-        <p class="mt-2 text-xs text-[var(--app-text-muted)]">connected sessions</p>
-      </div>
-      <div class="app-card p-5">
-        <p class="app-card-title">Recent Disconnects</p>
-        <span class="app-card-value">{{ recentDisconnects }}</span>
-        <p class="mt-2 text-xs text-[var(--app-text-muted)]">last 24h</p>
-      </div>
-    </div>
+    <NTabs
+      class="agent-section-tabs"
+      type="line"
+      :value="activeAgentSection"
+      @update:value="selectAgentSection"
+    >
+      <NTab
+        v-for="section in agentSections"
+        :key="section.key"
+        :name="section.key"
+        :tab="section.label"
+      />
+    </NTabs>
 
-    <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-      <div class="app-card p-6">
-        <p class="app-card-title">Memory Usage (Sys)</p>
-        <span class="app-card-value">{{ bigIntLabel(status.latestAgentStats?.memorySysMb) }} MB</span>
+    <section v-if="activeAgentSection === 'fleet'" class="surface-card agent-overview">
+      <div class="agent-overview__main">
+        <div class="agent-overview__heading">
+          <p class="stat-label">Fleet connection</p>
+          <strong>{{ connectedAgentCount }}/{{ enabledAgents }}</strong>
+        </div>
+        <div class="agent-connection-meter" aria-hidden="true">
+          <span :style="connectedAgentPercentStyle"></span>
+        </div>
+        <p class="copy-sm muted-text">{{ fleetSummary }}</p>
+        <div class="agent-overview__tags">
+          <NTag size="small" :bordered="false" type="info">{{ totalAgents }} registered</NTag>
+          <NTag size="small" :bordered="false" type="success">{{ enabledAgents }} enabled</NTag>
+          <NTag v-if="disabledAgents" size="small" :bordered="false" type="warning">{{ disabledAgents }} disabled</NTag>
+        </div>
       </div>
-      <div class="app-card p-6">
-        <p class="app-card-title">Goroutines</p>
-        <span class="app-card-value">{{ bigIntLabel(status.latestAgentStats?.numGoroutine) }}</span>
-      </div>
-      <div class="app-card p-6">
-        <p class="app-card-title">Active Requests</p>
-        <span class="app-card-value">{{ activeAgentRequests }}</span>
-      </div>
-      <div class="app-card p-6">
-        <p class="app-card-title">Avg Memory (1h)</p>
-        <span class="app-card-value">{{ bigIntLabel(oneHourWindow?.agentAvgMemoryMb) }} MB</span>
-      </div>
-      <div class="app-card p-6">
-        <p class="app-card-title">Max Memory (24h)</p>
-        <span class="app-card-value">{{ bigIntLabel(dayWindow?.agentMaxMemoryMb) }} MB</span>
-      </div>
-      <div class="app-card p-6">
-        <p class="app-card-title">Max Goroutines (24h)</p>
-        <span class="app-card-value">{{ bigIntLabel(dayWindow?.agentMaxGoroutines) }}</span>
-      </div>
-    </div>
 
-    <section class="app-card overflow-hidden">
-      <div class="border-b border-[var(--app-border)] px-5 py-4">
-        <h4 class="text-sm font-semibold text-[var(--app-text-muted)] uppercase tracking-widest">Registered Agents</h4>
+      <div class="agent-overview__metrics">
+        <div class="agent-overview__metric">
+          <span>Fleet uptime</span>
+          <strong>{{ formatPercent(fleetUptime) }}</strong>
+          <small>{{ retentionDaysLabel }} retention</small>
+        </div>
+        <div class="agent-overview__metric">
+          <span>Longest live session</span>
+          <strong>{{ formatLongDuration(longestCurrentUptimeMillis) }}</strong>
+          <small>current uptime</small>
+        </div>
+        <div class="agent-overview__metric">
+          <span>Recent disconnects</span>
+          <strong :class="recentDisconnects ? 'warning-text' : 'base-text'">{{ recentDisconnects }}</strong>
+          <small>last 24h</small>
+        </div>
+      </div>
+    </section>
+
+    <section v-if="activeAgentSection === 'activity'" class="surface-card agent-runtime-card">
+      <div class="agent-section-header">
+        <div>
+          <h4>Runtime pressure</h4>
+          <p>Latest agent process stats plus rolling dashboard windows.</p>
+        </div>
+        <NTag size="small" :bordered="false" type="default">{{ activeAgentRequests }} active requests</NTag>
+      </div>
+      <div class="agent-runtime-grid">
+        <div v-for="metric in runtimeMetrics" :key="metric.label" class="agent-runtime-metric">
+          <span>{{ metric.label }}</span>
+          <strong>{{ metric.value }}</strong>
+          <small>{{ metric.detail }}</small>
+        </div>
+      </div>
+    </section>
+
+    <section v-if="activeAgentSection === 'fleet'" class="surface-card hide-overflow agent-table-card">
+      <div class="agent-section-header agent-section-header--table">
+        <div>
+          <h4>Registered agents</h4>
+          <p>Connection state, selector labels, uptime, and host runtime samples.</p>
+        </div>
+        <NTag size="small" :bordered="false" type="default">{{ totalAgents }} total</NTag>
       </div>
       <NDataTable
         v-if="agents.length"
@@ -676,7 +821,7 @@ async function copyUninstallSnippet() {
         :pagination="false"
         :bordered="false"
         :single-line="false"
-        :scroll-x="1280"
+        :scroll-x="1080"
         size="small"
       />
       <EmptyState
@@ -688,16 +833,20 @@ async function copyUninstallSnippet() {
       />
     </section>
 
-    <section class="app-card overflow-hidden">
-      <div class="border-b border-[var(--app-border)] px-5 py-4">
-        <h4 class="text-sm font-semibold text-[var(--app-text-muted)] uppercase tracking-widest">Recent Connection Sessions</h4>
+    <section v-if="activeAgentSection === 'activity'" class="surface-card hide-overflow agent-table-card">
+      <div class="agent-section-header agent-section-header--table">
+        <div>
+          <h4>Recent connection sessions</h4>
+          <p>Connection lifetime history retained for {{ retentionDaysLabel }}.</p>
+        </div>
+        <NTag size="small" :bordered="false" type="default">{{ recentAgentConnections.length }} sessions</NTag>
       </div>
       <NDataTable
         v-if="recentAgentConnections.length"
         :columns="sessionColumns"
         :data="recentAgentConnections"
         :row-key="sessionRowKey"
-        :pagination="false"
+        :pagination="sessionPagination"
         :bordered="false"
         :single-line="false"
         :scroll-x="860"
@@ -725,18 +874,18 @@ async function copyUninstallSnippet() {
       :bordered="false"
       @update:show="handleRotateModalUpdate"
     >
-      <div v-if="rotateAgentToConfirm" class="grid gap-5">
-        <div class="grid gap-2">
-          <p class="text-sm text-[var(--app-text)]">Rotate the token for {{ rotateAgentToConfirm.name }}?</p>
-          <p class="text-sm leading-6 text-[var(--app-text-muted)]">
+      <div v-if="rotateAgentToConfirm" class="layout-grid space-xl">
+        <div class="layout-grid space-sm">
+          <p class="copy-sm base-text">Rotate the token for {{ rotateAgentToConfirm.name }}?</p>
+          <p class="copy-sm line-relaxed muted-text">
             The new token will be shown once. The active agent connection will be disconnected immediately. In-flight requests through this agent may fail, and future connections and stats reports must use the new token.
           </p>
         </div>
-        <div class="rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-3">
-          <span class="mb-1 block text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">Agent ID</span>
-          <code class="block overflow-x-auto font-mono text-xs text-[var(--app-text)]">{{ rotateAgentToConfirm.publicId }}</code>
+        <div class="round-md framed frame-standard muted-bg pad-md">
+          <span class="margin-bottom-xs flow-box copy-xs weight-medium label-case letter-wide muted-text">Agent ID</span>
+          <code class="flow-box scroll-x mono-text copy-xs base-text">{{ rotateAgentToConfirm.publicId }}</code>
         </div>
-        <div class="flex justify-end gap-3">
+        <div class="layout-row align-end-row space-md">
           <DisabledHint :disabled="Boolean(busyDisabledReason)" :reason="busyDisabledReason">
             <NButton secondary attr-type="button" :disabled="Boolean(busyDisabledReason)" @click="closeRotateAgentModal">Cancel</NButton>
           </DisabledHint>
@@ -755,37 +904,37 @@ async function copyUninstallSnippet() {
       :bordered="false"
       @update:show="handleUninstallModalUpdate"
     >
-      <div v-if="uninstallAgent" class="grid gap-5">
-        <div class="grid gap-3 md:grid-cols-2">
-          <div class="grid gap-1.5">
-            <span class="text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">Agent</span>
-            <span class="rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] px-3 py-2 text-sm text-[var(--app-text)]">{{ uninstallAgent.name }}</span>
+      <div v-if="uninstallAgent" class="layout-grid space-xl">
+        <div class="layout-grid space-md mq-md-cols-two">
+          <div class="layout-grid space-xs">
+            <span class="copy-xs weight-medium label-case letter-wide muted-text">Agent</span>
+            <span class="round-md framed frame-standard muted-bg pad-x-md pad-y-sm copy-sm base-text">{{ uninstallAgent.name }}</span>
           </div>
-          <div class="grid gap-1.5">
-            <span class="text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">Agent ID</span>
-            <code class="overflow-x-auto rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] px-3 py-2 font-mono text-xs text-[var(--app-text)]">{{ uninstallAgent.publicId }}</code>
+          <div class="layout-grid space-xs">
+            <span class="copy-xs weight-medium label-case letter-wide muted-text">Agent ID</span>
+            <code class="scroll-x round-md framed frame-standard muted-bg pad-x-md pad-y-sm mono-text copy-xs base-text">{{ uninstallAgent.publicId }}</code>
           </div>
         </div>
 
-        <div class="app-warning-panel p-3 text-xs leading-5">
-          <p class="font-semibold uppercase tracking-wider">Remote host full purge</p>
-          <p class="mt-1 opacity-80">
+        <div class="warning-panel pad-md copy-xs line-normal">
+          <p class="weight-semibold label-case letter-wide">Remote host full purge</p>
+          <p class="margin-top-xs deemphasized">
             Run this command on the Linux host where the shell installer was used. It stops and removes the systemd service, deletes the config directory and binary, and removes the p2pstream service user and group.
           </p>
-          <p class="mt-2 opacity-80">
+          <p class="margin-top-sm deemphasized">
             This does not delete the management agent record. Delete or disable the agent here after the host is removed.
           </p>
         </div>
 
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           GitHub Repository
           <NInput v-model:value="uninstallReleaseRepository" size="small" placeholder="Kirari04/p2pstream" required />
         </label>
 
-        <p v-if="uninstallSnippetError" class="app-error-panel p-3 text-xs leading-5">{{ uninstallSnippetError }}</p>
-        <pre v-else class="max-h-[260px] overflow-auto rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-4 text-xs leading-5 text-[var(--app-text)]"><code>{{ uninstallSnippet }}</code></pre>
+        <p v-if="uninstallSnippetError" class="error-panel pad-md copy-xs line-normal">{{ uninstallSnippetError }}</p>
+        <pre v-else class="max-height-sm scroll-any round-md framed frame-standard muted-bg pad-lg copy-xs line-normal base-text"><code>{{ uninstallSnippet }}</code></pre>
 
-        <div class="flex justify-end gap-3">
+        <div class="layout-row align-end-row space-md">
           <NButton secondary attr-type="button" :disabled="Boolean(uninstallSnippetError)" @click="copyUninstallSnippet">{{ uninstallCopyLabel }}</NButton>
           <NButton type="primary" attr-type="button" @click="closeUninstallModal">Done</NButton>
         </div>
@@ -800,44 +949,48 @@ async function copyUninstallSnippet() {
       :bordered="false"
       @update:show="handleSetupModalUpdate"
     >
-      <div v-if="issuedAgent" class="grid gap-5">
-        <div class="grid gap-3 md:grid-cols-2">
-          <div class="grid gap-1.5">
-            <span class="text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">Agent</span>
-            <span class="rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] px-3 py-2 text-sm text-[var(--app-text)]">{{ issuedAgent.name }}</span>
+      <div v-if="issuedAgent" class="layout-grid space-xl">
+        <div class="layout-grid space-md mq-md-cols-two">
+          <div class="layout-grid space-xs">
+            <span class="copy-xs weight-medium label-case letter-wide muted-text">Agent</span>
+            <span class="round-md framed frame-standard muted-bg pad-x-md pad-y-sm copy-sm base-text">{{ issuedAgent.name }}</span>
           </div>
-          <div class="grid gap-1.5">
-            <span class="text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">Generated ID</span>
-            <code class="overflow-x-auto rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] px-3 py-2 font-mono text-xs text-[var(--app-text)]">{{ issuedAgent.publicId }}</code>
+          <div class="layout-grid space-xs">
+            <span class="copy-xs weight-medium label-case letter-wide muted-text">Generated ID</span>
+            <code class="scroll-x round-md framed frame-standard muted-bg pad-x-md pad-y-sm mono-text copy-xs base-text">{{ issuedAgent.publicId }}</code>
           </div>
         </div>
 
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <NAlert type="warning" :show-icon="false">
+          This token is shown once. Store it before closing this dialog.
+        </NAlert>
+
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           One-Time Token
-          <code class="block break-all rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-3 font-mono text-xs text-[var(--app-text)]">{{ issuedToken }}</code>
+          <code class="flow-box wrap-anywhere round-md framed frame-standard muted-bg pad-md mono-text copy-xs base-text">{{ issuedToken }}</code>
         </label>
 
-        <div v-if="setupIsRotation" class="rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-3 text-xs leading-5 text-[var(--app-text)]">
-          <p class="font-semibold uppercase tracking-wider">Existing Linux agent</p>
-          <p class="mt-1 text-[var(--app-text-muted)]">
+        <div v-if="setupIsRotation" class="round-md framed frame-standard muted-bg pad-md copy-xs line-normal base-text">
+          <p class="weight-semibold label-case letter-wide">Existing Linux agent</p>
+          <p class="margin-top-xs muted-text">
             Run the Linux reinstall command on the existing agent host. It rewrites the agent environment, refreshes embedded management CA material, and restarts p2pstream-agent.
           </p>
         </div>
 
-        <div class="grid gap-3 md:grid-cols-2">
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <div class="layout-grid space-md mq-md-cols-two">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Management URL
             <NInput v-model:value="setupManagementUrl" size="small" required />
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             GitHub Repository
             <NInput v-model:value="setupReleaseRepository" size="small" placeholder="Kirari04/p2pstream" required />
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Release Version
             <NInput v-model:value="setupReleaseVersion" size="small" placeholder="latest, staging, or vX.Y.Z" required />
           </label>
-          <label v-if="setupTab === 'docker'" class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label v-if="setupTab === 'docker'" class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Docker Image
             <NInput
               v-model:value="setupDockerImage"
@@ -848,51 +1001,54 @@ async function copyUninstallSnippet() {
           </label>
         </div>
 
-        <div v-if="!managementUsesTLS" class="app-warning-panel p-3 text-xs leading-5">
-          <p class="font-semibold uppercase tracking-wider">Insecure management URL</p>
-          <p class="mt-1 opacity-80">Agents reject HTTP management URLs by default. Enable the override only for isolated local development.</p>
-          <NCheckbox v-model:checked="setupAllowInsecureManagement" class="mt-3">
+        <div v-if="!managementUsesTLS" class="warning-panel pad-md copy-xs line-normal">
+          <p class="weight-semibold label-case letter-wide">Insecure management URL</p>
+          <p class="margin-top-xs deemphasized">Agents reject HTTP management URLs by default. Enable the override only for isolated local development.</p>
+          <NCheckbox v-model:checked="setupAllowInsecureManagement" class="margin-top-md">
             Allow insecure agent management connection
           </NCheckbox>
         </div>
 
-        <div v-if="managementUsesTLS" class="grid gap-3 md:grid-cols-3">
-          <label v-if="!embeddedManagementCAPEMBase64" class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <div v-if="managementUsesTLS" class="layout-grid space-md mq-md-cols-three">
+          <label v-if="!embeddedManagementCAPEMBase64" class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Management CA file
             <NInput v-model:value="setupManagementCAFile" size="small" placeholder="/etc/p2pstream/management-ca.pem" />
           </label>
-          <div v-else class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <div v-else class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Management CA
-            <div class="rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] px-3 py-2 text-xs normal-case leading-5 tracking-normal text-[var(--app-text)]">
+            <div class="round-md framed frame-standard muted-bg pad-x-md pad-y-sm copy-xs normal-text line-normal letter-normal base-text">
               Embedded pinned CA from this management server
             </div>
           </div>
-          <label v-if="agentClientCertificateRequired" class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label v-if="agentClientCertificateRequired" class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Agent Certificate
             <NInput v-model:value="setupAgentTLSCertFile" size="small" required />
           </label>
-          <label v-if="agentClientCertificateRequired" class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label v-if="agentClientCertificateRequired" class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Agent Key
             <NInput v-model:value="setupAgentTLSKeyFile" size="small" required />
           </label>
         </div>
 
-        <NButtonGroup class="flex flex-wrap" role="tablist" aria-label="Agent setup format" size="small">
-          <NButton
+        <NTabs
+          class="agent-setup-tabs"
+          type="segment"
+          size="small"
+          :value="setupTab"
+          @update:value="(value) => setupTab = value as 'install' | 'docker' | 'cli'"
+        >
+          <NTab
             v-for="tab in setupTabOptions"
             :key="tab.value"
-            attr-type="button"
-            :type="setupTab === tab.value ? 'primary' : 'default'"
-            @click="setupTab = tab.value"
-          >
-            {{ tab.label }}
-          </NButton>
-        </NButtonGroup>
+            :name="tab.value"
+            :tab="tab.label"
+          />
+        </NTabs>
 
-        <p v-if="setupSnippetError" class="app-error-panel p-3 text-xs leading-5">{{ setupSnippetError }}</p>
-        <pre v-else class="max-h-[360px] overflow-auto rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-4 text-xs leading-5 text-[var(--app-text)]"><code>{{ setupSnippet }}</code></pre>
+        <p v-if="setupSnippetError" class="error-panel pad-md copy-xs line-normal">{{ setupSnippetError }}</p>
+        <pre v-else class="max-height-md scroll-any round-md framed frame-standard muted-bg pad-lg copy-xs line-normal base-text"><code>{{ setupSnippet }}</code></pre>
 
-        <div class="flex justify-end gap-3">
+        <div class="layout-row align-end-row space-md">
           <NButton secondary attr-type="button" :disabled="Boolean(setupSnippetError)" @click="copySetupSnippet">{{ setupCopyLabel }}</NButton>
           <NButton type="primary" attr-type="button" @click="clearIssuedToken">Done</NButton>
         </div>
@@ -900,3 +1056,349 @@ async function copyUninstallSnippet() {
     </NModal>
   </div>
 </template>
+
+<style>
+.agent-page__header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.agent-title-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.35rem;
+}
+
+.agent-section-tabs {
+  min-width: 0;
+}
+
+.agent-section-tabs .n-tabs-nav {
+  margin-bottom: 0;
+}
+
+.agent-overview {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.agent-overview__main {
+  display: grid;
+  align-content: start;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.agent-overview__heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.agent-overview__heading strong {
+  color: var(--app-text);
+  font-family: var(--font-mono);
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.agent-connection-meter {
+  height: 0.5rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--app-panel-muted);
+}
+
+.agent-connection-meter span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--app-accent), var(--app-success));
+  transition: width 180ms ease;
+}
+
+.agent-overview__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.agent-overview__metrics {
+  display: grid;
+  overflow: hidden;
+  border: 1px solid var(--app-border-subtle);
+  border-radius: 6px;
+}
+
+.agent-overview__metric {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 0;
+  padding: 0.85rem;
+}
+
+.agent-overview__metric + .agent-overview__metric {
+  border-top: 1px solid var(--app-border-subtle);
+}
+
+.agent-overview__metric span,
+.agent-runtime-metric span {
+  color: var(--app-text-muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.agent-overview__metric strong,
+.agent-runtime-metric strong {
+  color: var(--app-text);
+  font-family: var(--font-mono);
+  font-size: 1.15rem;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.agent-overview__metric small,
+.agent-runtime-metric small {
+  color: var(--app-text-muted);
+  font-size: 0.75rem;
+}
+
+.agent-runtime-card,
+.agent-table-card {
+  overflow: hidden;
+}
+
+.agent-section-header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+  border-bottom: 1px solid var(--app-border);
+  padding: 1rem 1.25rem;
+}
+
+.agent-section-header h4 {
+  margin: 0;
+  color: var(--app-text);
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.agent-section-header p {
+  margin: 0.25rem 0 0;
+  color: var(--app-text-muted);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
+.agent-runtime-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.agent-runtime-metric {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 0;
+  border-top: 1px solid var(--app-border-subtle);
+  padding: 1rem;
+}
+
+.agent-runtime-metric:nth-child(odd) {
+  border-right: 1px solid var(--app-border-subtle);
+}
+
+.agent-cell {
+  display: grid;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+.agent-cell__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.agent-cell__name {
+  min-width: 0;
+  color: var(--app-text);
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.agent-cell__id {
+  color: var(--app-text-muted);
+  font-size: 0.75rem;
+  overflow-wrap: anywhere;
+}
+
+.agent-cell__labels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.agent-selector {
+  display: grid;
+  gap: 0.2rem;
+  max-width: 100%;
+  border-left: 2px solid var(--app-border);
+  padding-left: 0.55rem;
+}
+
+.agent-selector__label {
+  color: var(--app-text-muted);
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.agent-selector__value {
+  color: var(--app-text-muted);
+  font-size: 0.6875rem;
+  overflow-wrap: anywhere;
+}
+
+.agent-state-cell {
+  min-width: 0;
+}
+
+.agent-state-cell__status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.agent-state-dot {
+  width: 0.6rem;
+  height: 0.6rem;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--app-border) 50%, transparent);
+}
+
+.agent-state-dot--connected {
+  background: var(--app-success);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--app-success) 18%, transparent);
+}
+
+.agent-state-dot--offline {
+  background: var(--app-warning);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--app-warning) 18%, transparent);
+}
+
+.agent-compact-stack {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.agent-metric-line {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin: 0;
+  font-size: 0.75rem;
+}
+
+.agent-metric-line strong {
+  font-weight: 700;
+  text-align: right;
+}
+
+.agent-subline {
+  margin: 0;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.agent-row-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.45rem;
+}
+
+.agent-setup-tabs {
+  max-width: 100%;
+}
+
+.agent-setup-tabs .n-tabs-nav {
+  width: min(100%, 32rem);
+}
+
+@media (min-width: 640px) {
+  .agent-page__header,
+  .agent-section-header {
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: space-between;
+  }
+
+  .agent-overview__metrics {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .agent-overview__metric + .agent-overview__metric {
+    border-top: 0;
+    border-left: 1px solid var(--app-border-subtle);
+  }
+
+  .agent-runtime-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .agent-runtime-metric {
+    border-right: 1px solid var(--app-border-subtle);
+  }
+
+  .agent-runtime-metric:nth-child(3n) {
+    border-right: 0;
+  }
+}
+
+@media (min-width: 960px) {
+  .agent-overview {
+    grid-template-columns: minmax(18rem, 0.9fr) minmax(0, 1.4fr);
+    align-items: stretch;
+    padding: 1.25rem;
+  }
+
+  .agent-overview__metrics {
+    align-self: stretch;
+  }
+
+  .agent-runtime-grid {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  .agent-runtime-metric {
+    border-right: 1px solid var(--app-border-subtle);
+  }
+
+  .agent-runtime-metric:nth-child(3n) {
+    border-right: 1px solid var(--app-border-subtle);
+  }
+
+  .agent-runtime-metric:nth-child(6n) {
+    border-right: 0;
+  }
+}
+</style>

--- a/web/management/src/views/Diagnostics.vue
+++ b/web/management/src/views/Diagnostics.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, h, onMounted, ref, watch } from "vue";
-import { NButton, NButtonGroup, NDataTable, NSelect } from "naive-ui";
+import { NAlert, NButton, NButtonGroup, NDataTable, NEmpty, NSelect } from "naive-ui";
 import type { DataTableColumns } from "naive-ui";
 import { useManagementClient } from "@/composables/useManagementClient";
 import type {
@@ -263,7 +263,7 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
       </div>
     </section>
 
-    <section v-if="error" class="diagnostics-error">{{ error }}</section>
+    <NAlert v-if="error" type="error" :show-icon="false">{{ error }}</NAlert>
 
     <section class="summary-strip" :class="{ loading: isLoading }">
       <div class="summary-item">
@@ -317,7 +317,7 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
           </div>
         </div>
       </div>
-      <div v-else class="empty-state">No status codes in this window.</div>
+      <NEmpty v-else size="small" description="No status codes in this window." />
     </section>
 
     <section class="breakdown-grid">
@@ -335,27 +335,30 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
             </div>
           </div>
         </div>
-        <div v-else class="empty-state compact">{{ section.empty }}</div>
+        <NEmpty v-else size="small" class="panel-empty panel-empty--compact" :description="section.empty" />
       </div>
     </section>
 
-    <section class="diagnostics-panel">
+    <section class="diagnostics-panel diagnostics-panel--table">
       <div class="panel-heading">
         <div>
           <h4>Recent Samples</h4>
           <p>Newest non-success responses and proxy/internal failures.</p>
         </div>
       </div>
-      <NDataTable
-        :columns="sampleColumns"
-        :data="recentSamples"
-        :row-key="sampleRowKey"
-        :pagination="false"
-        :bordered="false"
-        :single-line="false"
-        :scroll-x="1530"
-        size="small"
-      />
+      <div v-if="recentSamples.length" class="diagnostics-table-shell">
+        <NDataTable
+          :columns="sampleColumns"
+          :data="recentSamples"
+          :row-key="sampleRowKey"
+          :pagination="false"
+          :bordered="false"
+          :single-line="false"
+          :scroll-x="1530"
+          size="small"
+        />
+      </div>
+      <NEmpty v-else size="small" description="No recent problem samples in this window." />
     </section>
   </div>
 </template>
@@ -367,10 +370,14 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
 }
 
 .diagnostics-header {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: end;
-  justify-content: space-between;
   gap: 1rem;
+}
+
+.diagnostics-header > div:first-child {
+  min-width: 0;
 }
 
 .diagnostics-header h3 {
@@ -387,62 +394,28 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
 }
 
 .header-controls {
-  display: inline-flex;
-  flex-wrap: wrap;
-  justify-content: end;
+  display: grid;
+  grid-template-columns: auto 14rem;
+  align-items: center;
   gap: 0.5rem;
+  justify-content: end;
 }
 
 .window-tabs {
-  display: inline-grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  overflow: hidden;
-  border: 1px solid var(--app-border);
-  border-radius: 6px;
-  background: var(--app-panel-muted);
-  padding: 0.2rem;
+  min-width: 15rem;
 }
 
-.window-tabs button {
+.window-tabs :deep(.n-button) {
   min-width: 0;
   height: 2rem;
-  border-radius: 4px;
-  color: var(--app-text-muted);
   font-size: 0.78rem;
   font-weight: 650;
   letter-spacing: 0;
   padding: 0 0.75rem;
-  transition: background 140ms ease, color 140ms ease;
-}
-
-.window-tabs button:hover {
-  background: var(--app-panel-muted);
-  color: var(--app-text);
-}
-
-.window-tabs button.active {
-  background: var(--app-panel);
-  color: var(--app-text);
 }
 
 .sample-select {
-  height: 2.4rem;
-  border: 1px solid var(--app-border);
-  border-radius: 6px;
-  background: var(--app-panel-muted);
-  color: var(--app-text);
-  font-size: 0.8rem;
-  outline: none;
-  padding: 0 0.6rem;
-}
-
-.diagnostics-error {
-  border: 1px solid rgb(239 68 68 / 45%);
-  border-radius: 6px;
-  background: var(--app-panel-muted);
-  color: var(--app-error);
-  font-size: 0.85rem;
-  padding: 0.85rem 1rem;
+  width: 14rem;
 }
 
 .summary-strip,
@@ -499,6 +472,10 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
   display: grid;
   gap: 1rem;
   padding: 1rem;
+}
+
+.diagnostics-panel--table {
+  overflow: hidden;
 }
 
 .panel-heading {
@@ -655,79 +632,19 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
   white-space: nowrap;
 }
 
-.table-scroll {
+.diagnostics-table-shell {
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
   overflow-x: auto;
 }
 
-.samples-table {
-  width: 100%;
-  min-width: 1120px;
-  border-collapse: collapse;
-  font-size: 0.78rem;
+.diagnostics-table-shell :deep(.n-data-table) {
+  min-width: 0;
 }
 
-.samples-table th,
-.samples-table td {
-  border-top: 1px solid var(--app-border);
-  padding: 0.65rem 0.5rem;
-  text-align: right;
-  white-space: nowrap;
-}
-
-.samples-table th {
-  color: var(--app-text-muted);
-  font-size: 0.68rem;
-  font-weight: 700;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
-.samples-table td {
-  color: var(--app-text);
-}
-
-.samples-table th:first-child,
-.samples-table td:first-child,
-.samples-table th:nth-child(2),
-.samples-table td:nth-child(2),
-.samples-table th:nth-child(3),
-.samples-table td:nth-child(3),
-.samples-table th:nth-child(5),
-.samples-table td:nth-child(5),
-.samples-table th:nth-child(6),
-.samples-table td:nth-child(6),
-.samples-table th:nth-child(7),
-.samples-table td:nth-child(7),
-.samples-table th:nth-child(8),
-.samples-table td:nth-child(8),
-.samples-table th:nth-child(9),
-.samples-table td:nth-child(9) {
-  text-align: left;
-}
-
-.name-cell {
-  max-width: 12rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.empty-state,
-.empty-row {
-  color: var(--app-text-muted);
-  font-size: 0.82rem;
-}
-
-.empty-state {
-  border-top: 1px solid var(--app-border);
-  padding-top: 0.7rem;
-}
-
-.empty-state.compact {
-  font-size: 0.78rem;
-}
-
-.empty-row {
-  text-align: center !important;
+.panel-empty {
+  align-self: start;
 }
 
 @media (min-width: 640px) {
@@ -752,17 +669,19 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width: 860px) {
   .diagnostics-header {
     align-items: stretch;
-    flex-direction: column;
+    grid-template-columns: 1fr;
   }
 
   .header-controls {
+    grid-template-columns: 1fr;
     justify-content: stretch;
   }
 
   .window-tabs {
+    min-width: 0;
     width: 100%;
   }
 

--- a/web/management/src/views/Monitor.vue
+++ b/web/management/src/views/Monitor.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { RouterView, useRoute, useRouter } from "vue-router";
+import { NTab, NTabs } from "naive-ui";
+
+const route = useRoute();
+const router = useRouter();
+
+const monitorSections = [
+  {
+    key: "traffic",
+    label: "Traffic Flow",
+    path: "/monitor/traffic",
+  },
+  {
+    key: "diagnostics",
+    label: "Diagnostics",
+    path: "/monitor/diagnostics",
+  },
+] as const;
+
+type MonitorSectionKey = typeof monitorSections[number]["key"];
+
+const activeSection = computed<MonitorSectionKey>(() =>
+  route.path.includes("/diagnostics") ? "diagnostics" : "traffic",
+);
+
+async function selectSection(value: string | number) {
+  const section = monitorSections.find((item) => item.key === value);
+  if (!section || section.key === activeSection.value) return;
+  await router.push(section.path);
+}
+</script>
+
+<template>
+  <div class="stack-xl monitor-page">
+    <NTabs
+      class="monitor-tabs"
+      type="line"
+      animated
+      :value="activeSection"
+      @update:value="selectSection"
+    >
+      <NTab
+        v-for="section in monitorSections"
+        :key="section.key"
+        :name="section.key"
+        :tab="section.label"
+      />
+    </NTabs>
+
+    <RouterView />
+  </div>
+</template>
+
+<style scoped>
+.monitor-page {
+  gap: 1.25rem;
+}
+
+.monitor-tabs {
+  min-width: 0;
+}
+
+.monitor-tabs :deep(.n-tabs-nav) {
+  margin-bottom: 0;
+}
+</style>

--- a/web/management/src/views/NotFound.vue
+++ b/web/management/src/views/NotFound.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { RouterLink } from "vue-router";
+import { NButton, NResult } from "naive-ui";
+</script>
+
+<template>
+  <div class="not-found-page">
+    <NResult
+      status="404"
+      title="Page not found"
+      description="This management page does not exist."
+    >
+      <template #footer>
+        <div class="not-found-actions">
+          <RouterLink to="/overview" custom>
+            <template #default="{ navigate }">
+              <NButton type="primary" @click="navigate">Go to overview</NButton>
+            </template>
+          </RouterLink>
+          <RouterLink to="/monitor/traffic" custom>
+            <template #default="{ navigate }">
+              <NButton secondary @click="navigate">Open monitor</NButton>
+            </template>
+          </RouterLink>
+        </div>
+      </template>
+    </NResult>
+  </div>
+</template>
+
+<style scoped>
+.not-found-page {
+  display: grid;
+  min-height: min(34rem, 70vh);
+  place-items: center;
+  padding: 2rem 1rem;
+}
+
+.not-found-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+</style>

--- a/web/management/src/views/Overview.vue
+++ b/web/management/src/views/Overview.vue
@@ -276,7 +276,7 @@ function hotspotRowKey(row: DashboardProxyDimensionSummary): string {
 
       <div class="metric-card">
         <p class="metric-kicker">Success</p>
-        <div class="metric-value text-green-300">{{ formatPercent(successRate(selectedWindow)) }}</div>
+        <div class="metric-value success-text">{{ formatPercent(successRate(selectedWindow)) }}</div>
         <p class="metric-subline">{{ formatNumber(nonSuccessRequests(selectedWindow)) }} non-success / {{ formatNumber(proxyFailureRequests(selectedWindow)) }} proxy failures</p>
       </div>
 
@@ -377,7 +377,7 @@ function hotspotRowKey(row: DashboardProxyDimensionSummary): string {
             <p>Selected window plus last-hour error kinds.</p>
           </div>
           <div class="panel-actions">
-            <router-link to="/diagnostics" class="diagnostics-link">View diagnostics</router-link>
+            <router-link to="/monitor/diagnostics" class="diagnostics-link">View diagnostics</router-link>
             <span class="signal-pill" :class="selectedWindow?.proxySlowRequests ? 'warn' : ''">
               {{ formatNumber(selectedWindow?.proxySlowRequests) }} slow
             </span>

--- a/web/management/src/views/ProxyConfig.vue
+++ b/web/management/src/views/ProxyConfig.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, h, ref } from "vue";
-import { NButton, NDataTable, NTag } from "naive-ui";
+import { useRoute, useRouter } from "vue-router";
+import { NButton, NDataTable, NTabPane, NTabs, NTag } from "naive-ui";
 import type { DataTableColumns } from "naive-ui";
 import { Ban as BanIcon } from "@lucide/vue";
 import { Check as CheckIcon } from "@lucide/vue";
@@ -36,7 +37,25 @@ import {
   type PublicListener,
 } from "@/gen/proto/p2pstream/v1/management_pb";
 
+const proxySectionKeys = ["routes", "listeners"] as const;
+type ProxySectionKey = typeof proxySectionKeys[number];
+type ProxySectionSummary = {
+  key: ProxySectionKey;
+  label: string;
+  value: string;
+  detail: string;
+  description: string;
+};
+type ProxySummaryCard = ProxySectionSummary | {
+  key: "targets" | "proxy";
+  label: string;
+  value: string;
+  detail: string;
+};
+
 const managementClient = useManagementClient();
+const route = useRoute();
+const router = useRouter();
 
 const {
   dashboard,
@@ -70,7 +89,7 @@ const listenerColumns = computed<DataTableColumns<PublicListener>>(() => [
     title: "Bind",
     key: "bind",
     minWidth: 180,
-    render: (listener) => h("span", { class: "font-mono text-xs" }, bindLabel(listener)),
+    render: (listener) => h("span", { class: "mono-text copy-xs" }, bindLabel(listener)),
   },
   {
     title: "Protocol",
@@ -88,19 +107,19 @@ const listenerColumns = computed<DataTableColumns<PublicListener>>(() => [
     title: "State",
     key: "state",
     minWidth: 180,
-    render: (listener) => h("div", { class: "flex flex-col gap-1" }, [
+    render: (listener) => h("div", { class: "layout-row layout-column space-2xs" }, [
       h(
         NTag,
         {
           size: "small",
           bordered: false,
           type: naiveTagType(listener.enabled ? severityForState(listenerRuntimeState(listener, listenerStatus(listener))) : "warn"),
-          class: "w-fit",
+          class: "fit-width",
         },
         { default: () => listenerStateLabel(listener, listenerStatus(listener)) },
       ),
       listenerStatus(listener)?.lastError
-        ? h("span", { class: "max-w-[280px] truncate text-xs text-red-400" }, listenerStatus(listener)?.lastError)
+        ? h("span", { class: "max-token-width clip-text copy-xs error-text" }, listenerStatus(listener)?.lastError)
         : null,
     ]),
   },
@@ -109,7 +128,7 @@ const listenerColumns = computed<DataTableColumns<PublicListener>>(() => [
     key: "actions",
     width: 220,
     align: "right",
-    render: (listener) => h("div", { class: "flex justify-end gap-2" }, [
+    render: (listener) => h("div", { class: "layout-row align-end-row space-sm" }, [
       h(
         DisabledHint,
         { disabled: Boolean(busyDisabledReason.value), reason: busyDisabledReason.value },
@@ -124,7 +143,7 @@ const listenerColumns = computed<DataTableColumns<PublicListener>>(() => [
               disabled: Boolean(busyDisabledReason.value),
               onClick: () => void setListenerEnabled(listener, !listener.enabled),
             },
-            { icon: () => listener.enabled ? h(BanIcon, { class: "h-3.5 w-3.5" }) : h(CheckIcon, { class: "h-3.5 w-3.5" }) },
+            { icon: () => listener.enabled ? h(BanIcon, { class: "icon-sm" }) : h(CheckIcon, { class: "icon-sm" }) },
           ),
         },
       ),
@@ -142,7 +161,7 @@ const listenerColumns = computed<DataTableColumns<PublicListener>>(() => [
               disabled: Boolean(listenerRunningDisabledReason(listener)),
               onClick: () => void setListenerRunning(listener, !listenerStatus(listener)?.running),
             },
-            { icon: () => listenerStatus(listener)?.running ? h(TimesIcon, { class: "h-3.5 w-3.5" }) : h(RefreshIcon, { class: "h-3.5 w-3.5" }) },
+            { icon: () => listenerStatus(listener)?.running ? h(TimesIcon, { class: "icon-sm" }) : h(RefreshIcon, { class: "icon-sm" }) },
           ),
         },
       ),
@@ -160,7 +179,7 @@ const listenerColumns = computed<DataTableColumns<PublicListener>>(() => [
               disabled: Boolean(busyDisabledReason.value),
               onClick: () => editListener(listener),
             },
-            { icon: () => h(PencilIcon, { class: "h-3.5 w-3.5" }) },
+            { icon: () => h(PencilIcon, { class: "icon-sm" }) },
           ),
         },
       ),
@@ -178,7 +197,7 @@ const listenerColumns = computed<DataTableColumns<PublicListener>>(() => [
               disabled: Boolean(busyDisabledReason.value),
               onClick: () => void deleteListener(listener.id),
             },
-            { icon: () => h(TrashIcon, { class: "h-3.5 w-3.5" }) },
+            { icon: () => h(TrashIcon, { class: "icon-sm" }) },
           ),
         },
       ),
@@ -189,12 +208,31 @@ const listenerColumns = computed<DataTableColumns<PublicListener>>(() => [
 const editorHost = ref<InstanceType<typeof PublicProxyEditorHost> | null>(null);
 const { confirm } = useConfirmDialog();
 
-const summaryCards = computed(() => [
-  { label: "Listeners", value: listeners.value.length.toString(), detail: `${runningListeners.value.toString()} running` },
-  { label: "Targets", value: routeTargets.value.length.toString(), detail: "proxy and static destinations" },
-  { label: "Routes", value: routes.value.length.toString(), detail: "listener match rules" },
-  { label: "Proxy", value: proxyStateLabel(proxyState.value, status.value?.proxyRunning), detail: proxyIsRunning.value ? "accepting traffic" : "not running" },
+const proxySections = computed<ProxySectionSummary[]>(() => [
+  {
+    key: "routes",
+    label: "Routes",
+    value: routes.value.length.toString(),
+    detail: `${routeTargets.value.length.toString()} route targets`,
+    description: "Rules that match incoming requests to route targets.",
+  },
+  {
+    key: "listeners",
+    label: "Public Listeners",
+    value: listeners.value.length.toString(),
+    detail: `${runningListeners.value.toString()} running`,
+    description: "Incoming endpoints where the proxy accepts connections.",
+  },
 ]);
+const summaryCards = computed<ProxySummaryCard[]>(() => [
+  ...proxySections.value,
+  { key: "targets", label: "Targets", value: routeTargets.value.length.toString(), detail: "proxy and static destinations" },
+  { key: "proxy", label: "Proxy", value: proxyStateLabel(proxyState.value, status.value?.proxyRunning), detail: proxyIsRunning.value ? "accepting traffic" : "not running" },
+]);
+const activeProxySection = computed<ProxySectionKey>(() => normalizeProxySection(route.params.section));
+const activeProxyMeta = computed(() => (
+  proxySections.value.find((section) => section.key === activeProxySection.value) ?? proxySections.value[0]
+));
 
 function listenerStatus(listener: PublicListener) {
   return listenerStatuses.value.find((item) => item.listenerId === listener.id);
@@ -219,6 +257,17 @@ function listenerRunningDisabledReason(listener: PublicListener): string {
 async function run(action: () => Promise<void>) {
   if (!runManagementAction) return;
   await runManagementAction(action);
+}
+
+function normalizeProxySection(value: unknown): ProxySectionKey {
+  const section = Array.isArray(value) ? value[0] : value;
+  return proxySectionKeys.includes(section as ProxySectionKey) ? section as ProxySectionKey : "routes";
+}
+
+async function selectProxySection(value: string | number) {
+  const section = normalizeProxySection(value);
+  if (section === activeProxySection.value) return;
+  await router.push(`/proxy/${section}`);
 }
 
 function openAddListenerModal() {
@@ -277,13 +326,13 @@ async function deleteRoute(id: bigint) {
 </script>
 
 <template>
-  <div v-if="dashboard" class="space-y-8">
-    <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+  <div v-if="dashboard" class="stack-xl">
+    <div class="layout-row layout-column space-lg mq-md-row mq-md-align-end mq-md-spread">
       <div>
-        <h3 class="mb-2 text-xl font-bold">Proxy</h3>
-        <p class="text-sm text-[var(--app-text-muted)]">Public listeners, routes, and route targets.</p>
+        <h3 class="margin-bottom-sm copy-xl weight-bold">Proxy</h3>
+        <p class="copy-sm muted-text">{{ activeProxyMeta.description }}</p>
       </div>
-      <div class="flex items-center gap-3">
+      <div class="layout-row align-center space-md">
         <NTag size="small" :bordered="false" :type="naiveTagType(proxySeverity)">
           {{ proxyStateLabel(proxyState, status?.proxyRunning) }}
         </NTag>
@@ -294,7 +343,7 @@ async function deleteRoute(id: bigint) {
             :disabled="Boolean(busyDisabledReason)"
             @click="setProxyRunning?.(true)"
           >
-            <template #icon><PlusIcon class="h-4 w-4" /></template>
+            <template #icon><PlusIcon class="icon-md icon-md" /></template>
             Start Proxy
           </NButton>
         </DisabledHint>
@@ -305,116 +354,171 @@ async function deleteRoute(id: bigint) {
             :disabled="Boolean(busyDisabledReason)"
             @click="setProxyRunning?.(false)"
           >
-            <template #icon><BanIcon class="h-4 w-4" /></template>
+            <template #icon><BanIcon class="icon-md icon-md" /></template>
             Stop Proxy
           </NButton>
         </DisabledHint>
       </div>
     </div>
 
-    <p v-if="proxyError" class="rounded-md border border-red-900/50 bg-red-950/20 px-4 py-3 text-sm text-red-400">
+    <p v-if="proxyError" class="round-md framed error-border error-surface pad-x-lg pad-y-md copy-sm error-text">
       {{ proxyError }}
     </p>
 
-    <section class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-      <div v-for="card in summaryCards" :key="card.label" class="app-card p-4">
-        <p class="text-xs font-semibold uppercase tracking-widest text-[var(--app-text-muted)]">{{ card.label }}</p>
-        <p class="mt-2 text-2xl font-semibold text-[var(--app-text)]">{{ card.value }}</p>
-        <p class="mt-1 text-xs text-[var(--app-text-muted)]">{{ card.detail }}</p>
+    <section class="summary-grid summary-grid--four proxy-summary-grid" aria-label="Proxy configuration summary">
+      <div
+        v-for="card in summaryCards"
+        :key="card.key"
+        class="surface-card pad-lg proxy-summary-card"
+        :class="{ 'proxy-summary-card--active': card.key === activeProxySection }"
+      >
+        <p class="copy-xs weight-semibold label-case letter-widest muted-text">{{ card.label }}</p>
+        <p class="margin-top-sm copy-2xl weight-semibold base-text">{{ card.value }}</p>
+        <p class="margin-top-xs copy-xs muted-text">{{ card.detail }}</p>
       </div>
     </section>
 
-    <section class="app-card overflow-hidden">
-      <div class="border-b border-[var(--app-border)] px-5 py-4 flex items-center justify-between gap-4">
-        <div>
-          <h4 class="text-sm font-semibold uppercase tracking-widest text-[var(--app-text-muted)]">Public Listeners</h4>
-          <p class="mt-0.5 text-xs text-[var(--app-text-muted)] normal-case tracking-normal">Incoming endpoints where the proxy accepts connections.</p>
-        </div>
-        <NButton secondary size="small" @click="openAddListenerModal">
-          <template #icon><PlusIcon class="h-3.5 w-3.5" /></template>
-          Add Listener
-        </NButton>
-      </div>
-      <div>
-        <NDataTable
-          v-if="listeners.length"
-          :columns="listenerColumns"
-          :data="listeners"
-          :row-key="listenerRowKey"
-          :row-props="listenerRowProps"
-          :pagination="false"
-          :bordered="false"
-          :single-line="false"
-          :scroll-x="900"
-          size="small"
-        />
-        <EmptyState
-          v-else
-          title="No listeners configured"
-          description="Listeners accept public HTTP or HTTPS traffic on published ports."
-          action-label="Add Listener"
-          @action="openAddListenerModal"
-        />
-      </div>
-    </section>
-
-    <section class="app-card overflow-hidden">
-      <div class="border-b border-[var(--app-border)] px-5 py-4 flex items-center justify-between gap-4">
-        <div>
-          <h4 class="text-sm font-semibold uppercase tracking-widest text-[var(--app-text-muted)]">Routes</h4>
-          <p class="mt-0.5 text-xs text-[var(--app-text-muted)] normal-case tracking-normal">Rules that match incoming requests to route targets.</p>
-        </div>
-        <NButton secondary size="small" @click="openAddRouteModal">
-          <template #icon><PlusIcon class="h-3.5 w-3.5" /></template>
-          Add Route
-        </NButton>
-      </div>
-      <div class="divide-y divide-[var(--app-border-subtle)]">
-        <div
-          v-for="route in routes"
-          :key="route.id.toString()"
-          :data-testid="`route-row-${route.id.toString()}`"
-          class="grid gap-3 px-5 py-4 sm:grid-cols-[1fr_auto]"
-        >
-          <div class="min-w-0">
-            <div class="flex min-w-0 items-center gap-2">
-              <p class="truncate text-sm font-medium text-[var(--app-text)]">{{ listenerName(route.listenerId, listeners) }} -> {{ routeDestinationLabel(route) }}</p>
-              <span
-                v-if="routeAction(route) === PublicRouteAction.REDIRECT"
-                class="shrink-0 rounded border border-[var(--app-accent)] px-1.5 py-0.5 text-[0.62rem] font-semibold uppercase tracking-wider text-[var(--app-accent)]"
-              >
-                Redirect
-              </span>
+    <NTabs class="proxy-tabs" type="line" animated :value="activeProxySection" @update:value="selectProxySection">
+      <NTabPane name="routes" :tab="`Routes (${routes.length})`">
+        <section class="surface-card hide-overflow">
+          <div class="divider-bottom frame-standard pad-x-xl pad-y-lg layout-row align-center spread-items space-lg">
+            <div>
+              <h4 class="copy-sm weight-semibold label-case letter-widest muted-text">Routes</h4>
+              <p class="margin-top-2xs copy-xs muted-text normal-text letter-normal">Rules that match incoming requests to route targets.</p>
             </div>
-            <p class="truncate font-mono text-xs text-[var(--app-text-muted)]">
-              {{ route.priority.toString() }} / {{ route.hostPattern || "*" }}{{ route.pathPrefix || "/" }}
-            </p>
-            <p class="truncate font-mono text-xs text-[var(--app-text-muted)]">
-              {{ routeTargetSummary(route) }}
-            </p>
-          </div>
-          <div class="flex gap-2">
-            <NButton secondary size="small" aria-label="Edit route" title="Edit route" @click="editRoute(route.id)">
-              <template #icon><PencilIcon class="h-3.5 w-3.5" /></template>
-            </NButton>
-            <NButton secondary size="small" aria-label="Clone route" title="Clone route" @click="cloneRoute(route.id)">
-              <template #icon><WindowMaximizeIcon class="h-3.5 w-3.5" /></template>
-            </NButton>
-            <NButton type="error" size="small" aria-label="Delete route" title="Delete route" @click="deleteRoute(route.id)">
-              <template #icon><TrashIcon class="h-3.5 w-3.5" /></template>
+            <NButton secondary size="small" @click="openAddRouteModal">
+              <template #icon><PlusIcon class="icon-sm icon-sm" /></template>
+              Add Route
             </NButton>
           </div>
-        </div>
-        <EmptyState
-          v-if="!routes.length"
-          title="No routes configured"
-          description="Routes match hosts and paths before forwarding, redirecting, or using listener defaults."
-          action-label="Add Route"
-          @action="openAddRouteModal"
-        />
-      </div>
-    </section>
+          <div class="divided-list">
+            <div
+              v-for="route in routes"
+              :key="route.id.toString()"
+              :data-testid="`route-row-${route.id.toString()}`"
+              class="layout-grid space-md pad-x-xl pad-y-lg mq-sm-one-auto"
+            >
+              <div class="min-width-zero">
+                <div class="layout-row min-width-zero align-center space-sm">
+                  <p class="clip-text copy-sm weight-medium base-text">{{ listenerName(route.listenerId, listeners) }} -> {{ routeDestinationLabel(route) }}</p>
+                  <span
+                    v-if="routeAction(route) === PublicRouteAction.REDIRECT"
+                    class="no-shrink round-sm framed accent-frame pad-x-xs pad-y-2xs copy-3xs weight-semibold label-case letter-wide accent-text"
+                  >
+                    Redirect
+                  </span>
+                </div>
+                <p class="clip-text mono-text copy-xs muted-text">
+                  {{ route.priority.toString() }} / {{ route.hostPattern || "*" }}{{ route.pathPrefix || "/" }}
+                </p>
+                <p class="clip-text mono-text copy-xs muted-text">
+                  {{ routeTargetSummary(route) }}
+                </p>
+              </div>
+              <div class="layout-row space-sm">
+                <NButton secondary size="small" aria-label="Edit route" title="Edit route" @click="editRoute(route.id)">
+                  <template #icon><PencilIcon class="icon-sm icon-sm" /></template>
+                </NButton>
+                <NButton secondary size="small" aria-label="Clone route" title="Clone route" @click="cloneRoute(route.id)">
+                  <template #icon><WindowMaximizeIcon class="icon-sm icon-sm" /></template>
+                </NButton>
+                <NButton type="error" size="small" aria-label="Delete route" title="Delete route" @click="deleteRoute(route.id)">
+                  <template #icon><TrashIcon class="icon-sm icon-sm" /></template>
+                </NButton>
+              </div>
+            </div>
+            <EmptyState
+              v-if="!routes.length"
+              title="No routes configured"
+              description="Routes match hosts and paths before forwarding, redirecting, or using listener defaults."
+              action-label="Add Route"
+              @action="openAddRouteModal"
+            />
+          </div>
+        </section>
+      </NTabPane>
+
+      <NTabPane name="listeners" :tab="`Public Listeners (${listeners.length})`">
+        <section class="surface-card hide-overflow">
+          <div class="divider-bottom frame-standard pad-x-xl pad-y-lg layout-row align-center spread-items space-lg">
+            <div>
+              <h4 class="copy-sm weight-semibold label-case letter-widest muted-text">Public Listeners</h4>
+              <p class="margin-top-2xs copy-xs muted-text normal-text letter-normal">Incoming endpoints where the proxy accepts connections.</p>
+            </div>
+            <NButton secondary size="small" @click="openAddListenerModal">
+              <template #icon><PlusIcon class="icon-sm icon-sm" /></template>
+              Add Listener
+            </NButton>
+          </div>
+          <div>
+            <NDataTable
+              v-if="listeners.length"
+              :columns="listenerColumns"
+              :data="listeners"
+              :row-key="listenerRowKey"
+              :row-props="listenerRowProps"
+              :pagination="false"
+              :bordered="false"
+              :single-line="false"
+              :scroll-x="900"
+              size="small"
+            />
+            <EmptyState
+              v-else
+              title="No listeners configured"
+              description="Listeners accept public HTTP or HTTPS traffic on published ports."
+              action-label="Add Listener"
+              @action="openAddListenerModal"
+            />
+          </div>
+        </section>
+      </NTabPane>
+    </NTabs>
 
     <PublicProxyEditorHost ref="editorHost" :config="config" />
   </div>
 </template>
+
+<style scoped>
+.proxy-summary-card {
+  min-height: 7rem;
+  padding: 0.875rem;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.proxy-summary-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.proxy-summary-card--active {
+  border-color: var(--app-accent);
+  box-shadow: inset 0 0 0 1px var(--app-accent-soft);
+}
+
+.proxy-summary-card--active .base-text {
+  color: var(--app-accent);
+}
+
+.proxy-tabs {
+  min-width: 0;
+}
+
+.proxy-tabs :deep(.n-tabs-nav) {
+  margin-bottom: 1rem;
+}
+
+.proxy-tabs :deep(.n-tab-pane) {
+  padding-top: 0.25rem;
+}
+
+@media (min-width: 900px) {
+  .proxy-summary-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .proxy-summary-card {
+    min-height: 0;
+    padding: 1rem;
+  }
+}
+</style>

--- a/web/management/src/views/ResponseTemplates.vue
+++ b/web/management/src/views/ResponseTemplates.vue
@@ -123,49 +123,49 @@ async function deleteTemplate(template: PublicResponseTemplate) {
 </script>
 
 <template>
-  <div class="space-y-8">
-    <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+  <div class="stack-xl">
+    <div class="layout-row layout-column space-lg mq-md-row mq-md-align-end mq-md-spread">
       <div>
-        <h3 class="mb-2 text-xl font-bold">Response Templates</h3>
-        <p class="text-sm text-[var(--app-text-muted)]">Reusable static bodies and validated WAF HTML pages.</p>
+        <h3 class="margin-bottom-sm copy-xl weight-bold">Response Templates</h3>
+        <p class="copy-sm muted-text">Reusable static bodies and validated WAF HTML pages.</p>
       </div>
       <NButton type="primary" @click="openCreate()">
-        <template #icon><PlusIcon class="h-3.5 w-3.5" /></template>
+        <template #icon><PlusIcon class="icon-sm icon-sm" /></template>
         Add Template
       </NButton>
     </div>
 
-    <section class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-      <div v-for="card in summaryCards" :key="card.label" class="app-card p-4">
-        <p class="text-xs font-semibold uppercase tracking-widest text-[var(--app-text-muted)]">{{ card.label }}</p>
-        <p class="mt-2 text-2xl font-semibold text-[var(--app-text)]">{{ card.value }}</p>
-        <p class="mt-1 text-xs text-[var(--app-text-muted)]">{{ card.detail }}</p>
+    <section class="layout-grid space-lg mq-sm-cols-two mq-xl-cols-four">
+      <div v-for="card in summaryCards" :key="card.label" class="surface-card pad-lg">
+        <p class="copy-xs weight-semibold label-case letter-widest muted-text">{{ card.label }}</p>
+        <p class="margin-top-sm copy-2xl weight-semibold base-text">{{ card.value }}</p>
+        <p class="margin-top-xs copy-xs muted-text">{{ card.detail }}</p>
       </div>
     </section>
 
-    <section class="app-card overflow-hidden">
-      <div class="border-b border-[var(--app-border)] px-5 py-4">
-        <h4 class="text-sm font-semibold uppercase tracking-widest text-[var(--app-text-muted)]">Templates</h4>
+    <section class="surface-card hide-overflow">
+      <div class="divider-bottom frame-standard pad-x-xl pad-y-lg">
+        <h4 class="copy-sm weight-semibold label-case letter-widest muted-text">Templates</h4>
       </div>
-      <div class="divide-y divide-[var(--app-border-subtle)]">
+      <div class="divided-list">
         <div
           v-for="template in templates"
           :key="template.id.toString()"
           :data-testid="`template-row-${template.id.toString()}`"
-          class="grid gap-3 px-5 py-4 lg:grid-cols-[1fr_auto]"
+          class="layout-grid space-md pad-x-xl pad-y-lg mq-lg-one-auto"
         >
-          <div class="min-w-0">
-            <div class="flex min-w-0 flex-wrap items-center gap-2">
-              <p class="truncate text-sm font-medium text-[var(--app-text)]">{{ template.name }}</p>
+          <div class="min-width-zero">
+            <div class="layout-row min-width-zero wrap-items align-center space-sm">
+              <p class="clip-text copy-sm weight-medium base-text">{{ template.name }}</p>
               <NTag size="small" :bordered="false" type="info">{{ kindLabel(template.kind) }}</NTag>
               <NTag size="small" :bordered="false" :type="naiveTagType(usageCount(template) ? 'warn' : 'info')">{{ usageCount(template).toString() }} uses</NTag>
             </div>
-            <p class="mt-1 truncate text-xs text-[var(--app-text-muted)]">{{ template.description || template.contentType || "No description" }}</p>
-            <p class="mt-1 truncate font-mono text-xs text-[var(--app-text-muted)]">Required: {{ requiredPlaceholderLabel(template.kind) }} / updated {{ formatUpdatedAt(template) }}</p>
+            <p class="margin-top-xs clip-text copy-xs muted-text">{{ template.description || template.contentType || "No description" }}</p>
+            <p class="margin-top-xs clip-text mono-text copy-xs muted-text">Required: {{ requiredPlaceholderLabel(template.kind) }} / updated {{ formatUpdatedAt(template) }}</p>
           </div>
-          <div class="flex gap-2 lg:justify-end">
+          <div class="layout-row space-sm mq-lg-end">
             <NButton secondary size="small" aria-label="Edit template" title="Edit template" @click="openEdit(template)">
-              <template #icon><PencilIcon class="h-3.5 w-3.5" /></template>
+              <template #icon><PencilIcon class="icon-sm icon-sm" /></template>
             </NButton>
             <DisabledHint :disabled="usageCount(template) > 0 || isBusy" :reason="usageCount(template) > 0 ? 'Remove all references before deleting this template.' : ''">
               <NButton
@@ -176,7 +176,7 @@ async function deleteTemplate(template: PublicResponseTemplate) {
                 :disabled="usageCount(template) > 0 || isBusy"
                 @click="deleteTemplate(template)"
               >
-                <template #icon><TrashIcon class="h-3.5 w-3.5" /></template>
+                <template #icon><TrashIcon class="icon-sm icon-sm" /></template>
               </NButton>
             </DisabledHint>
           </div>
@@ -191,7 +191,7 @@ async function deleteTemplate(template: PublicResponseTemplate) {
       </div>
     </section>
 
-    <section class="grid gap-3 sm:grid-cols-3">
+    <section class="layout-grid space-md mq-sm-cols-three">
       <NButton secondary @click="openCreate(PublicResponseTemplateKind.GENERIC_BODY)">New Generic Body</NButton>
       <NButton secondary @click="openCreate(PublicResponseTemplateKind.WAF_CAPTCHA_PAGE)">New Captcha Page</NButton>
       <NButton secondary @click="openCreate(PublicResponseTemplateKind.WAF_WAITING_ROOM_PAGE)">New Waiting Room</NButton>

--- a/web/management/src/views/Settings.vue
+++ b/web/management/src/views/Settings.vue
@@ -4,30 +4,30 @@ import { useRoute } from "vue-router";
 const route = useRoute();
 
 function sectionClass(path: string): string {
-  return route.path === path ? "border-[var(--app-accent)] text-[var(--app-text)]" : "border-transparent text-[var(--app-text-muted)] hover:text-[var(--app-text)]";
+  return route.path === path ? "accent-frame base-text" : "frame-transparent muted-text hover-base-text";
 }
 </script>
 
 <template>
-  <div class="space-y-8">
-    <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+  <div class="stack-xl">
+    <div class="layout-row layout-column space-lg mq-md-row mq-md-align-end mq-md-spread">
       <div>
-        <h3 class="mb-2 text-xl font-bold">Settings</h3>
-        <p class="text-sm text-[var(--app-text-muted)]">Instance configuration, environment registry, and API access.</p>
+        <h3 class="margin-bottom-sm copy-xl weight-bold">Settings</h3>
+        <p class="copy-sm muted-text">Instance configuration, environment registry, and API access.</p>
       </div>
     </div>
 
-    <nav class="flex gap-2 overflow-x-auto border-b border-[var(--app-border)]" aria-label="Settings sections">
+    <nav class="layout-row space-sm scroll-x divider-bottom frame-standard" aria-label="Settings sections">
       <router-link
         to="/settings/environments"
-        class="border-b-2 px-1 pb-3 text-sm font-medium transition-colors"
+        class="base-border-bottom pad-x-2xs pad-bottom-md copy-sm weight-medium layout-transition"
         :class="sectionClass('/settings/environments')"
       >
         Environments
       </router-link>
       <router-link
         to="/settings/api-tokens"
-        class="border-b-2 px-1 pb-3 text-sm font-medium transition-colors"
+        class="base-border-bottom pad-x-2xs pad-bottom-md copy-sm weight-medium layout-transition"
         :class="sectionClass('/settings/api-tokens')"
       >
         API Tokens

--- a/web/management/src/views/SettingsApiTokens.vue
+++ b/web/management/src/views/SettingsApiTokens.vue
@@ -66,13 +66,13 @@ const tokenColumns = computed<DataTableColumns<ManagementAccessToken>>(() => [
     title: "Expires",
     key: "expires",
     width: 180,
-    render: (token) => h("span", { class: "font-mono text-xs" }, formatDate(token.expiresAtUnixMillis)),
+    render: (token) => h("span", { class: "mono-text copy-xs" }, formatDate(token.expiresAtUnixMillis)),
   },
   {
     title: "Last Used",
     key: "lastUsed",
     width: 180,
-    render: (token) => h("span", { class: "font-mono text-xs" }, formatDate(token.lastUsedAtUnixMillis)),
+    render: (token) => h("span", { class: "mono-text copy-xs" }, formatDate(token.lastUsedAtUnixMillis)),
   },
   {
     title: "Status",
@@ -103,7 +103,7 @@ const tokenColumns = computed<DataTableColumns<ManagementAccessToken>>(() => [
             disabled: Boolean(actionDisabledReason.value),
             onClick: () => void deleteToken(token),
           },
-          { icon: () => h(TrashIcon, { class: "h-3.5 w-3.5" }) },
+          { icon: () => h(TrashIcon, { class: "icon-sm" }) },
         ),
       },
     ),
@@ -263,11 +263,11 @@ function handleIssuedTokenModalUpdate(show: boolean) {
 </script>
 
 <template>
-  <div class="space-y-8">
-    <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+  <div class="stack-xl">
+    <div class="layout-row layout-column space-lg mq-md-row mq-md-align-end mq-md-spread">
       <div>
-        <h4 class="mb-2 text-lg font-semibold text-[var(--app-text)]">API Tokens</h4>
-        <p class="text-sm text-[var(--app-text-muted)]">Admin API credentials for {{ selectedEnvironmentLabel }}.</p>
+        <h4 class="margin-bottom-sm copy-lg weight-semibold base-text">API Tokens</h4>
+        <p class="copy-sm muted-text">Admin API credentials for {{ selectedEnvironmentLabel }}.</p>
       </div>
       <DisabledHint :disabled="Boolean(actionDisabledReason)" :reason="actionDisabledReason">
         <NButton
@@ -279,23 +279,23 @@ function handleIssuedTokenModalUpdate(show: boolean) {
           :loading="isLoading"
           @click="refreshTokens"
         >
-          <template #icon><RefreshIcon class="h-3.5 w-3.5" /></template>
+          <template #icon><RefreshIcon class="icon-sm icon-sm" /></template>
         </NButton>
       </DisabledHint>
     </div>
 
-    <div v-if="selectedEnvironmentBlocked" class="rounded-md border border-amber-900/60 bg-[var(--app-panel)] p-4 text-sm text-amber-300">
+    <div v-if="selectedEnvironmentBlocked" class="round-md framed warning-border panel-bg pad-lg copy-sm warning-text">
       {{ selectedEnvironmentBlocked }}
     </div>
-    <div v-if="operationError" class="rounded-md border border-red-900/60 bg-[var(--app-panel)] p-4 text-sm text-red-400">
+    <div v-if="operationError" class="round-md framed error-border panel-bg pad-lg copy-sm error-text">
       {{ operationError }}
     </div>
 
-    <section class="grid gap-6 lg:grid-cols-[1fr_1.25fr]">
-      <div class="app-card p-5">
-        <h5 class="mb-4 text-sm font-semibold uppercase tracking-widest text-[var(--app-text-muted)]">Create API Token</h5>
-        <form class="grid gap-4" @submit.prevent="createToken">
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+    <section class="layout-grid space-2xl settings-token-grid">
+      <div class="surface-card pad-xl">
+        <h5 class="margin-bottom-lg copy-sm weight-semibold label-case letter-widest muted-text">Create API Token</h5>
+        <form class="layout-grid space-lg" @submit.prevent="createToken">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Name
             <NInput
               v-model:value="tokenForm.name"
@@ -304,7 +304,7 @@ function handleIssuedTokenModalUpdate(show: boolean) {
               :disabled="Boolean(actionDisabledReason)"
             />
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Expires
             <NDatePicker
               v-model:value="tokenForm.expiresAtUnixMillis"
@@ -325,9 +325,9 @@ function handleIssuedTokenModalUpdate(show: boolean) {
         </form>
       </div>
 
-      <div class="app-card overflow-hidden">
-        <div class="border-b border-[var(--app-border)] px-5 py-4">
-          <h5 class="text-sm font-semibold uppercase tracking-widest text-[var(--app-text-muted)]">API Tokens</h5>
+      <div class="surface-card hide-overflow">
+        <div class="divider-bottom frame-standard pad-x-xl pad-y-lg">
+          <h5 class="copy-sm weight-semibold label-case letter-widest muted-text">API Tokens</h5>
         </div>
         <NDataTable
           :columns="tokenColumns"
@@ -350,24 +350,24 @@ function handleIssuedTokenModalUpdate(show: boolean) {
       :bordered="false"
       @update:show="handleIssuedTokenModalUpdate"
     >
-      <div class="space-y-4">
-        <div class="rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-4">
-          <div class="mb-2">
-            <p class="text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">One-Time Token</p>
+      <div class="stack-md">
+        <div class="round-md framed frame-standard muted-bg pad-lg">
+          <div class="margin-bottom-sm">
+            <p class="copy-xs weight-medium label-case letter-wide muted-text">One-Time Token</p>
           </div>
           <code
-            class="block min-h-12 break-all rounded-md border border-[var(--app-border)] bg-[var(--app-panel)] p-3 font-mono text-xs leading-6 text-[var(--app-text)]"
+            class="flow-box min-code-height wrap-anywhere round-md framed frame-standard panel-bg pad-md mono-text copy-xs line-relaxed base-text"
           >
             <template v-if="isIssuedTokenVisible">
               {{ issuedToken }}
             </template>
             <template v-else>
-              <span>{{ issuedTokenVisiblePrefix }}</span><span class="inline-block select-none text-[var(--app-text-muted)] blur-[4px]" aria-hidden="true">{{ issuedTokenBlurredRemainder }}</span>
+              <span>{{ issuedTokenVisiblePrefix }}</span><span class="inline-block no-select muted-text secret-blur" aria-hidden="true">{{ issuedTokenBlurredRemainder }}</span>
             </template>
           </code>
         </div>
 
-        <div class="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+        <div class="layout-row layout-column-reverse space-md mq-sm-row mq-sm-end">
           <NButton secondary attr-type="button" @click="clearIssuedToken">Done</NButton>
           <NButton
             secondary
@@ -376,8 +376,8 @@ function handleIssuedTokenModalUpdate(show: boolean) {
             @click="isIssuedTokenVisible = !isIssuedTokenVisible"
           >
             <template #icon>
-              <EyeSlashIcon v-if="isIssuedTokenVisible" class="h-3.5 w-3.5" />
-              <EyeIcon v-else class="h-3.5 w-3.5" />
+              <EyeSlashIcon v-if="isIssuedTokenVisible" class="icon-sm icon-sm" />
+              <EyeIcon v-else class="icon-sm icon-sm" />
             </template>
             {{ isIssuedTokenVisible ? 'Hide' : 'Reveal' }}
           </NButton>

--- a/web/management/src/views/SettingsEnvironments.vue
+++ b/web/management/src/views/SettingsEnvironments.vue
@@ -79,9 +79,9 @@ const environmentColumns = computed<DataTableColumns<Environment>>(() => [
     key: "environment",
     minWidth: 260,
     render: (environment) => h("div", [
-      h("p", { class: "font-medium text-[var(--app-text)]" }, environment.name),
-      h("p", { class: "max-w-md truncate font-mono text-xs text-[var(--app-text-muted)]" }, environment.managementUrl),
-      h("div", { class: "mt-2 flex gap-2" }, [
+      h("p", { class: "weight-medium base-text" }, environment.name),
+      h("p", { class: "max-auth-width clip-text mono-text copy-xs muted-text" }, environment.managementUrl),
+      h("div", { class: "margin-top-sm layout-row space-sm" }, [
         !environment.enabled
           ? h(NTag, { size: "small", bordered: false, type: "warning" }, { default: () => "Disabled" })
           : null,
@@ -96,12 +96,12 @@ const environmentColumns = computed<DataTableColumns<Environment>>(() => [
     key: "transport",
     minWidth: 180,
     render: (environment) => h("div", [
-      h("p", { class: "text-[var(--app-text)]" }, transportLabel(environment.transport)),
+      h("p", { class: "base-text" }, transportLabel(environment.transport)),
       environment.transport === EnvironmentTransport.AGENT
-        ? h("p", { class: "font-mono text-xs text-[var(--app-text-muted)]" }, [
+        ? h("p", { class: "mono-text copy-xs muted-text" }, [
           environment.agentName || `agent #${environment.agentId.toString()}`,
           " ",
-          h("span", { class: environment.agentConnected ? "text-green-400" : "text-amber-400" }, environment.agentConnected ? "connected" : "offline"),
+          h("span", { class: environment.agentConnected ? "success-text" : "warning-text" }, environment.agentConnected ? "connected" : "offline"),
         ])
         : null,
     ]),
@@ -120,35 +120,35 @@ const environmentColumns = computed<DataTableColumns<Environment>>(() => [
     title: "Certificate",
     key: "certificate",
     minWidth: 260,
-    render: (environment) => h("div", { class: "grid max-w-[18rem] gap-1.5" }, [
-      h("p", { class: "truncate text-xs text-[var(--app-text)]", title: certificateSubject(certificateForEnvironment(environment)) }, certificateSubject(certificateForEnvironment(environment))),
+    render: (environment) => h("div", { class: "layout-grid max-token-width space-xs" }, [
+      h("p", { class: "clip-text copy-xs base-text", title: certificateSubject(certificateForEnvironment(environment)) }, certificateSubject(certificateForEnvironment(environment))),
       h(
         "code",
         {
-          class: "inline-flex max-w-full rounded border border-[var(--app-border)] bg-[var(--app-panel-muted)] px-2 py-1 font-mono text-[11px] uppercase tracking-wider text-[var(--app-text)]",
+          class: "inline-row max-full round-sm framed frame-standard muted-bg pad-x-sm pad-y-xs mono-text copy-micro label-case letter-wide base-text",
           title: certificateFingerprintForEnvironment(environment) || "No certificate discovered",
         },
-        [h("span", { class: "truncate" }, formatFingerprint(certificateFingerprintForEnvironment(environment)))],
+        [h("span", { class: "clip-text" }, formatFingerprint(certificateFingerprintForEnvironment(environment)))],
       ),
-      h("p", { class: "text-xs text-[var(--app-text-muted)]" }, `Expires ${formatDate(certificateForEnvironment(environment)?.notAfterUnixMillis)}`),
+      h("p", { class: "copy-xs muted-text" }, `Expires ${formatDate(certificateForEnvironment(environment)?.notAfterUnixMillis)}`),
     ]),
   },
   {
     title: "Test Result",
     key: "testResult",
     minWidth: 220,
-    render: (environment) => h("div", { class: "grid max-w-xs gap-1.5", "aria-live": "polite" }, [
+    render: (environment) => h("div", { class: "layout-grid max-content-sm space-xs", "aria-live": "polite" }, [
       h(
         NTag,
         { size: "small", bordered: false, type: naiveTagType(testResultSeverity(environment)) },
         { default: () => testResultLabel(environment) },
       ),
-      h("p", { class: "font-mono text-xs text-[var(--app-text)]" }, formatDate(testResultCheckedAt(environment))),
+      h("p", { class: "mono-text copy-xs base-text" }, formatDate(testResultCheckedAt(environment))),
       testResultMessage(environment)
         ? h(
           "p",
           {
-            class: ["truncate text-xs", testResultState(environment) === "error" ? "text-red-400" : "text-[var(--app-text-muted)]"],
+            class: ["clip-text copy-xs", testResultState(environment) === "error" ? "error-text" : "muted-text"],
             title: testResultMessage(environment),
           },
           testResultMessage(environment),
@@ -161,7 +161,7 @@ const environmentColumns = computed<DataTableColumns<Environment>>(() => [
     key: "actions",
     width: 300,
     align: "right",
-    render: (environment) => h("div", { class: "flex justify-end gap-2" }, [
+    render: (environment) => h("div", { class: "layout-row align-end-row space-sm" }, [
       h(NButton, {
         secondary: true,
         size: "small",
@@ -169,7 +169,7 @@ const environmentColumns = computed<DataTableColumns<Environment>>(() => [
         title: "Discover certificate",
         disabled: Boolean(busyDisabledReason.value),
         onClick: () => void discoverCertificate(environment),
-      }, { icon: () => h(RefreshIcon, { class: "h-3.5 w-3.5" }) }),
+      }, { icon: () => h(RefreshIcon, { class: "icon-sm" }) }),
       h(NButton, {
         secondary: true,
         size: "small",
@@ -177,7 +177,7 @@ const environmentColumns = computed<DataTableColumns<Environment>>(() => [
         title: "Trust certificate",
         disabled: Boolean(busyDisabledReason.value) || !environment.observedCertificate?.sha256Fingerprint,
         onClick: () => trustCertificate(environment),
-      }, { icon: () => h(CheckIcon, { class: "h-3.5 w-3.5" }) }),
+      }, { icon: () => h(CheckIcon, { class: "icon-sm" }) }),
       h(
         DisabledHint,
         { disabled: Boolean(testEnvironmentDisabledReason(environment)), reason: testEnvironmentDisabledReason(environment) },
@@ -198,7 +198,7 @@ const environmentColumns = computed<DataTableColumns<Environment>>(() => [
         title: "Edit environment",
         disabled: Boolean(busyDisabledReason.value),
         onClick: () => openEditEnvironment(environment),
-      }, { icon: () => h(PencilIcon, { class: "h-3.5 w-3.5" }) }),
+      }, { icon: () => h(PencilIcon, { class: "icon-sm" }) }),
       h(NButton, {
         type: "error",
         size: "small",
@@ -206,7 +206,7 @@ const environmentColumns = computed<DataTableColumns<Environment>>(() => [
         title: "Delete environment",
         disabled: Boolean(busyDisabledReason.value),
         onClick: () => void deleteEnvironment(environment),
-      }, { icon: () => h(TrashIcon, { class: "h-3.5 w-3.5" }) }),
+      }, { icon: () => h(TrashIcon, { class: "icon-sm" }) }),
     ]),
   },
 ]);
@@ -537,27 +537,27 @@ function handleTrustModalUpdate(show: boolean) {
 </script>
 
 <template>
-  <div class="space-y-8">
-    <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+  <div class="stack-xl">
+    <div class="layout-row layout-column space-lg mq-md-row mq-md-align-end mq-md-spread">
       <div>
-        <h4 class="mb-2 text-lg font-semibold text-[var(--app-text)]">Environments</h4>
-        <p class="text-sm text-[var(--app-text-muted)]">Remote management endpoints, routing, and certificate trust.</p>
+        <h4 class="margin-bottom-sm copy-lg weight-semibold base-text">Environments</h4>
+        <p class="copy-sm muted-text">Remote management endpoints, routing, and certificate trust.</p>
       </div>
       <DisabledHint :disabled="Boolean(busyDisabledReason)" :reason="busyDisabledReason">
         <NButton secondary size="small" :disabled="Boolean(busyDisabledReason)" @click="openCreateEnvironment">
-          <template #icon><PlusIcon class="h-3.5 w-3.5" /></template>
+          <template #icon><PlusIcon class="icon-sm icon-sm" /></template>
           Add Environment
         </NButton>
       </DisabledHint>
     </div>
 
-    <div v-if="operationError" class="rounded-md border border-red-900/60 bg-[var(--app-panel)] p-4 text-sm text-red-400">
+    <div v-if="operationError" class="round-md framed error-border panel-bg pad-lg copy-sm error-text">
       {{ operationError }}
     </div>
 
-    <section class="app-card overflow-hidden">
-      <div class="border-b border-[var(--app-border)] px-5 py-4">
-        <h5 class="text-sm font-semibold uppercase tracking-widest text-[var(--app-text-muted)]">Registered Environments</h5>
+    <section class="surface-card hide-overflow">
+      <div class="divider-bottom frame-standard pad-x-xl pad-y-lg">
+        <h5 class="copy-sm weight-semibold label-case letter-widest muted-text">Registered Environments</h5>
       </div>
       <NDataTable
         :columns="environmentColumns"
@@ -578,18 +578,18 @@ function handleTrustModalUpdate(show: boolean) {
       :style="modalCardStyle('42rem')"
       :bordered="false"
     >
-      <form class="grid max-h-[calc(100vh-9rem)] gap-4 overflow-y-auto pr-1" @submit.prevent="submitEnvironment">
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+      <form class="layout-grid max-modal-height space-lg scroll-y pad-right-xs" @submit.prevent="submitEnvironment">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Name
           <NInput v-model:value="environmentForm.name" size="small" required />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Management URL
           <NInput v-model:value="environmentForm.managementUrl" size="small" placeholder="https://proxy.example.com:8081" required />
         </label>
-        <div class="grid gap-2 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <div class="layout-grid space-sm copy-xs weight-medium label-case letter-wide muted-text">
           Transport
-          <NButtonGroup class="w-fit" size="small">
+          <NButtonGroup class="fit-width" size="small">
             <NButton
               v-for="option in environmentTransportOptions"
               :key="option.value"
@@ -601,11 +601,11 @@ function handleTrustModalUpdate(show: boolean) {
             </NButton>
           </NButtonGroup>
         </div>
-        <label v-if="environmentForm.transport === EnvironmentTransport.AGENT" class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label v-if="environmentForm.transport === EnvironmentTransport.AGENT" class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Local Agent
           <NSelect v-model:value="environmentForm.agentId" size="small" :options="localAgentOptions" required />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Access Token
           <NInput
             v-model:value="environmentForm.accessToken"
@@ -614,14 +614,14 @@ function handleTrustModalUpdate(show: boolean) {
             :required="!environmentForm.id"
           />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Response Header Timeout
           <NInputNumber v-model:value="environmentForm.responseHeaderTimeoutMillis" size="small" :min="1000" :max="300000" required />
         </label>
         <NCheckbox v-model:checked="environmentForm.enabled">
           Enabled
         </NCheckbox>
-        <div class="mt-4 flex justify-end gap-3">
+        <div class="margin-top-lg layout-row align-end-row space-md">
           <NButton secondary attr-type="button" @click="isEnvironmentModalOpen = false">Cancel</NButton>
           <NButton type="primary" attr-type="submit" :disabled="Boolean(busyDisabledReason)">
             {{ environmentForm.id ? 'Save Changes' : 'Create Environment' }}
@@ -637,51 +637,51 @@ function handleTrustModalUpdate(show: boolean) {
       :bordered="false"
       @update:show="handleTrustModalUpdate"
     >
-      <div class="grid gap-5">
-        <div class="rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] p-4">
-          <div class="grid gap-4">
-            <div class="grid gap-1">
-              <p class="text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">Environment</p>
-              <p class="truncate text-sm text-[var(--app-text)]" :title="certificateTrustEnvironment?.name">
+      <div class="layout-grid space-xl">
+        <div class="round-md framed frame-standard muted-bg pad-lg">
+          <div class="layout-grid space-lg">
+            <div class="layout-grid space-2xs">
+              <p class="copy-xs weight-medium label-case letter-wide muted-text">Environment</p>
+              <p class="clip-text copy-sm base-text" :title="certificateTrustEnvironment?.name">
                 {{ certificateTrustEnvironment?.name }}
               </p>
             </div>
-            <div class="grid gap-1">
-              <p class="text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">SHA-256 Fingerprint</p>
+            <div class="layout-grid space-2xs">
+              <p class="copy-xs weight-medium label-case letter-wide muted-text">SHA-256 Fingerprint</p>
               <code
-                class="block max-w-full truncate rounded-md border border-[var(--app-border)] bg-[var(--app-panel)] px-3 py-2 font-mono text-xs uppercase tracking-wider text-[var(--app-text)]"
+                class="flow-box max-full clip-text round-md framed frame-standard panel-bg pad-x-md pad-y-sm mono-text copy-xs label-case letter-wide base-text"
                 :title="certificateTrustFingerprint"
               >
                 {{ formatFingerprint(certificateTrustFingerprint) }}
               </code>
             </div>
-            <div class="grid gap-1">
-              <p class="text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">Subject</p>
-              <p class="truncate text-sm text-[var(--app-text)]" :title="certificateSubject(certificateTrustCertificate)">
+            <div class="layout-grid space-2xs">
+              <p class="copy-xs weight-medium label-case letter-wide muted-text">Subject</p>
+              <p class="clip-text copy-sm base-text" :title="certificateSubject(certificateTrustCertificate)">
                 {{ certificateSubject(certificateTrustCertificate) }}
               </p>
             </div>
-            <div v-if="certificateTrustCertificate?.issuer" class="grid gap-1">
-              <p class="text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">Issuer</p>
-              <p class="truncate text-sm text-[var(--app-text)]" :title="certificateTrustCertificate.issuer">
+            <div v-if="certificateTrustCertificate?.issuer" class="layout-grid space-2xs">
+              <p class="copy-xs weight-medium label-case letter-wide muted-text">Issuer</p>
+              <p class="clip-text copy-sm base-text" :title="certificateTrustCertificate.issuer">
                 {{ certificateTrustCertificate.issuer }}
               </p>
             </div>
-            <div v-if="certificateSanSummary(certificateTrustCertificate)" class="grid gap-1">
-              <p class="text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">Names</p>
-              <p class="truncate text-sm text-[var(--app-text)]" :title="certificateSanSummary(certificateTrustCertificate)">
+            <div v-if="certificateSanSummary(certificateTrustCertificate)" class="layout-grid space-2xs">
+              <p class="copy-xs weight-medium label-case letter-wide muted-text">Names</p>
+              <p class="clip-text copy-sm base-text" :title="certificateSanSummary(certificateTrustCertificate)">
                 {{ certificateSanSummary(certificateTrustCertificate) }}
               </p>
             </div>
-            <div class="grid gap-1">
-              <p class="text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">Valid Until</p>
-              <p class="font-mono text-xs text-[var(--app-text)]">
+            <div class="layout-grid space-2xs">
+              <p class="copy-xs weight-medium label-case letter-wide muted-text">Valid Until</p>
+              <p class="mono-text copy-xs base-text">
                 {{ formatDate(certificateTrustCertificate?.notAfterUnixMillis) }}
               </p>
             </div>
           </div>
         </div>
-        <div class="flex justify-end gap-3">
+        <div class="layout-row align-end-row space-md">
           <NButton secondary attr-type="button" @click="closeTrustCertificateModal">Cancel</NButton>
           <NButton
             type="primary"

--- a/web/management/src/views/TlsConfig.vue
+++ b/web/management/src/views/TlsConfig.vue
@@ -358,67 +358,67 @@ watch(tlsDnsCredentials, () => {
 </script>
 
 <template>
-  <div v-if="dashboard" class="space-y-8">
-    <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+  <div v-if="dashboard" class="stack-xl">
+    <div class="layout-row layout-column space-lg mq-md-row mq-md-align-end mq-md-spread">
       <div>
-        <h3 class="mb-2 text-xl font-bold">TLS</h3>
-        <p class="text-sm text-[var(--app-text-muted)]">HTTPS certificate mappings and DNS credentials.</p>
+        <h3 class="margin-bottom-sm copy-xl weight-bold">TLS</h3>
+        <p class="copy-sm muted-text">HTTPS certificate mappings and DNS credentials.</p>
       </div>
-      <div class="flex flex-wrap gap-2">
+      <div class="layout-row wrap-items space-sm">
         <NButton secondary size="small" @click="openAddTlsCredentialModal">
-          <template #icon><PlusIcon class="h-3.5 w-3.5" /></template>
+          <template #icon><PlusIcon class="icon-sm icon-sm" /></template>
           Add DNS Credential
         </NButton>
         <NButton secondary size="small" @click="openAddTlsModal">
-          <template #icon><PlusIcon class="h-3.5 w-3.5" /></template>
+          <template #icon><PlusIcon class="icon-sm icon-sm" /></template>
           Add Certificate
         </NButton>
       </div>
     </div>
 
-    <section class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-      <div v-for="card in summaryCards" :key="card.label" class="app-card p-4">
-        <p class="text-xs font-semibold uppercase tracking-widest text-[var(--app-text-muted)]">{{ card.label }}</p>
-        <p class="mt-2 text-2xl font-semibold text-[var(--app-text)]">{{ card.value }}</p>
-        <p class="mt-1 text-xs text-[var(--app-text-muted)]">{{ card.detail }}</p>
+    <section class="layout-grid space-lg mq-sm-cols-two mq-xl-cols-four">
+      <div v-for="card in summaryCards" :key="card.label" class="surface-card pad-lg">
+        <p class="copy-xs weight-semibold label-case letter-widest muted-text">{{ card.label }}</p>
+        <p class="margin-top-sm copy-2xl weight-semibold base-text">{{ card.value }}</p>
+        <p class="margin-top-xs copy-xs muted-text">{{ card.detail }}</p>
       </div>
     </section>
 
-    <section class="app-card overflow-hidden">
-      <div class="border-b border-[var(--app-border)] px-5 py-4 flex items-center justify-between gap-4">
+    <section class="surface-card hide-overflow">
+      <div class="divider-bottom frame-standard pad-x-xl pad-y-lg layout-row align-center spread-items space-lg">
         <div>
-          <h4 class="text-sm font-semibold uppercase tracking-widest text-[var(--app-text-muted)]">TLS Certificates</h4>
-          <p class="mt-0.5 text-xs text-[var(--app-text-muted)] normal-case tracking-normal">Certificates for HTTPS listeners.</p>
+          <h4 class="copy-sm weight-semibold label-case letter-widest muted-text">TLS Certificates</h4>
+          <p class="margin-top-2xs copy-xs muted-text normal-text letter-normal">Certificates for HTTPS listeners.</p>
         </div>
         <NButton secondary size="small" @click="openAddTlsModal">
-          <template #icon><PlusIcon class="h-3.5 w-3.5" /></template>
+          <template #icon><PlusIcon class="icon-sm icon-sm" /></template>
           Add Certificate
         </NButton>
       </div>
-      <div class="divide-y divide-[var(--app-border-subtle)]">
+      <div class="divided-list">
         <div
           v-for="cert in tlsCertificates"
           :key="cert.id.toString()"
           :data-testid="`tls-row-${cert.id.toString()}`"
-          class="grid gap-3 px-5 py-4 sm:grid-cols-[1fr_auto]"
+          class="layout-grid space-md pad-x-xl pad-y-lg mq-sm-one-auto"
         >
-          <div class="min-w-0">
-            <div class="flex min-w-0 items-center gap-2">
-              <p class="truncate text-sm font-medium text-[var(--app-text)]">{{ listenerName(cert.listenerId, listeners) }} / {{ cert.hostnamePattern }}</p>
+          <div class="min-width-zero">
+            <div class="layout-row min-width-zero align-center space-sm">
+              <p class="clip-text copy-sm weight-medium base-text">{{ listenerName(cert.listenerId, listeners) }} / {{ cert.hostnamePattern }}</p>
               <NTag v-if="isDefaultSelfSignedCertificate(cert)" size="small" :bordered="false" type="info">Self-signed</NTag>
               <NTag v-else size="small" :bordered="false" type="info">{{ tlsSourceLabel(cert) }}</NTag>
               <NTag size="small" :bordered="false" :type="naiveTagType(tlsStatusSeverity(cert))">{{ tlsStatusLabel(cert) }}</NTag>
             </div>
-            <p class="truncate text-xs text-[var(--app-text-muted)]">{{ tlsCertificateSummary(cert) }}</p>
-            <p v-if="tlsCertificateValiditySummary(cert)" class="truncate text-xs text-[var(--app-text-muted)]">{{ tlsCertificateValiditySummary(cert) }}</p>
-            <p v-if="tlsCertificateRenewalSummary(cert)" class="truncate text-xs text-[var(--app-text-muted)]">{{ tlsCertificateRenewalSummary(cert) }}</p>
-            <p v-if="tlsCertificateLastAttemptSummary(cert)" class="truncate text-xs text-[var(--app-text-muted)]">{{ tlsCertificateLastAttemptSummary(cert) }}</p>
-            <p v-if="cert.source === PublicTlsCertificateSource.ACME && cert.dnsCredentialId" class="truncate text-xs text-[var(--app-text-muted)]">
+            <p class="clip-text copy-xs muted-text">{{ tlsCertificateSummary(cert) }}</p>
+            <p v-if="tlsCertificateValiditySummary(cert)" class="clip-text copy-xs muted-text">{{ tlsCertificateValiditySummary(cert) }}</p>
+            <p v-if="tlsCertificateRenewalSummary(cert)" class="clip-text copy-xs muted-text">{{ tlsCertificateRenewalSummary(cert) }}</p>
+            <p v-if="tlsCertificateLastAttemptSummary(cert)" class="clip-text copy-xs muted-text">{{ tlsCertificateLastAttemptSummary(cert) }}</p>
+            <p v-if="cert.source === PublicTlsCertificateSource.ACME && cert.dnsCredentialId" class="clip-text copy-xs muted-text">
               Cloudflare / {{ dnsCredentialName(cert.dnsCredentialId, tlsDnsCredentials) }}
             </p>
-            <p v-if="cert.lastError" class="whitespace-pre-wrap break-words text-xs text-red-400">Last error: {{ cert.lastError }}</p>
+            <p v-if="cert.lastError" class="preserve-lines wrap-anywhere copy-xs error-text">Last error: {{ cert.lastError }}</p>
           </div>
-          <div class="flex gap-2">
+          <div class="layout-row space-sm">
             <DisabledHint
               v-if="cert.source === PublicTlsCertificateSource.ACME"
               :disabled="Boolean(busyDisabledReason)"
@@ -432,24 +432,24 @@ watch(tlsDnsCredentials, () => {
                 :disabled="Boolean(busyDisabledReason)"
                 @click="renewTlsCertificate(cert.id)"
               >
-                <template #icon><RefreshIcon class="h-3.5 w-3.5" /></template>
+                <template #icon><RefreshIcon class="icon-sm icon-sm" /></template>
               </NButton>
             </DisabledHint>
             <NButton secondary size="small" aria-label="Edit TLS mapping" title="Edit TLS mapping" @click="editTlsCertificate(cert.id)">
-              <template #icon><PencilIcon class="h-3.5 w-3.5" /></template>
+              <template #icon><PencilIcon class="icon-sm icon-sm" /></template>
             </NButton>
             <NButton type="error" size="small" aria-label="Delete TLS mapping" title="Delete TLS mapping" @click="deleteTlsCertificate(cert.id)">
-              <template #icon><TrashIcon class="h-3.5 w-3.5" /></template>
+              <template #icon><TrashIcon class="icon-sm icon-sm" /></template>
             </NButton>
           </div>
         </div>
-        <div v-if="httpsListeners.length && !tlsCertificates.length" class="grid gap-3 px-5 py-4 sm:grid-cols-[1fr_auto]">
-          <div class="min-w-0">
-            <div class="flex min-w-0 items-center gap-2">
-              <p class="truncate text-sm font-medium text-[var(--app-text)]">{{ httpsListeners[0]?.name ?? "HTTPS listener" }} / p2pstream.local</p>
+        <div v-if="httpsListeners.length && !tlsCertificates.length" class="layout-grid space-md pad-x-xl pad-y-lg mq-sm-one-auto">
+          <div class="min-width-zero">
+            <div class="layout-row min-width-zero align-center space-sm">
+              <p class="clip-text copy-sm weight-medium base-text">{{ httpsListeners[0]?.name ?? "HTTPS listener" }} / p2pstream.local</p>
               <NTag size="small" :bordered="false" type="info">Self-signed</NTag>
             </div>
-            <p class="truncate text-xs text-[var(--app-text-muted)]">Runtime fallback certificate</p>
+            <p class="clip-text copy-xs muted-text">Runtime fallback certificate</p>
           </div>
         </div>
         <EmptyState
@@ -460,33 +460,33 @@ watch(tlsDnsCredentials, () => {
       </div>
     </section>
 
-    <section class="app-card overflow-hidden">
-      <div class="border-b border-[var(--app-border)] px-5 py-4 flex items-center justify-between gap-4">
+    <section class="surface-card hide-overflow">
+      <div class="divider-bottom frame-standard pad-x-xl pad-y-lg layout-row align-center spread-items space-lg">
         <div>
-          <h4 class="text-sm font-semibold uppercase tracking-widest text-[var(--app-text-muted)]">DNS Credentials</h4>
-          <p class="mt-0.5 text-xs text-[var(--app-text-muted)] normal-case tracking-normal">Credentials used for DNS-01 certificate challenges.</p>
+          <h4 class="copy-sm weight-semibold label-case letter-widest muted-text">DNS Credentials</h4>
+          <p class="margin-top-2xs copy-xs muted-text normal-text letter-normal">Credentials used for DNS-01 certificate challenges.</p>
         </div>
         <NButton secondary size="small" @click="openAddTlsCredentialModal">
-          <template #icon><PlusIcon class="h-3.5 w-3.5" /></template>
+          <template #icon><PlusIcon class="icon-sm icon-sm" /></template>
           Add DNS Credential
         </NButton>
       </div>
-      <div class="divide-y divide-[var(--app-border-subtle)]">
-        <div v-for="credential in tlsDnsCredentials" :key="credential.id.toString()" class="grid gap-3 px-5 py-4 sm:grid-cols-[1fr_auto]">
-          <div class="min-w-0">
-            <div class="flex min-w-0 items-center gap-2">
-              <p class="truncate text-sm font-medium text-[var(--app-text)]">{{ credential.name }}</p>
+      <div class="divided-list">
+        <div v-for="credential in tlsDnsCredentials" :key="credential.id.toString()" class="layout-grid space-md pad-x-xl pad-y-lg mq-sm-one-auto">
+          <div class="min-width-zero">
+            <div class="layout-row min-width-zero align-center space-sm">
+              <p class="clip-text copy-sm weight-medium base-text">{{ credential.name }}</p>
               <NTag size="small" :bordered="false" type="info">Cloudflare</NTag>
               <NTag v-if="!credential.enabled" size="small" :bordered="false" type="warning">Disabled</NTag>
             </div>
-            <p class="truncate font-mono text-xs text-[var(--app-text-muted)]">{{ credential.cloudflareZoneId }}</p>
+            <p class="clip-text mono-text copy-xs muted-text">{{ credential.cloudflareZoneId }}</p>
           </div>
-          <div class="flex gap-2">
+          <div class="layout-row space-sm">
             <NButton secondary size="small" aria-label="Edit DNS credential" title="Edit DNS credential" @click="editTlsCredential(credential)">
-              <template #icon><PencilIcon class="h-3.5 w-3.5" /></template>
+              <template #icon><PencilIcon class="icon-sm icon-sm" /></template>
             </NButton>
             <NButton type="error" size="small" aria-label="Delete DNS credential" title="Delete DNS credential" @click="deleteTlsCredential(credential.id)">
-              <template #icon><TrashIcon class="h-3.5 w-3.5" /></template>
+              <template #icon><TrashIcon class="icon-sm icon-sm" /></template>
             </NButton>
           </div>
         </div>
@@ -507,10 +507,10 @@ watch(tlsDnsCredentials, () => {
       :style="modalCardStyle('36rem')"
       :bordered="false"
     >
-      <form class="grid max-h-[calc(100vh-9rem)] gap-4 overflow-y-auto pr-1" @submit.prevent="submitTlsCertificate">
-        <div class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+      <form class="layout-grid max-modal-height space-lg scroll-y pad-right-xs" @submit.prevent="submitTlsCertificate">
+        <div class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Method
-          <NButtonGroup class="grid grid-cols-2 gap-2 sm:grid-cols-4" size="small">
+          <NButtonGroup class="layout-grid cols-two space-sm mq-sm-cols-four" size="small">
             <NButton
               v-for="method in tlsMethodOptions"
               :key="method.value"
@@ -522,36 +522,36 @@ watch(tlsDnsCredentials, () => {
             </NButton>
           </NButtonGroup>
         </div>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           HTTPS listener
           <NSelect v-model:value="tlsForm.listenerId" size="small" :options="httpsListenerOptions" required />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Hostname pattern
           <NInput v-model:value="tlsForm.hostnamePattern" size="small" placeholder="app.example.com" required />
-          <p class="text-xs font-normal normal-case tracking-normal text-[var(--app-text-muted)]">Exact domain or wildcard prefix (*.example.com).</p>
+          <p class="copy-xs weight-normal normal-text letter-normal muted-text">Exact domain or wildcard prefix (*.example.com).</p>
         </label>
-        <div v-if="tlsForm.method !== 'manual'" class="grid gap-3">
-          <div class="grid gap-3 sm:grid-cols-2">
-            <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <div v-if="tlsForm.method !== 'manual'" class="layout-grid space-md">
+          <div class="layout-grid space-md mq-sm-cols-two">
+            <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
               ACME email
               <NInput v-model:value="tlsForm.acmeEmail" size="small" type="text" placeholder="admin@example.com" required />
-              <p class="text-xs font-normal normal-case tracking-normal text-[var(--app-text-muted)]">Used for certificate expiration notices from Let's Encrypt.</p>
+              <p class="copy-xs weight-normal normal-text letter-normal muted-text">Used for certificate expiration notices from Let's Encrypt.</p>
             </label>
-            <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+            <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
               CA environment
               <NSelect v-model:value="tlsForm.acmeCa" size="small" :options="acmeCaOptions" />
             </label>
           </div>
-          <label v-if="tlsForm.method === 'dns_01'" class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label v-if="tlsForm.method === 'dns_01'" class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Cloudflare credential
             <NSelect v-model:value="tlsForm.dnsCredentialId" size="small" :options="dnsCredentialOptions" required />
           </label>
         </div>
-        <div v-if="tlsForm.method === 'manual'" class="grid gap-3">
-          <div class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <div v-if="tlsForm.method === 'manual'" class="layout-grid space-md">
+          <div class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Certificate material
-            <NButtonGroup class="grid grid-cols-2 gap-2" size="small">
+            <NButtonGroup class="layout-grid cols-two space-sm" size="small">
               <NButton
                 v-for="option in manualTlsMaterialOptions"
                 :key="option.value"
@@ -563,12 +563,12 @@ watch(tlsDnsCredentials, () => {
               </NButton>
             </NButtonGroup>
           </div>
-          <label v-if="tlsForm.manualMode === 'generate'" class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label v-if="tlsForm.manualMode === 'generate'" class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Validity days
             <NInputNumber v-model:value="tlsForm.selfSignedValidityDays" size="small" :min="1" :max="3650" :step="1" required />
           </label>
-          <div v-else class="grid gap-3 sm:grid-cols-2">
-            <div class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <div v-else class="layout-grid space-md mq-sm-cols-two">
+            <div class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
               Certificate file
               <NUpload
                 :default-upload="false"
@@ -578,9 +578,9 @@ watch(tlsDnsCredentials, () => {
               >
                 <NButton secondary size="small" attr-type="button">Choose certificate</NButton>
               </NUpload>
-              <span v-if="tlsForm.certFileName" class="truncate text-xs normal-case tracking-normal text-[var(--app-text)]">{{ tlsForm.certFileName }}</span>
+              <span v-if="tlsForm.certFileName" class="clip-text copy-xs normal-text letter-normal base-text">{{ tlsForm.certFileName }}</span>
             </div>
-            <div class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+            <div class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
               Private key file
               <NUpload
                 :default-upload="false"
@@ -590,20 +590,20 @@ watch(tlsDnsCredentials, () => {
               >
                 <NButton secondary size="small" attr-type="button">Choose private key</NButton>
               </NUpload>
-              <span v-if="tlsForm.keyFileName" class="truncate text-xs normal-case tracking-normal text-[var(--app-text)]">{{ tlsForm.keyFileName }}</span>
+              <span v-if="tlsForm.keyFileName" class="clip-text copy-xs normal-text letter-normal base-text">{{ tlsForm.keyFileName }}</span>
             </div>
           </div>
         </div>
-        <p v-if="tlsForm.id && tlsForm.method === 'manual' && tlsForm.manualMode === 'upload'" class="rounded-md border border-[var(--app-border)] bg-[var(--app-panel-muted)] px-3 py-2 text-xs text-[var(--app-text-muted)]">
+        <p v-if="tlsForm.id && tlsForm.method === 'manual' && tlsForm.manualMode === 'upload'" class="round-md framed frame-standard muted-bg pad-x-md pad-y-sm copy-xs muted-text">
           Current certificate is stored in the app config directory.
         </p>
-        <p v-if="tlsUploadError" class="rounded-md border border-red-900/50 bg-red-950/20 px-3 py-2 text-sm text-red-400">
+        <p v-if="tlsUploadError" class="round-md framed error-border error-surface pad-x-md pad-y-sm copy-sm error-text">
           {{ tlsUploadError }}
         </p>
-        <NCheckbox v-model:checked="tlsForm.enabled" class="mt-2">
+        <NCheckbox v-model:checked="tlsForm.enabled" class="margin-top-sm">
           Enabled
         </NCheckbox>
-        <div class="mt-4 flex justify-end gap-3">
+        <div class="margin-top-lg layout-row align-end-row space-md">
           <NButton secondary attr-type="button" @click="isTlsModalOpen = false">Cancel</NButton>
           <DisabledHint :disabled="Boolean(tlsSubmitDisabledReason)" :reason="tlsSubmitDisabledReason">
             <NButton type="primary" attr-type="submit" :disabled="tlsSubmitDisabled">
@@ -621,16 +621,16 @@ watch(tlsDnsCredentials, () => {
       :style="modalCardStyle('32rem')"
       :bordered="false"
     >
-      <form class="grid max-h-[calc(100vh-9rem)] gap-4 overflow-y-auto pr-1" @submit.prevent="submitTlsCredential">
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+      <form class="layout-grid max-modal-height space-lg scroll-y pad-right-xs" @submit.prevent="submitTlsCredential">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Name
           <NInput v-model:value="tlsCredentialForm.name" size="small" placeholder="cloudflare-prod" required />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           Cloudflare zone ID
-          <NInput v-model:value="tlsCredentialForm.cloudflareZoneId" size="small" class="font-mono" required />
+          <NInput v-model:value="tlsCredentialForm.cloudflareZoneId" size="small" class="mono-text" required />
         </label>
-        <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
           API token
           <NInput
             v-model:value="tlsCredentialForm.apiToken"
@@ -640,13 +640,13 @@ watch(tlsDnsCredentials, () => {
             :required="!tlsCredentialForm.id"
           />
         </label>
-        <p v-if="tlsCredentialError" class="rounded-md border border-red-900/50 bg-red-950/20 px-3 py-2 text-sm text-red-400">
+        <p v-if="tlsCredentialError" class="round-md framed error-border error-surface pad-x-md pad-y-sm copy-sm error-text">
           {{ tlsCredentialError }}
         </p>
-        <NCheckbox v-model:checked="tlsCredentialForm.enabled" class="mt-2">
+        <NCheckbox v-model:checked="tlsCredentialForm.enabled" class="margin-top-sm">
           Enabled
         </NCheckbox>
-        <div class="mt-4 flex justify-end gap-3">
+        <div class="margin-top-lg layout-row align-end-row space-md">
           <NButton secondary attr-type="button" @click="isTlsCredentialModalOpen = false">Cancel</NButton>
           <DisabledHint :disabled="Boolean(tlsCredentialSubmitDisabledReason)" :reason="tlsCredentialSubmitDisabledReason">
             <NButton type="primary" attr-type="submit" :disabled="Boolean(tlsCredentialSubmitDisabledReason)">

--- a/web/management/src/views/Traffic.vue
+++ b/web/management/src/views/Traffic.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, h, inject, onBeforeUnmount, onMounted, ref, shallowRef, watch } from "vue";
-import { NButton, NButtonGroup, NCheckbox, NDataTable } from "naive-ui";
+import { NAlert, NButton, NCheckbox, NDataTable, NRadioButton, NRadioGroup, NTag } from "naive-ui";
 import type { DataTableColumns } from "naive-ui";
 import { dashboardKey, publicProxyConfigKey, selectedEnvironmentIdKey } from "@/composables/managementContextKeys";
 import { useManagementClient } from "@/composables/useManagementClient";
@@ -10,15 +10,11 @@ import TrafficFlowEditTargetChooser from "@/components/editors/TrafficFlowEditTa
 import TrafficFlowDiagram from "@/components/TrafficFlowDiagram.vue";
 import TrafficTraceDetailsModal from "@/components/TrafficTraceDetailsModal.vue";
 import { NO_TRACES_REASON, TRACE_BUSY_REASON } from "@/lib/disabledReasons";
-import { TrafficTraceStore, formatDuration, traceStreamRequestForSequence } from "@/lib/trafficTraceStore";
+import { TrafficTraceStore, traceStreamRequestForSequence } from "@/lib/trafficTraceStore";
 import type { TrafficFlowEditRequest, TrafficFlowEditTarget } from "@/types/trafficFlowEdit";
 import type { TraceRenderStats, TraceRequest, TraceRequestView } from "@/types/trafficTrace";
 import { emptyTraceRenderStats } from "@/types/trafficTrace";
-import type {
-  DashboardWindowSummary,
-  TrafficTraceEvent,
-  TrafficTraceSettings,
-} from "@/gen/proto/p2pstream/v1/management_pb";
+import type { TrafficTraceEvent, TrafficTraceSettings } from "@/gen/proto/p2pstream/v1/management_pb";
 import { TrafficTraceLevel } from "@/gen/proto/p2pstream/v1/management_pb";
 import { messageFromError } from "@/lib/errors";
 
@@ -28,7 +24,6 @@ const dashboard = inject(dashboardKey, computed(() => null));
 const publicProxyConfig = inject(publicProxyConfigKey, computed(() => null));
 const selectedEnvironmentId = inject(selectedEnvironmentIdKey, computed(() => "0"));
 
-const trafficWindows = computed(() => dashboard?.value?.windows ?? []);
 const config = computed(() => publicProxyConfig?.value ?? null);
 
 const traceSettings = ref<TrafficTraceSettings | null>(null);
@@ -70,11 +65,11 @@ const traceColumns = computed<DataTableColumns<TraceRequestView>>(() => [
     key: "request",
     minWidth: 260,
     render: (request) => h("div", [
-      h("div", { class: "flex items-center gap-2" }, [
-        h("span", { class: "rounded border border-[var(--app-border)] px-1.5 py-0.5 font-mono text-[0.7rem] text-[var(--app-text)]" }, request.methodLabel),
-        h("span", { class: "max-w-[18rem] truncate font-mono text-xs text-[var(--app-text)]" }, request.pathLabel),
+      h("div", { class: "layout-row align-center space-sm" }, [
+        h("span", { class: "round-sm framed frame-standard pad-x-xs pad-y-2xs mono-text copy-2xs base-text" }, request.methodLabel),
+        h("span", { class: "max-token-width clip-text mono-text copy-xs base-text" }, request.pathLabel),
       ]),
-      h("p", { class: "mt-1 max-w-[22rem] truncate font-mono text-[0.7rem] text-[var(--app-text-muted)]" }, request.requestIdLabel),
+      h("p", { class: "margin-top-xs max-trace-width clip-text mono-text copy-2xs muted-text" }, request.requestIdLabel),
     ]),
   },
   {
@@ -82,8 +77,8 @@ const traceColumns = computed<DataTableColumns<TraceRequestView>>(() => [
     key: "flow",
     minWidth: 260,
     render: (request) => h("div", [
-      h("p", { class: "text-xs text-[var(--app-text)]" }, request.flowLabel),
-      h("p", { class: "mt-1 text-[0.7rem] text-[var(--app-text-muted)]" }, `${request.stageLabel}${request.sampledEventCount ? ` / sampled ${numberLabel(request.sampledEventCount)}` : ""}`),
+      h("p", { class: "copy-xs base-text" }, request.flowLabel),
+      h("p", { class: "margin-top-xs copy-2xs muted-text" }, `${request.stageLabel}${request.sampledEventCount ? ` / sampled ${numberLabel(request.sampledEventCount)}` : ""}`),
     ]),
   },
   {
@@ -91,24 +86,15 @@ const traceColumns = computed<DataTableColumns<TraceRequestView>>(() => [
     key: "status",
     width: 110,
     align: "right",
-    render: (request) => h("span", { class: ["font-mono text-xs", request.statusClass] }, request.statusLabel),
+    render: (request) => h("span", { class: ["mono-text copy-xs", request.statusClass] }, request.statusLabel),
   },
   {
     title: "Duration",
     key: "duration",
     width: 120,
     align: "right",
-    render: (request) => h("span", { class: "font-mono text-xs text-[var(--app-text-muted)]" }, request.durationLabel),
+    render: (request) => h("span", { class: "mono-text copy-xs muted-text" }, request.durationLabel),
   },
-]);
-const trafficWindowColumns = computed<DataTableColumns<DashboardWindowSummary>>(() => [
-  { title: "Window", key: "window", minWidth: 140, render: (item) => item.label },
-  { title: "Requests", key: "requests", width: 130, align: "right", render: (item) => bigIntLabel(item.proxyRequests) },
-  { title: "Success", key: "success", width: 130, align: "right", render: (item) => h("span", { class: "text-green-500" }, bigIntLabel(item.proxySuccess)) },
-  { title: "Errors", key: "errors", width: 130, align: "right", render: (item) => h("span", { class: "text-red-500" }, bigIntLabel(proxyErrors(item))) },
-  { title: "Avg Duration", key: "duration", width: 140, align: "right", render: (item) => h("span", { class: "text-[var(--app-text-muted)]" }, formatDuration(item.proxyAvgDurationMs)) },
-  { title: "Traffic In", key: "in", width: 130, align: "right", render: (item) => formatBytes(item.agentBytesReceived) },
-  { title: "Traffic Out", key: "out", width: 130, align: "right", render: (item) => formatBytes(item.agentBytesSent) },
 ]);
 
 const tracingEnabled = computed(() => traceSettings.value?.enabled === true);
@@ -120,6 +106,13 @@ const traceTableSummary = computed(() => {
     return `Sampled under load: ${numberLabel(stats.sampledEvents)} events / ${numberLabel(stats.sampledRequests)} requests omitted from rendering.`;
   }
   return `Latest ${numberLabel(stats.renderedTableRows)} rendered from ${numberLabel(stats.retainedRequests)} retained requests.`;
+});
+const streamStateTagType = computed(() => {
+  if (!tracingEnabled.value) return "default";
+  if (streamState.value === "live") return "success";
+  if (streamState.value === "error") return "error";
+  if (streamState.value === "connecting" || streamState.value === "retrying") return "warning";
+  return "info";
 });
 
 async function loadTraceSettings(loadVersion: number) {
@@ -277,7 +270,7 @@ function traceRowKey(request: TraceRequestView): string {
 
 function traceRowProps(request: TraceRequestView) {
   return {
-    class: "cursor-pointer",
+    class: "interactive-cursor",
     role: "button",
     tabindex: 0,
     "aria-label": `Open trace details for ${request.requestIdLabel}`,
@@ -288,10 +281,6 @@ function traceRowProps(request: TraceRequestView) {
       openTraceDetails(request);
     },
   };
-}
-
-function trafficWindowRowKey(item: DashboardWindowSummary): string {
-  return item.label;
 }
 
 function handleFlowEditRequest(request: TrafficFlowEditRequest) {
@@ -313,10 +302,6 @@ function handlePageHide() {
   stopTraceStream("idle");
 }
 
-function proxyErrors(window: DashboardWindowSummary): bigint {
-  return window.proxyClientError + window.proxyServerError + window.proxyInternalError;
-}
-
 function bigIntLabel(value: bigint | undefined): string {
   if (value === undefined) return "0";
   return new Intl.NumberFormat().format(Number(value));
@@ -324,14 +309,6 @@ function bigIntLabel(value: bigint | undefined): string {
 
 function numberLabel(value: number): string {
   return new Intl.NumberFormat().format(value);
-}
-
-function formatBytes(value: bigint | undefined): string {
-  if (value === undefined) return "0 B";
-  const bytes = Number(value);
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 }
 
 function streamStateLabel(): string {
@@ -368,92 +345,93 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div v-if="dashboard" class="space-y-8">
-    <section class="space-y-4">
-      <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-        <div>
-          <h3 class="text-xl font-bold mb-2">Traffic Flow</h3>
-          <p class="text-[var(--app-text-muted)] text-sm">Live request routing across listeners, routes, targets, agents, and upstreams.</p>
-        </div>
-
-        <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
-          <DisabledHint :disabled="Boolean(traceBusyDisabledReason)" :reason="traceBusyDisabledReason">
-            <NCheckbox
-              class="flex h-10 items-center rounded-md border border-[var(--app-border)] bg-[var(--app-panel)] px-3"
-              :checked="tracingEnabled"
-              :disabled="Boolean(traceBusyDisabledReason)"
-              @update:checked="setTracingEnabled"
-            >
-              Tracing
-            </NCheckbox>
-          </DisabledHint>
-
-          <NButtonGroup class="grid grid-cols-4 overflow-hidden rounded-md border border-[var(--app-border)]" size="small">
-            <DisabledHint
-              v-for="option in traceLevelOptions"
-              :key="option.value"
-              full-width
-              :disabled="Boolean(traceBusyDisabledReason)"
-              :reason="traceBusyDisabledReason"
-            >
-              <NButton
-                attr-type="button"
-                class="h-10 w-full"
-                :type="selectedTraceLevel === option.value ? 'primary' : 'default'"
-                :disabled="Boolean(traceBusyDisabledReason)"
-                @click="setTraceLevel(option.value)"
-              >
-                {{ option.label }}
-              </NButton>
-            </DisabledHint>
-          </NButtonGroup>
-        </div>
-      </div>
-
-      <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <div class="app-card p-4">
-          <p class="app-card-title">Trace State</p>
-          <span class="text-lg font-semibold" :class="tracingEnabled ? 'text-green-400' : 'text-[var(--app-text-muted)]'">{{ streamStateLabel() }}</span>
-        </div>
-        <div class="app-card p-4">
-          <p class="app-card-title">Events</p>
-          <span class="text-lg font-semibold">{{ bigIntLabel(traceSettings?.emittedEvents) }}</span>
-        </div>
-        <div class="app-card p-4">
-          <p class="app-card-title">Dropped</p>
-          <span class="text-lg font-semibold" :class="traceSettings?.droppedEvents ? 'text-amber-400' : 'text-[var(--app-text)]'">
-            {{ bigIntLabel(traceSettings?.droppedEvents) }}
-          </span>
-        </div>
-        <div class="app-card p-4">
-          <p class="app-card-title">Rendered</p>
-          <span class="text-lg font-semibold">{{ numberLabel(renderStats.renderedTableRows) }}/{{ numberLabel(renderStats.retainedRequests) }}</span>
-        </div>
-      </div>
-      <div class="grid gap-3">
-        <NButton quaternary size="small" attr-type="button" class="w-fit" @click="showDebugStats = !showDebugStats">
-          {{ showDebugStats ? 'Hide' : 'Show' }} debug stats
-        </NButton>
-        <div v-if="showDebugStats" class="grid gap-3 sm:grid-cols-3">
-          <div class="app-card p-4">
-            <p class="app-card-title">Subscribers</p>
-            <span class="text-lg font-semibold">{{ traceSettings?.subscriberCount?.toString() ?? "0" }}</span>
+  <div v-if="dashboard" class="stack-xl traffic-page">
+    <section class="stack-md">
+      <div class="surface-card traffic-console">
+        <div class="traffic-console__header">
+          <div class="traffic-console__intro">
+            <div class="traffic-title-row">
+              <h3 class="copy-xl weight-bold">Traffic Flow</h3>
+              <NTag size="small" :bordered="false" :type="streamStateTagType">{{ streamStateLabel() }}</NTag>
+            </div>
+            <p class="muted-text copy-sm">Live request routing across listeners, routes, targets, agents, and upstreams.</p>
           </div>
-          <div class="app-card p-4">
-            <p class="app-card-title">Sampled</p>
-            <span class="text-lg font-semibold" :class="renderStats.sampledEvents || renderStats.sampledRequests ? 'text-amber-400' : 'text-[var(--app-text)]'">
-              {{ numberLabel(renderStats.sampledEvents) }}/{{ numberLabel(renderStats.sampledRequests) }}
+
+          <div class="traffic-console__controls">
+            <DisabledHint :disabled="Boolean(traceBusyDisabledReason)" :reason="traceBusyDisabledReason">
+              <NCheckbox
+                class="traffic-tracing-toggle"
+                :checked="tracingEnabled"
+                :disabled="Boolean(traceBusyDisabledReason)"
+                @update:checked="setTracingEnabled"
+              >
+                Tracing
+              </NCheckbox>
+            </DisabledHint>
+
+            <DisabledHint full-width :disabled="Boolean(traceBusyDisabledReason)" :reason="traceBusyDisabledReason">
+              <NRadioGroup
+                class="traffic-level-group"
+                :value="selectedTraceLevel"
+                :disabled="Boolean(traceBusyDisabledReason)"
+                button-style="solid"
+                size="small"
+                @update:value="(value) => setTraceLevel(value as TrafficTraceLevel)"
+              >
+                <NRadioButton v-for="option in traceLevelOptions" :key="option.value" :value="option.value">
+                  {{ option.label }}
+                </NRadioButton>
+              </NRadioGroup>
+            </DisabledHint>
+          </div>
+        </div>
+
+        <div class="traffic-status-grid">
+          <div class="traffic-status-item">
+            <p class="stat-label">Trace State</p>
+            <span class="copy-lg weight-semibold" :class="tracingEnabled ? 'success-text' : 'muted-text'">{{ streamStateLabel() }}</span>
+          </div>
+          <div class="traffic-status-item">
+            <p class="stat-label">Events</p>
+            <span class="copy-lg weight-semibold">{{ bigIntLabel(traceSettings?.emittedEvents) }}</span>
+          </div>
+          <div class="traffic-status-item">
+            <p class="stat-label">Dropped</p>
+            <span class="copy-lg weight-semibold" :class="traceSettings?.droppedEvents ? 'warning-text' : 'base-text'">
+              {{ bigIntLabel(traceSettings?.droppedEvents) }}
             </span>
           </div>
-          <div class="app-card p-4">
-            <p class="app-card-title">Live Tokens</p>
-            <span class="text-lg font-semibold">{{ renderedTokenCount }}</span>
+          <div class="traffic-status-item">
+            <p class="stat-label">Rendered</p>
+            <span class="copy-lg weight-semibold">{{ numberLabel(renderStats.renderedTableRows) }}/{{ numberLabel(renderStats.retainedRequests) }}</span>
           </div>
         </div>
-      </div>
 
-      <div v-if="streamError" class="rounded-md border border-amber-900/60 bg-amber-950/20 px-4 py-3 text-sm text-amber-300">
-        {{ streamError }}
+        <div class="traffic-debug-panel">
+          <NButton quaternary size="small" attr-type="button" class="traffic-debug-toggle" @click="showDebugStats = !showDebugStats">
+            {{ showDebugStats ? 'Hide' : 'Show' }} debug stats
+          </NButton>
+          <div v-if="showDebugStats" class="traffic-debug-grid">
+            <div class="traffic-debug-item">
+              <p class="stat-label">Subscribers</p>
+              <span class="copy-lg weight-semibold">{{ traceSettings?.subscriberCount?.toString() ?? "0" }}</span>
+            </div>
+            <div class="traffic-debug-item">
+              <p class="stat-label">Sampled</p>
+              <span class="copy-lg weight-semibold" :class="renderStats.sampledEvents || renderStats.sampledRequests ? 'warning-text' : 'base-text'">
+                {{ numberLabel(renderStats.sampledEvents) }}/{{ numberLabel(renderStats.sampledRequests) }}
+              </span>
+            </div>
+            <div class="traffic-debug-item">
+              <p class="stat-label">Live Tokens</p>
+              <span class="copy-lg weight-semibold">{{ renderedTokenCount }}</span>
+            </div>
+          </div>
+        </div>
+
+        <NAlert v-if="streamError" type="warning" :show-icon="false">
+          {{ streamError }}
+        </NAlert>
       </div>
 
       <TrafficFlowDiagram
@@ -465,17 +443,17 @@ onBeforeUnmount(() => {
         @edit-node="handleFlowEditRequest"
       />
 
-      <div class="app-card overflow-hidden">
-        <div class="flex items-center justify-between border-b border-[var(--app-border)] px-5 py-4">
+      <div class="surface-card hide-overflow">
+        <div class="layout-row align-center spread-items divider-bottom frame-standard pad-x-xl pad-y-lg">
           <div>
-            <h4 class="font-semibold">Recent traces</h4>
-            <p class="text-xs text-[var(--app-text-muted)]">{{ traceTableSummary }}</p>
+            <h4 class="weight-semibold">Recent traces</h4>
+            <p class="copy-xs muted-text">{{ traceTableSummary }}</p>
           </div>
           <DisabledHint :disabled="Boolean(clearTracesDisabledReason)" :reason="clearTracesDisabledReason">
             <NButton
               secondary
               size="small"
-              class="border-[var(--app-border)]! bg-transparent! text-[var(--app-text-muted)]! hover:border-[var(--app-text-muted)]!"
+              class="important-muted-frame important-transparent-bg important-muted-text important-muted-button"
               :disabled="Boolean(clearTracesDisabledReason)"
               @click="clearTraceRequests"
             >
@@ -498,26 +476,6 @@ onBeforeUnmount(() => {
       </div>
     </section>
 
-    <section class="space-y-4">
-      <div>
-        <h3 class="text-xl font-bold mb-2">Traffic History</h3>
-        <p class="text-[var(--app-text-muted)] text-sm">Aggregated request counts across different time windows.</p>
-      </div>
-
-      <div class="app-card overflow-hidden">
-        <NDataTable
-          :columns="trafficWindowColumns"
-          :data="trafficWindows"
-          :row-key="trafficWindowRowKey"
-          :pagination="false"
-          :bordered="false"
-          :single-line="false"
-          :scroll-x="910"
-          size="small"
-        />
-      </div>
-    </section>
-
     <TrafficTraceDetailsModal
       v-model="isDetailsOpen"
       :request="selectedRequest"
@@ -531,3 +489,139 @@ onBeforeUnmount(() => {
     />
   </div>
 </template>
+
+<style scoped>
+.traffic-console {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.traffic-console__header {
+  display: grid;
+  gap: 1rem;
+}
+
+.traffic-console__intro {
+  min-width: 0;
+}
+
+.traffic-title-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.traffic-console__controls {
+  display: grid;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.traffic-tracing-toggle {
+  display: inline-flex;
+  min-height: 2.25rem;
+  align-items: center;
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
+  background: var(--app-panel);
+  padding: 0 0.8rem;
+}
+
+.traffic-level-group {
+  min-width: 0;
+  width: 100%;
+}
+
+.traffic-level-group :deep(.n-radio-button) {
+  flex: 1 1 0;
+  min-width: 0;
+  text-align: center;
+}
+
+.traffic-level-group :deep(.n-radio-button__label) {
+  width: 100%;
+  text-align: center;
+}
+
+.traffic-status-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  overflow: hidden;
+  border: 1px solid var(--app-border-subtle);
+  border-radius: 6px;
+}
+
+.traffic-status-item {
+  min-width: 0;
+  background: var(--app-panel-muted);
+  padding: 0.85rem;
+}
+
+.traffic-status-item:nth-child(even) {
+  border-left: 1px solid var(--app-border-subtle);
+}
+
+.traffic-status-item:nth-child(n + 3) {
+  border-top: 1px solid var(--app-border-subtle);
+}
+
+.traffic-debug-panel {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.traffic-debug-toggle {
+  justify-self: start;
+}
+
+.traffic-debug-grid {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.traffic-debug-item {
+  min-width: 0;
+  border: 1px solid var(--app-border-subtle);
+  border-radius: 6px;
+  background: var(--app-panel-muted);
+  padding: 0.85rem;
+}
+
+@media (min-width: 760px) {
+  .traffic-console {
+    padding: 1.25rem;
+  }
+
+  .traffic-console__header {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: end;
+  }
+
+  .traffic-console__controls {
+    width: min(100%, 32rem);
+    grid-template-columns: auto minmax(22rem, 1fr);
+    align-items: center;
+    justify-content: end;
+  }
+
+  .traffic-status-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .traffic-status-item {
+    border-left: 1px solid var(--app-border-subtle);
+    border-top: 0;
+  }
+
+  .traffic-status-item:first-child {
+    border-left: 0;
+  }
+
+  .traffic-debug-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+</style>

--- a/web/management/src/views/TrafficPolicies.vue
+++ b/web/management/src/views/TrafficPolicies.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
 import { Pencil as PencilIcon } from "@lucide/vue";
 import { Plus as PlusIcon } from "@lucide/vue";
 import { Trash2 as TrashIcon } from "@lucide/vue";
-import { NButton, NCheckbox, NInputNumber, NTag } from "naive-ui";
+import { NButton, NCheckbox, NInputNumber, NTabPane, NTabs, NTag } from "naive-ui";
 import { useManagementClient } from "@/composables/useManagementClient";
 import EmptyState from "@/components/EmptyState.vue";
 import PublicProxyEditorHost from "@/components/editors/PublicProxyEditorHost.vue";
@@ -36,7 +37,19 @@ import {
 import { naiveTagType } from "@/lib/naiveUi";
 import type { PublicWafCaptchaProvider } from "@/gen/proto/p2pstream/v1/management_pb";
 
+const policySectionKeys = ["rate-limits", "waf", "cache", "traffic-shaper"] as const;
+type PolicySectionKey = typeof policySectionKeys[number];
+type PolicySectionSummary = {
+  key: PolicySectionKey;
+  label: string;
+  value: string;
+  detail: string;
+  description: string;
+};
+
 const managementClient = useManagementClient();
+const route = useRoute();
+const router = useRouter();
 
 const {
   dashboard,
@@ -69,12 +82,40 @@ const cacheSettingsForm = reactive({
   cleanupIntervalSeconds: 60,
 });
 
-const summaryCards = computed(() => [
-  { label: "Rate Limits", value: enabledRateLimitRules.value.toString(), detail: `${rateLimitRules.value.length.toString()} total rules` },
-  { label: "WAF", value: enabledWafRules.value.toString(), detail: `${wafCaptchaProviders.value.length.toString()} captcha providers` },
-  { label: "Cache", value: enabledCacheRules.value.toString(), detail: cacheSettingsForm.enabled ? "storage enabled" : "storage disabled" },
-  { label: "Traffic Shapers", value: enabledTrafficShapers.value.toString(), detail: `${trafficShaperRules.value.length.toString()} total shapers` },
+const policySections = computed<PolicySectionSummary[]>(() => [
+  {
+    key: "rate-limits",
+    label: "Rate Limits",
+    value: enabledRateLimitRules.value.toString(),
+    detail: `${rateLimitRules.value.length.toString()} total rules`,
+    description: "Throttle traffic based on request rate per client or route.",
+  },
+  {
+    key: "waf",
+    label: "WAF",
+    value: enabledWafRules.value.toString(),
+    detail: `${wafCaptchaProviders.value.length.toString()} captcha providers`,
+    description: "Block, challenge, or queue matching application traffic before it reaches routes.",
+  },
+  {
+    key: "cache",
+    label: "Cache",
+    value: enabledCacheRules.value.toString(),
+    detail: cacheSettingsForm.enabled ? "storage enabled" : "storage disabled",
+    description: "Cache public static files on the proxy after routing while keeping WAF, rate limits, and shaping active.",
+  },
+  {
+    key: "traffic-shaper",
+    label: "Traffic Shaper",
+    value: enabledTrafficShapers.value.toString(),
+    detail: `${trafficShaperRules.value.length.toString()} total shapers`,
+    description: "Limit bandwidth consumption per request or client.",
+  },
 ]);
+const activePolicySection = computed<PolicySectionKey>(() => normalizePolicySection(route.params.section));
+const activePolicyMeta = computed(() => (
+  policySections.value.find((section) => section.key === activePolicySection.value) ?? policySections.value[0]
+));
 
 const cacheSettingsDisabledReason = computed(() => {
   if (isBusy.value) return BUSY_REASON;
@@ -99,6 +140,17 @@ watch(cacheSettings, (settings) => {
 async function run(action: () => Promise<void>) {
   if (!runManagementAction) return;
   await runManagementAction(action);
+}
+
+function normalizePolicySection(value: unknown): PolicySectionKey {
+  const section = Array.isArray(value) ? value[0] : value;
+  return policySectionKeys.includes(section as PolicySectionKey) ? section as PolicySectionKey : "rate-limits";
+}
+
+async function selectPolicySection(value: string | number) {
+  const section = normalizePolicySection(value);
+  if (section === activePolicySection.value) return;
+  await router.push(`/policies/${section}`);
 }
 
 function openAddRateLimitRuleModal() {
@@ -199,51 +251,58 @@ async function deleteTrafficShaperRule(id: bigint) {
 </script>
 
 <template>
-  <div v-if="dashboard" class="space-y-8">
-    <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-      <div>
-        <h3 class="mb-2 text-xl font-bold">Traffic Policy</h3>
-        <p class="text-sm text-[var(--app-text-muted)]">Rate limits, WAF rules, cache behavior, and bandwidth shaping.</p>
+  <div v-if="dashboard" class="stack-xl">
+    <div class="page-toolbar policy-toolbar">
+      <div class="page-toolbar__body">
+        <h3 class="margin-bottom-sm copy-xl weight-bold">Traffic Policy</h3>
+        <p class="copy-sm muted-text">{{ activePolicyMeta.description }}</p>
       </div>
     </div>
 
-    <section class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-      <div v-for="card in summaryCards" :key="card.label" class="app-card p-4">
-        <p class="text-xs font-semibold uppercase tracking-widest text-[var(--app-text-muted)]">{{ card.label }}</p>
-        <p class="mt-2 text-2xl font-semibold text-[var(--app-text)]">{{ card.value }}</p>
-        <p class="mt-1 text-xs text-[var(--app-text-muted)]">{{ card.detail }}</p>
+    <section class="summary-grid summary-grid--four policy-summary-grid" aria-label="Policy type summary">
+      <div
+        v-for="section in policySections"
+        :key="section.key"
+        class="surface-card pad-lg policy-summary-card"
+        :class="{ 'policy-summary-card--active': section.key === activePolicySection }"
+      >
+        <p class="copy-xs weight-semibold label-case letter-widest muted-text">{{ section.label }}</p>
+        <p class="margin-top-sm copy-2xl weight-semibold base-text">{{ section.value }}</p>
+        <p class="margin-top-xs copy-xs muted-text">{{ section.detail }}</p>
       </div>
     </section>
 
-    <section class="app-card overflow-hidden">
-      <div class="border-b border-[var(--app-border)] px-5 py-4 flex items-center justify-between gap-4">
+    <NTabs class="policy-tabs" type="line" animated :value="activePolicySection" @update:value="selectPolicySection">
+      <NTabPane name="rate-limits" :tab="`Rate Limits (${enabledRateLimitRules})`">
+    <section class="surface-card hide-overflow">
+      <div class="divider-bottom frame-standard pad-x-xl pad-y-lg layout-row align-center spread-items space-lg">
         <div>
-          <h4 class="text-sm font-semibold uppercase tracking-widest text-[var(--app-text-muted)]">Rate Limits</h4>
-          <p class="mt-0.5 text-xs text-[var(--app-text-muted)] normal-case tracking-normal">Throttle traffic based on request rate per client or route.</p>
+          <h4 class="copy-sm weight-semibold label-case letter-widest muted-text">Rate Limits</h4>
+          <p class="margin-top-2xs copy-xs muted-text normal-text letter-normal">Throttle traffic based on request rate per client or route.</p>
         </div>
         <NButton secondary size="small" @click="openAddRateLimitRuleModal">
-          <template #icon><PlusIcon class="h-3.5 w-3.5" /></template>
+          <template #icon><PlusIcon class="icon-sm icon-sm" /></template>
           Add Rule
         </NButton>
       </div>
-      <div class="divide-y divide-[var(--app-border-subtle)]">
-        <div v-for="rule in rateLimitRules" :key="rule.id.toString()" class="grid gap-3 px-5 py-4 lg:grid-cols-[1fr_auto]">
-          <div class="min-w-0">
-            <div class="flex min-w-0 flex-wrap items-center gap-2">
-              <p class="truncate text-sm font-medium text-[var(--app-text)]">{{ rule.name }}</p>
+      <div class="divided-list">
+        <div v-for="rule in rateLimitRules" :key="rule.id.toString()" class="layout-grid space-md pad-x-xl pad-y-lg mq-lg-one-auto">
+          <div class="min-width-zero">
+            <div class="layout-row min-width-zero wrap-items align-center space-sm">
+              <p class="clip-text copy-sm weight-medium base-text">{{ rule.name }}</p>
               <NTag size="small" :bordered="false" type="info">{{ rateLimitAlgorithmLabel(rule.algorithm) }}</NTag>
               <NTag v-if="!rule.enabled" size="small" :bordered="false" type="warning">Disabled</NTag>
               <NTag size="small" :bordered="false" type="info">P{{ rule.priority.toString() }}</NTag>
             </div>
-            <p class="mt-1 truncate font-mono text-xs text-[var(--app-text-muted)]">{{ rateLimitRuleSummary(rule) }} / key {{ rateLimitKeySummary(rule) }}</p>
-            <p class="mt-1 truncate text-xs text-[var(--app-text-muted)]">{{ publicPolicyMatchSummary(rule) }} / response {{ rule.responseStatusCode.toString() }}</p>
+            <p class="margin-top-xs clip-text mono-text copy-xs muted-text">{{ rateLimitRuleSummary(rule) }} / key {{ rateLimitKeySummary(rule) }}</p>
+            <p class="margin-top-xs clip-text copy-xs muted-text">{{ publicPolicyMatchSummary(rule) }} / response {{ rule.responseStatusCode.toString() }}</p>
           </div>
-          <div class="flex gap-2 lg:justify-end">
+          <div class="layout-row space-sm mq-lg-end">
             <NButton secondary size="small" aria-label="Edit rate-limit rule" title="Edit rate-limit rule" @click="editRateLimitRule(rule.id)">
-              <template #icon><PencilIcon class="h-3.5 w-3.5" /></template>
+              <template #icon><PencilIcon class="icon-sm icon-sm" /></template>
             </NButton>
             <NButton type="error" size="small" aria-label="Delete rate-limit rule" title="Delete rate-limit rule" @click="deleteRateLimitRule(rule.id)">
-              <template #icon><TrashIcon class="h-3.5 w-3.5" /></template>
+              <template #icon><TrashIcon class="icon-sm icon-sm" /></template>
             </NButton>
           </div>
         </div>
@@ -256,62 +315,64 @@ async function deleteTrafficShaperRule(id: bigint) {
         />
       </div>
     </section>
+      </NTabPane>
 
-    <section class="app-card overflow-hidden">
-      <div class="border-b border-[var(--app-border)] px-5 py-4 flex items-center justify-between gap-4">
+      <NTabPane name="waf" :tab="`WAF (${enabledWafRules})`">
+    <section class="surface-card hide-overflow">
+      <div class="divider-bottom frame-standard pad-x-xl pad-y-lg layout-row align-center spread-items space-lg">
         <div>
-          <h4 class="text-sm font-semibold uppercase tracking-widest text-[var(--app-text-muted)]">WAF</h4>
-          <p class="mt-0.5 text-xs text-[var(--app-text-muted)] normal-case tracking-normal">Block, challenge, or queue matching application traffic before it reaches routes.</p>
+          <h4 class="copy-sm weight-semibold label-case letter-widest muted-text">WAF</h4>
+          <p class="margin-top-2xs copy-xs muted-text normal-text letter-normal">Block, challenge, or queue matching application traffic before it reaches routes.</p>
         </div>
-        <div class="flex flex-wrap gap-2">
+        <div class="layout-row wrap-items space-sm">
           <NButton secondary size="small" @click="openAddWafCaptchaProviderModal">
-            <template #icon><PlusIcon class="h-3.5 w-3.5" /></template>
+            <template #icon><PlusIcon class="icon-sm icon-sm" /></template>
             Add Provider
           </NButton>
           <NButton secondary size="small" @click="openAddWafRuleModal">
-            <template #icon><PlusIcon class="h-3.5 w-3.5" /></template>
+            <template #icon><PlusIcon class="icon-sm icon-sm" /></template>
             Add Rule
           </NButton>
         </div>
       </div>
-      <div class="divide-y divide-[var(--app-border-subtle)]">
-        <div v-for="provider in wafCaptchaProviders" :key="`provider-${provider.id.toString()}`" class="grid gap-3 px-5 py-4 lg:grid-cols-[1fr_auto]">
-          <div class="min-w-0">
-            <div class="flex min-w-0 flex-wrap items-center gap-2">
-              <p class="truncate text-sm font-medium text-[var(--app-text)]">{{ provider.name }}</p>
+      <div class="divided-list">
+        <div v-for="provider in wafCaptchaProviders" :key="`provider-${provider.id.toString()}`" class="layout-grid space-md pad-x-xl pad-y-lg mq-lg-one-auto">
+          <div class="min-width-zero">
+            <div class="layout-row min-width-zero wrap-items align-center space-sm">
+              <p class="clip-text copy-sm weight-medium base-text">{{ provider.name }}</p>
               <NTag size="small" :bordered="false" type="info">{{ wafProviderLabel(provider.providerType) }}</NTag>
               <NTag size="small" :bordered="false" :type="naiveTagType(provider.secretKeySet ? 'success' : 'danger')">{{ provider.secretKeySet ? 'Secret saved' : 'Secret missing' }}</NTag>
               <NTag v-if="!provider.enabled" size="small" :bordered="false" type="warning">Disabled</NTag>
             </div>
-            <p class="mt-1 truncate font-mono text-xs text-[var(--app-text-muted)]">{{ provider.siteKey }}</p>
+            <p class="margin-top-xs clip-text mono-text copy-xs muted-text">{{ provider.siteKey }}</p>
           </div>
-          <div class="flex gap-2 lg:justify-end">
+          <div class="layout-row space-sm mq-lg-end">
             <NButton secondary size="small" aria-label="Edit captcha provider" title="Edit captcha provider" @click="editWafCaptchaProvider(provider)">
-              <template #icon><PencilIcon class="h-3.5 w-3.5" /></template>
+              <template #icon><PencilIcon class="icon-sm icon-sm" /></template>
             </NButton>
             <NButton type="error" size="small" aria-label="Delete captcha provider" title="Delete captcha provider" @click="deleteWafCaptchaProvider(provider.id)">
-              <template #icon><TrashIcon class="h-3.5 w-3.5" /></template>
+              <template #icon><TrashIcon class="icon-sm icon-sm" /></template>
             </NButton>
           </div>
         </div>
-        <div v-for="rule in wafRules" :key="`rule-${rule.id.toString()}`" class="grid gap-3 px-5 py-4 lg:grid-cols-[1fr_auto]">
-          <div class="min-w-0">
-            <div class="flex min-w-0 flex-wrap items-center gap-2">
-              <p class="truncate text-sm font-medium text-[var(--app-text)]">{{ rule.name }}</p>
+        <div v-for="rule in wafRules" :key="`rule-${rule.id.toString()}`" class="layout-grid space-md pad-x-xl pad-y-lg mq-lg-one-auto">
+          <div class="min-width-zero">
+            <div class="layout-row min-width-zero wrap-items align-center space-sm">
+              <p class="clip-text copy-sm weight-medium base-text">{{ rule.name }}</p>
               <NTag size="small" :bordered="false" type="info">{{ wafActionLabel(rule.action) }}</NTag>
               <NTag size="small" :bordered="false" type="info">{{ wafActivationLabel(rule.activationMode) }}</NTag>
               <NTag v-if="!rule.enabled" size="small" :bordered="false" type="warning">Disabled</NTag>
               <NTag size="small" :bordered="false" type="info">P{{ rule.priority.toString() }}</NTag>
             </div>
-            <p class="mt-1 truncate font-mono text-xs text-[var(--app-text-muted)]">{{ wafRuleSummary(rule, wafCaptchaProviders) }} / key {{ rateLimitKeySummary(rule) }}</p>
-            <p class="mt-1 truncate text-xs text-[var(--app-text-muted)]">{{ publicPolicyMatchSummary(rule) }}</p>
+            <p class="margin-top-xs clip-text mono-text copy-xs muted-text">{{ wafRuleSummary(rule, wafCaptchaProviders) }} / key {{ rateLimitKeySummary(rule) }}</p>
+            <p class="margin-top-xs clip-text copy-xs muted-text">{{ publicPolicyMatchSummary(rule) }}</p>
           </div>
-          <div class="flex gap-2 lg:justify-end">
+          <div class="layout-row space-sm mq-lg-end">
             <NButton secondary size="small" aria-label="Edit WAF rule" title="Edit WAF rule" @click="editWafRule(rule.id)">
-              <template #icon><PencilIcon class="h-3.5 w-3.5" /></template>
+              <template #icon><PencilIcon class="icon-sm icon-sm" /></template>
             </NButton>
             <NButton type="error" size="small" aria-label="Delete WAF rule" title="Delete WAF rule" @click="deleteWafRule(rule.id)">
-              <template #icon><TrashIcon class="h-3.5 w-3.5" /></template>
+              <template #icon><TrashIcon class="icon-sm icon-sm" /></template>
             </NButton>
           </div>
         </div>
@@ -324,82 +385,84 @@ async function deleteTrafficShaperRule(id: bigint) {
         />
       </div>
     </section>
+      </NTabPane>
 
-    <section class="app-card overflow-hidden">
-      <div class="border-b border-[var(--app-border)] px-5 py-4 flex items-center justify-between gap-4">
+      <NTabPane name="cache" :tab="`Cache (${enabledCacheRules})`">
+    <section class="surface-card hide-overflow">
+      <div class="divider-bottom frame-standard pad-x-xl pad-y-lg layout-row align-center spread-items space-lg">
         <div>
-          <h4 class="text-sm font-semibold uppercase tracking-widest text-[var(--app-text-muted)]">Cache</h4>
-          <p class="mt-0.5 text-xs text-[var(--app-text-muted)] normal-case tracking-normal">Cache public static files on the proxy after routing while keeping WAF, rate limits, and shaping active.</p>
+          <h4 class="copy-sm weight-semibold label-case letter-widest muted-text">Cache</h4>
+          <p class="margin-top-2xs copy-xs muted-text normal-text letter-normal">Cache public static files on the proxy after routing while keeping WAF, rate limits, and shaping active.</p>
         </div>
-        <div class="flex flex-wrap gap-2">
+        <div class="layout-row wrap-items space-sm">
           <NButton secondary size="small" @click="purgeAllCache">
-            <template #icon><TrashIcon class="h-3.5 w-3.5" /></template>
+            <template #icon><TrashIcon class="icon-sm icon-sm" /></template>
             Purge All
           </NButton>
           <NButton secondary size="small" @click="openAddCacheRuleModal">
-            <template #icon><PlusIcon class="h-3.5 w-3.5" /></template>
+            <template #icon><PlusIcon class="icon-sm icon-sm" /></template>
             Add Rule
           </NButton>
         </div>
       </div>
-      <div class="grid gap-4 border-b border-[var(--app-border)] bg-[var(--app-panel-muted)] px-5 py-4">
-        <div class="flex flex-wrap items-center justify-between gap-3">
+      <div class="layout-grid space-lg divider-bottom frame-standard muted-bg pad-x-xl pad-y-lg">
+        <div class="layout-row wrap-items align-center spread-items space-md">
           <div>
-            <h5 class="text-xs font-semibold uppercase tracking-widest text-[var(--app-text-muted)]">Cache Settings</h5>
-            <p class="mt-1 text-xs text-[var(--app-text-muted)]">Bodies are stored under the configured public cache directory; metadata stays in SQLite.</p>
+            <h5 class="copy-xs weight-semibold label-case letter-widest muted-text">Cache Settings</h5>
+            <p class="margin-top-xs copy-xs muted-text">Bodies are stored under the configured public cache directory; metadata stays in SQLite.</p>
           </div>
           <NCheckbox v-model:checked="cacheSettingsForm.enabled">
             Enabled
           </NCheckbox>
         </div>
-        <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+        <div class="layout-grid space-md mq-sm-cols-two mq-xl-cols-five">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Disk MiB
             <NInputNumber v-model:value="cacheSettingsForm.maxDiskMiB" size="small" :min="1" />
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Memory MiB
             <NInputNumber v-model:value="cacheSettingsForm.maxMemoryMiB" size="small" :min="1" />
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Hot object KiB
             <NInputNumber v-model:value="cacheSettingsForm.hotObjectKiB" size="small" :min="1" />
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Max entries
             <NInputNumber v-model:value="cacheSettingsForm.maxEntries" size="small" :min="1" />
           </label>
-          <label class="grid gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--app-text-muted)]">
+          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
             Cleanup seconds
             <NInputNumber v-model:value="cacheSettingsForm.cleanupIntervalSeconds" size="small" :min="1" :max="3600" />
           </label>
         </div>
-        <div class="flex justify-end">
+        <div class="layout-row align-end-row">
           <NButton type="primary" size="small" :disabled="Boolean(cacheSettingsDisabledReason)" :title="cacheSettingsDisabledReason" @click="saveCacheSettings">
             Save Settings
           </NButton>
         </div>
       </div>
-      <div class="divide-y divide-[var(--app-border-subtle)]">
-        <div v-for="rule in cacheRules" :key="rule.id.toString()" class="grid gap-3 px-5 py-4 lg:grid-cols-[1fr_auto]">
-          <div class="min-w-0">
-            <div class="flex min-w-0 flex-wrap items-center gap-2">
-              <p class="truncate text-sm font-medium text-[var(--app-text)]">{{ rule.name }}</p>
+      <div class="divided-list">
+        <div v-for="rule in cacheRules" :key="rule.id.toString()" class="layout-grid space-md pad-x-xl pad-y-lg mq-lg-one-auto">
+          <div class="min-width-zero">
+            <div class="layout-row min-width-zero wrap-items align-center space-sm">
+              <p class="clip-text copy-sm weight-medium base-text">{{ rule.name }}</p>
               <NTag size="small" :bordered="false" type="info">{{ cacheTtlModeLabel(rule.ttlMode) }}</NTag>
               <NTag size="small" :bordered="false" type="info">{{ cacheScopeLabel(rule.scope) }}</NTag>
               <NTag size="small" :bordered="false" :type="naiveTagType(rule.allowCookieRequests ? 'warn' : 'info')">{{ rule.allowCookieRequests ? 'Cookies allowed' : 'Cookies blocked' }}</NTag>
               <NTag v-if="!rule.enabled" size="small" :bordered="false" type="warning">Disabled</NTag>
               <NTag size="small" :bordered="false" type="info">P{{ rule.priority.toString() }}</NTag>
             </div>
-            <p class="mt-1 truncate font-mono text-xs text-[var(--app-text-muted)]">{{ cacheRuleSummary(rule) }} / {{ cacheQueryModeLabel(rule.queryMode) }}</p>
-            <p class="mt-1 truncate text-xs text-[var(--app-text-muted)]">{{ cacheRuleMatchSummary(rule) }}</p>
+            <p class="margin-top-xs clip-text mono-text copy-xs muted-text">{{ cacheRuleSummary(rule) }} / {{ cacheQueryModeLabel(rule.queryMode) }}</p>
+            <p class="margin-top-xs clip-text copy-xs muted-text">{{ cacheRuleMatchSummary(rule) }}</p>
           </div>
-          <div class="flex gap-2 lg:justify-end">
+          <div class="layout-row space-sm mq-lg-end">
             <NButton secondary size="small" aria-label="Edit cache rule" title="Edit cache rule" @click="editCacheRule(rule.id)">
-              <template #icon><PencilIcon class="h-3.5 w-3.5" /></template>
+              <template #icon><PencilIcon class="icon-sm icon-sm" /></template>
             </NButton>
             <NButton type="error" size="small" aria-label="Delete cache rule" title="Delete cache rule" @click="deleteCacheRule(rule.id)">
-              <template #icon><TrashIcon class="h-3.5 w-3.5" /></template>
+              <template #icon><TrashIcon class="icon-sm icon-sm" /></template>
             </NButton>
           </div>
         </div>
@@ -412,36 +475,38 @@ async function deleteTrafficShaperRule(id: bigint) {
         />
       </div>
     </section>
+      </NTabPane>
 
-    <section class="app-card overflow-hidden">
-      <div class="border-b border-[var(--app-border)] px-5 py-4 flex items-center justify-between gap-4">
+      <NTabPane name="traffic-shaper" :tab="`Traffic Shaper (${enabledTrafficShapers})`">
+    <section class="surface-card hide-overflow">
+      <div class="divider-bottom frame-standard pad-x-xl pad-y-lg layout-row align-center spread-items space-lg">
         <div>
-          <h4 class="text-sm font-semibold uppercase tracking-widest text-[var(--app-text-muted)]">Traffic Shaper</h4>
-          <p class="mt-0.5 text-xs text-[var(--app-text-muted)] normal-case tracking-normal">Limit bandwidth consumption per request or client.</p>
+          <h4 class="copy-sm weight-semibold label-case letter-widest muted-text">Traffic Shaper</h4>
+          <p class="margin-top-2xs copy-xs muted-text normal-text letter-normal">Limit bandwidth consumption per request or client.</p>
         </div>
         <NButton secondary size="small" @click="openAddTrafficShaperRuleModal">
-          <template #icon><PlusIcon class="h-3.5 w-3.5" /></template>
+          <template #icon><PlusIcon class="icon-sm icon-sm" /></template>
           Add Shaper
         </NButton>
       </div>
-      <div class="divide-y divide-[var(--app-border-subtle)]">
-        <div v-for="rule in trafficShaperRules" :key="rule.id.toString()" class="grid gap-3 px-5 py-4 lg:grid-cols-[1fr_auto]">
-          <div class="min-w-0">
-            <div class="flex min-w-0 flex-wrap items-center gap-2">
-              <p class="truncate text-sm font-medium text-[var(--app-text)]">{{ rule.name }}</p>
+      <div class="divided-list">
+        <div v-for="rule in trafficShaperRules" :key="rule.id.toString()" class="layout-grid space-md pad-x-xl pad-y-lg mq-lg-one-auto">
+          <div class="min-width-zero">
+            <div class="layout-row min-width-zero wrap-items align-center space-sm">
+              <p class="clip-text copy-sm weight-medium base-text">{{ rule.name }}</p>
               <NTag size="small" :bordered="false" type="info">{{ trafficShaperScopeLabel(rule.budgetScope) }}</NTag>
               <NTag v-if="!rule.enabled" size="small" :bordered="false" type="warning">Disabled</NTag>
               <NTag size="small" :bordered="false" type="info">P{{ rule.priority.toString() }}</NTag>
             </div>
-            <p class="mt-1 truncate font-mono text-xs text-[var(--app-text-muted)]">{{ trafficShaperRuleSummary(rule) }} / {{ trafficShaperBudgetSummary(rule) }}</p>
-            <p class="mt-1 truncate text-xs text-[var(--app-text-muted)]">{{ publicPolicyMatchSummary(rule) }} / key {{ trafficShaperKeySummary(rule) }}</p>
+            <p class="margin-top-xs clip-text mono-text copy-xs muted-text">{{ trafficShaperRuleSummary(rule) }} / {{ trafficShaperBudgetSummary(rule) }}</p>
+            <p class="margin-top-xs clip-text copy-xs muted-text">{{ publicPolicyMatchSummary(rule) }} / key {{ trafficShaperKeySummary(rule) }}</p>
           </div>
-          <div class="flex gap-2 lg:justify-end">
+          <div class="layout-row space-sm mq-lg-end">
             <NButton secondary size="small" aria-label="Edit traffic-shaper rule" title="Edit traffic-shaper rule" @click="editTrafficShaperRule(rule.id)">
-              <template #icon><PencilIcon class="h-3.5 w-3.5" /></template>
+              <template #icon><PencilIcon class="icon-sm icon-sm" /></template>
             </NButton>
             <NButton type="error" size="small" aria-label="Delete traffic-shaper rule" title="Delete traffic-shaper rule" @click="deleteTrafficShaperRule(rule.id)">
-              <template #icon><TrashIcon class="h-3.5 w-3.5" /></template>
+              <template #icon><TrashIcon class="icon-sm icon-sm" /></template>
             </NButton>
           </div>
         </div>
@@ -454,7 +519,53 @@ async function deleteTrafficShaperRule(id: bigint) {
         />
       </div>
     </section>
+      </NTabPane>
+    </NTabs>
 
     <PublicProxyEditorHost ref="editorHost" :config="config" />
   </div>
 </template>
+
+<style scoped>
+.policy-summary-card {
+  min-height: 7rem;
+  padding: 0.875rem;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.policy-summary-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.policy-summary-card--active {
+  border-color: var(--app-accent);
+  box-shadow: inset 0 0 0 1px var(--app-accent-soft);
+}
+
+.policy-summary-card--active .base-text {
+  color: var(--app-accent);
+}
+
+.policy-tabs {
+  min-width: 0;
+}
+
+.policy-tabs :deep(.n-tabs-nav) {
+  margin-bottom: 1rem;
+}
+
+.policy-tabs :deep(.n-tab-pane) {
+  padding-top: 0.25rem;
+}
+
+@media (min-width: 900px) {
+  .policy-summary-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .policy-summary-card {
+    min-height: 0;
+    padding: 1rem;
+  }
+}
+</style>

--- a/web/management/vite.config.ts
+++ b/web/management/vite.config.ts
@@ -1,7 +1,6 @@
 import { fileURLToPath, URL } from "node:url";
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
-import tailwindcss from "@tailwindcss/vite";
 
 const managementProxyTarget = process.env.VITE_MANAGEMENT_PROXY_TARGET ?? "https://127.0.0.1:8081";
 const managementProxySecure = process.env.VITE_MANAGEMENT_PROXY_SECURE === "true";
@@ -10,7 +9,7 @@ const hmrHost = process.env.VITE_HMR_HOST ?? "localhost";
 const hmrClientPort = Number.parseInt(process.env.VITE_HMR_CLIENT_PORT ?? "8081", 10);
 
 export default defineConfig({
-  plugins: [vue(), tailwindcss()],
+  plugins: [vue()],
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),


### PR DESCRIPTION
## Summary
- remove Tailwind from the management frontend and migrate styling to Naive UI plus semantic CSS
- reorganize Proxy, Traffic Policy, Monitor, and Agent pages into clearer subpage flows
- add Monitor routes for traffic/diagnostics, not-found handling, traffic flow fixes, and updated e2e coverage
- improve Agent fleet/activity UX with route-backed tabs and compact operational tables

## Verification
- cd web/management && bun run typecheck
- cd web/management && bun test src
- cd web/management && bun run build
- browser smoke on the user-running dev server for Monitor, Traffic Flow, Diagnostics, Proxy, Traffic Policy, and Agent pages

Note: full bun run e2e was not run because the Playwright config starts its own backend/frontend servers, and local dev servers are user-managed for this workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Monitor section for Traffic Flow and Diagnostics navigation
  * Added 404 page for unknown routes

* **Bug Fixes**
  * Updated legacy route handling; `/traffic` and `/diagnostics` now properly redirect to Monitor section

* **UI/UX Improvements**
  * Migrated to a new design system with improved layouts and responsive styles
  * Refreshed components using updated Naive UI patterns
  * Improved traffic diagram resize handling for better display on window changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->