### PR TITLE
Harden public config routing and environment scoping

### DIFF
--- a/internal/managementui/handler.go
+++ b/internal/managementui/handler.go
@@ -29,6 +29,13 @@ func NewHandler(devProxyURL, distDir string) http.Handler {
 			if serveManagementUIFile(w, r, distFS, relPath) {
 				return
 			}
+			if !shouldServeManagementUIIndex(r, relPath) {
+				http.NotFound(w, r)
+				return
+			}
+		} else if !shouldServeManagementUIIndex(r, "") {
+			http.NotFound(w, r)
+			return
 		}
 		if serveManagementUIFile(w, r, distFS, "index.html") {
 			return
@@ -53,6 +60,40 @@ func managementUIAssetPath(requestPath string) string {
 		return ""
 	}
 	return relPath
+}
+
+func shouldServeManagementUIIndex(r *http.Request, relPath string) bool {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		return false
+	}
+	if looksLikeManagementUIAssetPath(relPath) {
+		return false
+	}
+	return managementUIAcceptsHTML(r.Header.Get("Accept"))
+}
+
+func looksLikeManagementUIAssetPath(relPath string) bool {
+	if relPath == "" {
+		return false
+	}
+	return path.Ext(relPath) != "" || relPath == "assets" || strings.HasPrefix(relPath, "assets/")
+}
+
+func managementUIAcceptsHTML(accept string) bool {
+	if strings.TrimSpace(accept) == "" {
+		return true
+	}
+	for _, part := range strings.Split(accept, ",") {
+		mediaType := strings.TrimSpace(part)
+		if semi := strings.IndexByte(mediaType, ';'); semi >= 0 {
+			mediaType = strings.TrimSpace(mediaType[:semi])
+		}
+		switch mediaType {
+		case "text/html", "application/xhtml+xml", "*/*":
+			return true
+		}
+	}
+	return false
 }
 
 func serveManagementUIFile(w http.ResponseWriter, r *http.Request, distFS fs.FS, name string) bool {

--- a/internal/managementui/handler_test.go
+++ b/internal/managementui/handler_test.go
@@ -49,6 +49,7 @@ func TestHandlerFallsBackToIndexForSPARoute(t *testing.T) {
 	writeFile(t, filepath.Join(distDir, "index.html"), "<html>app shell</html>")
 
 	req := httptest.NewRequest(http.MethodGet, "/settings", nil)
+	req.Header.Set("Accept", "text/html")
 	rec := httptest.NewRecorder()
 
 	NewHandler("", distDir).ServeHTTP(rec, req)
@@ -58,6 +59,42 @@ func TestHandlerFallsBackToIndexForSPARoute(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "app shell") {
 		t.Fatalf("expected index fallback, got %q", rec.Body.String())
+	}
+}
+
+func TestHandlerReturnsNotFoundForMissingAsset(t *testing.T) {
+	distDir := t.TempDir()
+	writeFile(t, filepath.Join(distDir, "index.html"), "<html>app shell</html>")
+
+	req := httptest.NewRequest(http.MethodGet, "/assets/missing.js", nil)
+	req.Header.Set("Accept", "*/*")
+	rec := httptest.NewRecorder()
+
+	NewHandler("", distDir).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "app shell") {
+		t.Fatalf("missing asset fell back to index: %q", rec.Body.String())
+	}
+}
+
+func TestHandlerReturnsNotFoundForNonHTMLSPARouteRequest(t *testing.T) {
+	distDir := t.TempDir()
+	writeFile(t, filepath.Join(distDir, "index.html"), "<html>app shell</html>")
+
+	req := httptest.NewRequest(http.MethodGet, "/settings", nil)
+	req.Header.Set("Accept", "application/json")
+	rec := httptest.NewRecorder()
+
+	NewHandler("", distDir).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "app shell") {
+		t.Fatalf("non-HTML request fell back to index: %q", rec.Body.String())
 	}
 }
 
@@ -83,15 +120,15 @@ func TestHandlerDoesNotServeTraversalOutsideDist(t *testing.T) {
 
 			NewHandler("", distDir).ServeHTTP(rec, req)
 
-			if rec.Code != http.StatusOK {
-				t.Fatalf("expected status 200, got %d", rec.Code)
+			if rec.Code != http.StatusNotFound {
+				t.Fatalf("expected status 404, got %d", rec.Code)
 			}
 			body := rec.Body.String()
 			if strings.Contains(body, "outside-secret") {
 				t.Fatalf("served file outside dist for %q: %q", target, body)
 			}
-			if !strings.Contains(body, "app shell") {
-				t.Fatalf("expected index fallback for %q, got %q", target, body)
+			if strings.Contains(body, "app shell") {
+				t.Fatalf("traversal path fell back to index for %q: %q", target, body)
 			}
 		})
 	}

--- a/internal/server/public_acme.go
+++ b/internal/server/public_acme.go
@@ -570,6 +570,12 @@ func (m *publicACMEManager) markIssueFailed(ctx context.Context, cert db.PublicT
 			Time("attempt_at", attemptAt).
 			Time("retry_at", retryAt).
 			Msg("Failed to record ACME certificate issue error")
+		return
+	}
+	if err := m.app.refreshPublicProxySnapshot(ctx); err != nil {
+		publicACMELogCertificate(log.Warn().Err(err), cert, trigger, publicACMEStageRefreshProxySnapshot).
+			Time("attempt_at", attemptAt).
+			Msg("Failed to refresh public proxy after ACME issue failure")
 	}
 }
 

--- a/internal/server/public_config.go
+++ b/internal/server/public_config.go
@@ -112,6 +112,17 @@ type publicRouteTargetUpstreamHeaderInput struct {
 	Sensitive int64
 }
 
+type existingSensitiveUpstreamHeaderValue struct {
+	TargetID int64
+	Name     string
+	Value    string
+}
+
+type existingPublicRouteTargetSecrets struct {
+	UpstreamHeaders    map[int64]existingSensitiveUpstreamHeaderValue
+	BasicAuthPasswords map[int64]string
+}
+
 type publicRouteTargetMutationInput struct {
 	Params          db.CreatePublicRouteTargetParams
 	UpstreamHeaders []publicRouteTargetUpstreamHeaderInput

--- a/internal/server/public_config_handlers.go
+++ b/internal/server/public_config_handlers.go
@@ -325,6 +325,7 @@ func (s *publicConfigService) createPublicRoute(
 		req.Msg.RedirectPreservePathSuffix,
 		req.Msg.RedirectPreserveQuery,
 		req.Msg.PathSecurityMode,
+		existingPublicRouteTargetSecrets{},
 	)
 	if err != nil {
 		return nil, err
@@ -355,6 +356,10 @@ func (s *publicConfigService) updatePublicRoute(
 	req *connect.Request[p2pstreamv1.UpdatePublicRouteRequest],
 ) (*connect.Response[p2pstreamv1.UpdatePublicRouteResponse], error) {
 	a := s.app
+	existingSecrets, err := a.existingPublicRouteTargetSecrets(ctx, req.Msg.Id)
+	if err != nil {
+		return nil, publicDBError(err)
+	}
 	params, routeTargets, err := a.validatePublicRouteInput(
 		ctx,
 		req.Msg.ListenerId,
@@ -372,6 +377,7 @@ func (s *publicConfigService) updatePublicRoute(
 		req.Msg.RedirectPreservePathSuffix,
 		req.Msg.RedirectPreserveQuery,
 		req.Msg.PathSecurityMode,
+		existingSecrets,
 	)
 	if err != nil {
 		return nil, err
@@ -386,6 +392,37 @@ func (s *publicConfigService) updatePublicRoute(
 	}
 	upstreamHeaders, responseHeaders := a.publicRouteTargetHeaderMaps(ctx)
 	return connect.NewResponse(&p2pstreamv1.UpdatePublicRouteResponse{Route: publicRouteToProto(route, storedTargets, upstreamHeaders, responseHeaders, s.targetHealth)}), nil
+}
+
+func (a *App) existingPublicRouteTargetSecrets(ctx context.Context, routeID int64) (existingPublicRouteTargetSecrets, error) {
+	targets, err := a.DB.ListPublicRouteTargetsByRoute(ctx, routeID)
+	if err != nil {
+		return existingPublicRouteTargetSecrets{}, err
+	}
+	secrets := existingPublicRouteTargetSecrets{
+		UpstreamHeaders:    make(map[int64]existingSensitiveUpstreamHeaderValue),
+		BasicAuthPasswords: make(map[int64]string),
+	}
+	for _, target := range targets {
+		if target.UpstreamBasicAuthEnabled != 0 && target.UpstreamBasicAuthPassword != "" {
+			secrets.BasicAuthPasswords[target.ID] = target.UpstreamBasicAuthPassword
+		}
+		headers, err := a.DB.ListPublicRouteTargetUpstreamHeadersByTarget(ctx, target.ID)
+		if err != nil {
+			return existingPublicRouteTargetSecrets{}, err
+		}
+		for _, header := range headers {
+			if header.Sensitive == 0 && !isForcedSensitiveUpstreamHeader(header.Name) {
+				continue
+			}
+			secrets.UpstreamHeaders[header.ID] = existingSensitiveUpstreamHeaderValue{
+				TargetID: header.TargetID,
+				Name:     header.Name,
+				Value:    header.Value,
+			}
+		}
+	}
+	return secrets, nil
 }
 
 func (a *App) createPublicRouteWithTargets(

--- a/internal/server/public_config_proto.go
+++ b/internal/server/public_config_proto.go
@@ -341,7 +341,8 @@ func publicRouteTargetUpstreamHeadersToProto(headers []db.PublicRouteTargetUpstr
 	resp := make([]*p2pstreamv1.PublicRouteTargetUpstreamHeader, 0, len(headers))
 	for _, header := range headers {
 		value := header.Value
-		if header.Sensitive != 0 {
+		sensitive := header.Sensitive != 0
+		if sensitive {
 			value = ""
 		}
 		resp = append(resp, &p2pstreamv1.PublicRouteTargetUpstreamHeader{
@@ -349,8 +350,8 @@ func publicRouteTargetUpstreamHeadersToProto(headers []db.PublicRouteTargetUpstr
 			TargetId:  header.TargetID,
 			Name:      header.Name,
 			Value:     value,
-			Sensitive: header.Sensitive != 0,
-			ValueSet:  true,
+			Sensitive: sensitive,
+			ValueSet:  !sensitive,
 			Position:  header.Position,
 		})
 	}

--- a/internal/server/public_config_test.go
+++ b/internal/server/public_config_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -91,5 +92,184 @@ func TestPublicRoutePathSecurityModeManagementAPI(t *testing.T) {
 	}
 	if got := updateResp.Msg.Route.PathSecurityMode; got != p2pstreamv1.PublicRoutePathSecurityMode_PUBLIC_ROUTE_PATH_SECURITY_MODE_STRICT {
 		t.Fatalf("updated path security mode = %v, want strict", got)
+	}
+}
+
+func TestPublicRouteUpdatePreservesMaskedSensitiveUpstreamHeaders(t *testing.T) {
+	app := NewApp(nil, newServerTestDB(t))
+	header := createTestAdminSession(t, app)
+	listener := seedPublicConfigTestListener(t, app.DB)
+
+	createReq := testPublicRouteRequest(listener.ID, "/masked-secret", []*p2pstreamv1.PublicRouteTargetUpstreamHeader{
+		{Name: "X-Secret", Value: "top-secret", Sensitive: true, ValueSet: true},
+		{Name: "Cookie", Value: "session=abc", ValueSet: true},
+	})
+	createReq.Header().Set("Cookie", header.Get("Cookie"))
+	createResp, err := app.CreatePublicRoute(context.Background(), createReq)
+	if err != nil {
+		t.Fatalf("create route: %v", err)
+	}
+	if len(createResp.Msg.Route.Targets) != 1 || len(createResp.Msg.Route.Targets[0].UpstreamRequestHeaders) != 2 {
+		t.Fatalf("created route headers = %+v", createResp.Msg.Route.Targets)
+	}
+	for _, got := range createResp.Msg.Route.Targets[0].UpstreamRequestHeaders {
+		if got.Value != "" || got.ValueSet {
+			t.Fatalf("sensitive header proto = %+v, want masked with value_set=false", got)
+		}
+	}
+
+	updateTarget := createResp.Msg.Route.Targets[0]
+	updateTarget.Name = "renamed-target"
+	updateReq := testPublicRouteUpdateRequest(createResp.Msg.Route, "/masked-secret-updated", []*p2pstreamv1.PublicRouteTarget{updateTarget})
+	updateReq.Header().Set("Cookie", header.Get("Cookie"))
+	updateResp, err := app.UpdatePublicRoute(context.Background(), updateReq)
+	if err != nil {
+		t.Fatalf("update route with masked headers: %v", err)
+	}
+	if got := updateResp.Msg.Route.Targets[0].UpstreamRequestHeaders[0]; got.Value != "" || got.ValueSet {
+		t.Fatalf("updated sensitive header proto = %+v, want masked with value_set=false", got)
+	}
+	assertPublicRouteUpstreamHeaderValues(t, app.DB, updateResp.Msg.Route.Id, map[string]string{
+		"x-secret": "top-secret",
+		"cookie":   "session=abc",
+	})
+}
+
+func TestPublicRouteUpdateRejectsMaskedSensitiveHeaderFromAnotherRoute(t *testing.T) {
+	app := NewApp(nil, newServerTestDB(t))
+	header := createTestAdminSession(t, app)
+	listener := seedPublicConfigTestListener(t, app.DB)
+
+	firstReq := testPublicRouteRequest(listener.ID, "/first-secret", []*p2pstreamv1.PublicRouteTargetUpstreamHeader{
+		{Name: "X-Secret", Value: "first-secret", Sensitive: true, ValueSet: true},
+	})
+	firstReq.Header().Set("Cookie", header.Get("Cookie"))
+	firstResp, err := app.CreatePublicRoute(context.Background(), firstReq)
+	if err != nil {
+		t.Fatalf("create first route: %v", err)
+	}
+
+	secondReq := testPublicRouteRequest(listener.ID, "/second-secret", []*p2pstreamv1.PublicRouteTargetUpstreamHeader{
+		{Name: "X-Secret", Value: "second-secret", Sensitive: true, ValueSet: true},
+	})
+	secondReq.Header().Set("Cookie", header.Get("Cookie"))
+	secondResp, err := app.CreatePublicRoute(context.Background(), secondReq)
+	if err != nil {
+		t.Fatalf("create second route: %v", err)
+	}
+
+	forgedHeader := firstResp.Msg.Route.Targets[0].UpstreamRequestHeaders[0]
+	forgedHeader.TargetId = secondResp.Msg.Route.Targets[0].Id
+	forgedTarget := secondResp.Msg.Route.Targets[0]
+	forgedTarget.UpstreamRequestHeaders = []*p2pstreamv1.PublicRouteTargetUpstreamHeader{forgedHeader}
+	updateReq := testPublicRouteUpdateRequest(secondResp.Msg.Route, "/second-secret", []*p2pstreamv1.PublicRouteTarget{forgedTarget})
+	updateReq.Header().Set("Cookie", header.Get("Cookie"))
+	_, err = app.UpdatePublicRoute(context.Background(), updateReq)
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("update with cross-route masked header error = %v, want invalid argument", err)
+	}
+	assertPublicRouteUpstreamHeaderValues(t, app.DB, secondResp.Msg.Route.Id, map[string]string{
+		"x-secret": "second-secret",
+	})
+}
+
+func TestPublicRouteUpdateOmitsUpstreamHeaderToDelete(t *testing.T) {
+	app := NewApp(nil, newServerTestDB(t))
+	header := createTestAdminSession(t, app)
+	listener := seedPublicConfigTestListener(t, app.DB)
+
+	createReq := testPublicRouteRequest(listener.ID, "/delete-secret", []*p2pstreamv1.PublicRouteTargetUpstreamHeader{
+		{Name: "X-Secret", Value: "top-secret", Sensitive: true, ValueSet: true},
+	})
+	createReq.Header().Set("Cookie", header.Get("Cookie"))
+	createResp, err := app.CreatePublicRoute(context.Background(), createReq)
+	if err != nil {
+		t.Fatalf("create route: %v", err)
+	}
+
+	updateTarget := createResp.Msg.Route.Targets[0]
+	updateTarget.UpstreamRequestHeaders = nil
+	updateReq := testPublicRouteUpdateRequest(createResp.Msg.Route, "/delete-secret", []*p2pstreamv1.PublicRouteTarget{updateTarget})
+	updateReq.Header().Set("Cookie", header.Get("Cookie"))
+	updateResp, err := app.UpdatePublicRoute(context.Background(), updateReq)
+	if err != nil {
+		t.Fatalf("update route without header: %v", err)
+	}
+	assertPublicRouteUpstreamHeaderValues(t, app.DB, updateResp.Msg.Route.Id, map[string]string{})
+}
+
+func seedPublicConfigTestListener(t *testing.T, database *db.DB) db.PublicListener {
+	t.Helper()
+	listener, err := database.CreatePublicListener(context.Background(), db.CreatePublicListenerParams{
+		Name:        "public-http",
+		BindAddress: "",
+		Port:        8080,
+		Protocol:    publicListenerProtocolHTTP,
+		Enabled:     1,
+	})
+	if err != nil {
+		t.Fatalf("create listener: %v", err)
+	}
+	return listener
+}
+
+func testPublicRouteRequest(listenerID int64, pathPrefix string, headers []*p2pstreamv1.PublicRouteTargetUpstreamHeader) *connect.Request[p2pstreamv1.CreatePublicRouteRequest] {
+	return connect.NewRequest(&p2pstreamv1.CreatePublicRouteRequest{
+		ListenerId:       listenerID,
+		Priority:         10,
+		PathPrefix:       pathPrefix,
+		Enabled:          true,
+		Action:           p2pstreamv1.PublicRouteAction_PUBLIC_ROUTE_ACTION_FORWARD,
+		PathSecurityMode: p2pstreamv1.PublicRoutePathSecurityMode_PUBLIC_ROUTE_PATH_SECURITY_MODE_STRICT,
+		Targets: []*p2pstreamv1.PublicRouteTarget{{
+			Name:                   "target-1",
+			Enabled:                true,
+			TargetType:             p2pstreamv1.PublicRouteTargetType_PUBLIC_ROUTE_TARGET_TYPE_PROXY,
+			Url:                    "http://127.0.0.1:9000",
+			Transport:              p2pstreamv1.PublicRouteTargetTransport_PUBLIC_ROUTE_TARGET_TRANSPORT_DIRECT,
+			Weight:                 100,
+			UpstreamRequestHeaders: headers,
+		}},
+	})
+}
+
+func testPublicRouteUpdateRequest(route *p2pstreamv1.PublicRoute, pathPrefix string, targets []*p2pstreamv1.PublicRouteTarget) *connect.Request[p2pstreamv1.UpdatePublicRouteRequest] {
+	return connect.NewRequest(&p2pstreamv1.UpdatePublicRouteRequest{
+		Id:                  route.Id,
+		ListenerId:          route.ListenerId,
+		Priority:            route.Priority,
+		PathPrefix:          pathPrefix,
+		Enabled:             route.Enabled,
+		Action:              p2pstreamv1.PublicRouteAction_PUBLIC_ROUTE_ACTION_FORWARD,
+		TargetLoadBalancing: route.TargetLoadBalancing,
+		IsDefault:           route.IsDefault,
+		Targets:             targets,
+		PathSecurityMode:    route.PathSecurityMode,
+	})
+}
+
+func assertPublicRouteUpstreamHeaderValues(t *testing.T, database *db.DB, routeID int64, want map[string]string) {
+	t.Helper()
+	targets, err := database.ListPublicRouteTargetsByRoute(context.Background(), routeID)
+	if err != nil {
+		t.Fatalf("list targets: %v", err)
+	}
+	got := make(map[string]string)
+	for _, target := range targets {
+		headers, err := database.ListPublicRouteTargetUpstreamHeadersByTarget(context.Background(), target.ID)
+		if err != nil {
+			t.Fatalf("list upstream headers: %v", err)
+		}
+		for _, header := range headers {
+			got[strings.ToLower(header.Name)] = header.Value
+		}
+	}
+	if len(got) != len(want) {
+		t.Fatalf("upstream headers = %+v, want %+v", got, want)
+	}
+	for name, wantValue := range want {
+		if got[name] != wantValue {
+			t.Fatalf("upstream header %s = %q, want %q (all headers %+v)", name, got[name], wantValue, got)
+		}
 	}
 }

--- a/internal/server/public_config_validation.go
+++ b/internal/server/public_config_validation.go
@@ -120,7 +120,11 @@ func normalizePublicRouteTargetUpstreamResponseHeaderTimeoutMillis(timeoutMillis
 	return timeoutMillis
 }
 
-func (a *App) validatePublicRouteTargets(ctx context.Context, targets []*p2pstreamv1.PublicRouteTarget) ([]publicRouteTargetMutationInput, error) {
+func (a *App) validatePublicRouteTargets(
+	ctx context.Context,
+	targets []*p2pstreamv1.PublicRouteTarget,
+	existingSecrets existingPublicRouteTargetSecrets,
+) ([]publicRouteTargetMutationInput, error) {
 	if len(targets) == 0 {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("forwarding route requires at least one target"))
 	}
@@ -197,11 +201,11 @@ func (a *App) validatePublicRouteTargets(ctx context.Context, targets []*p2pstre
 			} else {
 				params.AgentSelectorJson = "{}"
 			}
-			upstreamHeaders, err = validatePublicRouteTargetUpstreamHeaders(target.UpstreamRequestHeaders, target.UpstreamBasicAuth != nil && target.UpstreamBasicAuth.Enabled)
+			upstreamHeaders, err = validatePublicRouteTargetUpstreamHeaders(target.Id, target.UpstreamRequestHeaders, target.UpstreamBasicAuth != nil && target.UpstreamBasicAuth.Enabled, existingSecrets)
 			if err != nil {
 				return nil, err
 			}
-			authEnabled, authUsername, authPassword, err := validatePublicRouteTargetBasicAuth(target.UpstreamBasicAuth)
+			authEnabled, authUsername, authPassword, err := validatePublicRouteTargetBasicAuth(target.Id, target.UpstreamBasicAuth, existingSecrets)
 			if err != nil {
 				return nil, err
 			}
@@ -334,6 +338,7 @@ func (a *App) validatePublicRouteInput(
 	redirectPreservePathSuffix bool,
 	redirectPreserveQuery bool,
 	pathSecurityMode p2pstreamv1.PublicRoutePathSecurityMode,
+	existingSecrets existingPublicRouteTargetSecrets,
 ) (db.UpdatePublicRouteParams, []publicRouteTargetMutationInput, error) {
 	if _, err := a.DB.GetPublicListener(ctx, listenerID); err != nil {
 		return db.UpdatePublicRouteParams{}, nil, publicDBError(err)
@@ -371,7 +376,7 @@ func (a *App) validatePublicRouteInput(
 		if err != nil {
 			return db.UpdatePublicRouteParams{}, nil, err
 		}
-		routeTargets, err = a.validatePublicRouteTargets(ctx, targets)
+		routeTargets, err = a.validatePublicRouteTargets(ctx, targets, existingSecrets)
 		if err != nil {
 			return db.UpdatePublicRouteParams{}, nil, err
 		}
@@ -463,8 +468,10 @@ func validatePublicStaticHeaders(headers []*p2pstreamv1.PublicHeader) ([]publicR
 }
 
 func validatePublicRouteTargetUpstreamHeaders(
+	targetID int64,
 	headers []*p2pstreamv1.PublicRouteTargetUpstreamHeader,
 	basicAuthEnabled bool,
+	existingSecrets existingPublicRouteTargetSecrets,
 ) ([]publicRouteTargetUpstreamHeaderInput, error) {
 	resp := make([]publicRouteTargetUpstreamHeaderInput, 0, len(headers))
 	seen := make(map[string]struct{}, len(headers))
@@ -493,8 +500,12 @@ func validatePublicRouteTargetUpstreamHeaders(
 
 		sensitive := header.Sensitive || isForcedSensitiveUpstreamHeader(name)
 		value := header.Value
-		if sensitive && !header.ValueSet {
-			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("sensitive upstream request header %q requires a value", name))
+		if sensitive && value == "" {
+			if existingValue, ok := existingSensitiveUpstreamHeaderValueForUpdate(existingSecrets, header.Id, targetID, name); ok {
+				value = existingValue
+			} else {
+				return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("sensitive upstream request header %q requires a value", name))
+			}
 		}
 		if err := validateUpstreamHeaderValue(name, value); err != nil {
 			return nil, err
@@ -509,7 +520,27 @@ func validatePublicRouteTargetUpstreamHeaders(
 	return resp, nil
 }
 
-func validatePublicRouteTargetBasicAuth(auth *p2pstreamv1.PublicRouteTargetBasicAuth) (int64, string, string, error) {
+func existingSensitiveUpstreamHeaderValueForUpdate(
+	existingSecrets existingPublicRouteTargetSecrets,
+	headerID int64,
+	targetID int64,
+	name string,
+) (string, bool) {
+	if headerID <= 0 || targetID <= 0 || existingSecrets.UpstreamHeaders == nil {
+		return "", false
+	}
+	existing, ok := existingSecrets.UpstreamHeaders[headerID]
+	if !ok || existing.TargetID != targetID || !strings.EqualFold(existing.Name, name) {
+		return "", false
+	}
+	return existing.Value, true
+}
+
+func validatePublicRouteTargetBasicAuth(
+	targetID int64,
+	auth *p2pstreamv1.PublicRouteTargetBasicAuth,
+	existingSecrets existingPublicRouteTargetSecrets,
+) (int64, string, string, error) {
 	if auth == nil || !auth.Enabled {
 		return 0, "", "", nil
 	}
@@ -525,8 +556,12 @@ func validatePublicRouteTargetBasicAuth(auth *p2pstreamv1.PublicRouteTargetBasic
 	}
 
 	password := auth.Password
-	if !auth.PasswordSet || password == "" {
-		return 0, "", "", connect.NewError(connect.CodeInvalidArgument, errors.New("upstream basic auth password is required"))
+	if password == "" {
+		if existingPassword, ok := existingSecrets.BasicAuthPasswords[targetID]; ok && targetID > 0 {
+			password = existingPassword
+		} else {
+			return 0, "", "", connect.NewError(connect.CodeInvalidArgument, errors.New("upstream basic auth password is required"))
+		}
 	}
 	if strings.ContainsAny(password, "\r\n") || !utf8.ValidString(password) {
 		return 0, "", "", connect.NewError(connect.CodeInvalidArgument, errors.New("upstream basic auth password must be valid UTF-8 without CR or LF"))

--- a/internal/server/public_routing.go
+++ b/internal/server/public_routing.go
@@ -864,12 +864,13 @@ func (a *App) selectRouteTarget(snap publicProxySnapshot, route publicRouteConfi
 		if target.PriorityGroup != lowestPriorityGroup || !a.targetEligibleForRoute(snap, target) {
 			continue
 		}
+		// Active request counts are local to this proxy process; least-active balancing is per-process.
 		candidates = append(candidates, routeTargetCandidate{
 			Target:         target,
 			TargetID:       target.ID,
 			Position:       target.Position,
 			Weight:         target.Weight,
-			ActiveRequests: 0,
+			ActiveRequests: a.TargetHealth.activeRequests(target.ID),
 		})
 	}
 	if len(candidates) == 0 {

--- a/internal/server/public_target_health_test.go
+++ b/internal/server/public_target_health_test.go
@@ -484,6 +484,46 @@ func TestRouteFallbackSelectedWhenPrimaryAgentPoolUnavailable(t *testing.T) {
 	}
 }
 
+func TestRouteTargetLeastActiveUsesTargetHealthCounters(t *testing.T) {
+	app := NewApp(nil, nil)
+	busy := publicRouteTargetConfig{
+		ID:            91,
+		Enabled:       true,
+		TargetType:    publicRouteTargetTypeStatic,
+		Position:      0,
+		Weight:        1,
+		PriorityGroup: 0,
+	}
+	idle := publicRouteTargetConfig{
+		ID:            92,
+		Enabled:       true,
+		TargetType:    publicRouteTargetTypeStatic,
+		Position:      1,
+		Weight:        1,
+		PriorityGroup: 0,
+	}
+	route := publicRouteConfig{
+		ID:                  91,
+		Enabled:             true,
+		Action:              publicRouteActionForward,
+		TargetLoadBalancing: publicRouteTargetLoadBalancingLeastActiveRequests,
+		Targets:             []publicRouteTargetConfig{busy, idle},
+	}
+	snap := publicProxySnapshot{
+		RouteTargets: map[int64]publicRouteTargetConfig{
+			busy.ID: busy,
+			idle.ID: idle,
+		},
+	}
+	done := app.TargetHealth.beginRequest(busy.ID)
+	t.Cleanup(done)
+
+	selected, _, ok := app.selectRouteTarget(snap, route)
+	if !ok || selected.ID != idle.ID {
+		t.Fatalf("route target selection = target=%d ok=%v, want idle target %d", selected.ID, ok, idle.ID)
+	}
+}
+
 func TestAgentPassiveFailureAppliesWhenHealthCheckEnabled(t *testing.T) {
 	app, backend := testAgentPoolApp(t)
 	app.TargetHealth.markAgentPassiveFailure(backend.ID, 1, nil)

--- a/internal/server/public_tls_config.go
+++ b/internal/server/public_tls_config.go
@@ -14,6 +14,7 @@ import (
 	"unicode/utf8"
 
 	"connectrpc.com/connect"
+	"github.com/rs/zerolog/log"
 
 	p2pstreamv1 "p2pstream/gen/proto/p2pstream/v1"
 	"p2pstream/internal/config"
@@ -56,6 +57,13 @@ func (s *publicConfigService) createPublicTlsDnsCredential(
 	})
 	if err != nil {
 		return nil, publicDBError(err)
+	}
+	if err := a.refreshPublicProxySnapshot(ctx); err != nil {
+		log.Warn().
+			Err(err).
+			Int64("credential_id", credential.ID).
+			Str("credential", credential.Name).
+			Msg("Failed to refresh public proxy after TLS DNS credential create")
 	}
 	return connect.NewResponse(&p2pstreamv1.CreatePublicTlsDnsCredentialResponse{Credential: publicTLSDNSCredentialToProto(credential)}), nil
 }
@@ -312,6 +320,10 @@ func (s *publicConfigService) renewPublicTlsCertificate(
 	})
 	if err != nil {
 		return nil, publicDBError(err)
+	}
+	if err := a.refreshPublicProxySnapshot(ctx); err != nil {
+		publicACMELogCertificate(log.Warn().Err(err), cert, publicACMETriggerManual, publicACMEStageRefreshProxySnapshot).
+			Msg("Failed to refresh public proxy after ACME certificate manual renewal")
 	}
 	a.queuePublicACMECertificateIssue(cert, publicACMETriggerManual)
 	return connect.NewResponse(&p2pstreamv1.RenewPublicTlsCertificateResponse{TlsCertificate: publicTLSCertificateToProto(cert)}), nil

--- a/tests/integration/upstream_backend_test.go
+++ b/tests/integration/upstream_backend_test.go
@@ -60,14 +60,14 @@ func TestPublicRouteTargetUpstreamConfigAPIValidationAndReadback(t *testing.T) {
 		t.Fatalf("unexpected masked basic auth readback: %+v", got)
 	}
 	assertUpstreamHeaderProto(t, created, "X-Visible", "visible", false, true)
-	assertUpstreamHeaderProto(t, created, "Cookie", "", true, true)
-	assertUpstreamHeaderProto(t, created, "X-Secret", "", true, true)
+	assertUpstreamHeaderProto(t, created, "Cookie", "", true, false)
+	assertUpstreamHeaderProto(t, created, "X-Secret", "", true, false)
 
 	cfg = getPublicProxyConfig(t, client, cookie)
 	readBack := publicRouteTargetByName(t, cfg, "upstream-api")
 	assertUpstreamHeaderProto(t, readBack, "X-Visible", "visible", false, true)
-	assertUpstreamHeaderProto(t, readBack, "Cookie", "", true, true)
-	assertUpstreamHeaderProto(t, readBack, "X-Secret", "", true, true)
+	assertUpstreamHeaderProto(t, readBack, "Cookie", "", true, false)
+	assertUpstreamHeaderProto(t, readBack, "X-Secret", "", true, false)
 	if readBack.GetUpstreamBasicAuth().GetPassword() != "" || !readBack.GetUpstreamBasicAuth().GetPasswordSet() {
 		t.Fatalf("expected masked saved basic auth password in config, got %+v", readBack.GetUpstreamBasicAuth())
 	}

--- a/web/management/src/ManagementApp.vue
+++ b/web/management/src/ManagementApp.vue
@@ -3,7 +3,6 @@ import { RefreshCw as RefreshIcon } from "@lucide/vue";
 import { NAlert, NButton, NCard, NForm, NFormItem, NInput, NModal, NSelect, NSkeleton, useMessage, useNotification } from "naive-ui";
 import { computed, onMounted, provide } from "vue";
 import { useRoute } from "vue-router";
-import { managementClient } from "@/api/managementClient";
 import DisabledHint from "@/components/DisabledHint.vue";
 import ThemeToggle from "@/components/ui/ThemeToggle.vue";
 import {
@@ -51,6 +50,7 @@ const {
   selectedEnvironmentLabel,
   selectedEnvironmentBlocked,
   environmentSelectOptions,
+  managementClient,
   isRefreshing,
   loadEnvironments,
   loadDashboard,

--- a/web/management/src/api/managementClient.test.ts
+++ b/web/management/src/api/managementClient.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { createRoutedManagementClient, type ManagementClient } from "./managementClient";
+
+function fakeClient(label: string, calls: string[]): ManagementClient {
+  return {
+    getDashboard: async () => {
+      calls.push(label);
+      return { label };
+    },
+  } as unknown as ManagementClient;
+}
+
+describe("createRoutedManagementClient", () => {
+  test("delegates calls to the current app-scoped client", async () => {
+    const calls: string[] = [];
+    const first = fakeClient("first", calls);
+    const second = fakeClient("second", calls);
+    let current = first;
+    const client = createRoutedManagementClient(() => current, () => "");
+
+    expect(await client.getDashboard({})).toEqual({ label: "first" });
+    current = second;
+    expect(await client.getDashboard({})).toEqual({ label: "second" });
+    expect(calls).toEqual(["first", "second"]);
+  });
+
+  test("rejects blocked unary calls before resolving or invoking a client", async () => {
+    let resolved = false;
+    const client = createRoutedManagementClient(
+      () => {
+        resolved = true;
+        return fakeClient("blocked", []);
+      },
+      () => "Environment is disabled.",
+    );
+
+    await expect(client.getDashboard({})).rejects.toThrow("Environment is disabled.");
+    expect(resolved).toBe(false);
+  });
+
+  test("returns a blocked stream as an async iterable", async () => {
+    let resolved = false;
+    const client = createRoutedManagementClient(
+      () => {
+        resolved = true;
+        return fakeClient("blocked", []);
+      },
+      () => "Environment is disabled.",
+    );
+
+    const stream = client.streamTrafficTraceEvents({});
+    await expect(stream[Symbol.asyncIterator]().next()).rejects.toThrow("Environment is disabled.");
+    expect(resolved).toBe(false);
+  });
+});

--- a/web/management/src/api/managementClient.ts
+++ b/web/management/src/api/managementClient.ts
@@ -12,16 +12,38 @@ export function createManagementClient(baseUrl: string) {
 
 export type ManagementClient = ReturnType<typeof createManagementClient>;
 
-export const localManagementClient = createManagementClient(window.location.origin);
+const localOrigin = typeof window === "undefined" ? "http://localhost" : window.location.origin;
 
-let activeManagementClient: ManagementClient = localManagementClient;
+export const localManagementClient = createManagementClient(localOrigin);
 
-export function setActiveManagementClientBase(baseUrl: string) {
-  activeManagementClient = createManagementClient(baseUrl);
+export function createRoutedManagementClient(
+  resolveClient: () => ManagementClient,
+  resolveBlockedReason: () => string,
+): ManagementClient {
+  return new Proxy({} as ManagementClient, {
+    get(_target, prop) {
+      const blockedReason = resolveBlockedReason();
+      if (blockedReason) {
+        if (isStreamingManagementMethod(prop)) {
+          return async function* blockedStream() {
+            throw new Error(blockedReason);
+          };
+        }
+        return () => Promise.reject(new Error(blockedReason));
+      }
+
+      const client = resolveClient();
+      const value = Reflect.get(client, prop, client);
+      if (typeof value !== "function") return value;
+      return value.bind(client);
+    },
+  });
 }
 
-export const managementClient = new Proxy({} as ManagementClient, {
-  get(_target, prop, receiver) {
-    return Reflect.get(activeManagementClient, prop, receiver);
-  },
-});
+function isStreamingManagementMethod(prop: string | symbol): boolean {
+  if (typeof prop !== "string") return false;
+  const method = (AgentManagementService.method as Record<string, { methodKind?: string } | undefined>)[prop];
+  return method?.methodKind === "server_streaming" ||
+    method?.methodKind === "client_streaming" ||
+    method?.methodKind === "bidi_streaming";
+}

--- a/web/management/src/components/editors/PublicRouteEditorModal.vue
+++ b/web/management/src/components/editors/PublicRouteEditorModal.vue
@@ -33,6 +33,36 @@ import {
 const managementClient = useManagementClient();
 
 type RouteFormMode = "create" | "edit" | "clone";
+type UpstreamHeaderForm = {
+  id: string;
+  targetId: string;
+  name: string;
+  value: string;
+  sensitive: boolean;
+  valueSet: boolean;
+  position: number;
+};
+type BasicAuthForm = {
+  enabled: boolean;
+  username: string;
+  password: string;
+  passwordSet: boolean;
+};
+type HealthCheckForm = {
+  enabled: boolean;
+  method: string;
+  path: string;
+  intervalMillis: number;
+  timeoutMillis: number;
+  healthyThreshold: number;
+  unhealthyThreshold: number;
+  expectedStatusMin: number;
+  expectedStatusMax: number;
+};
+type ResponseHeaderForm = {
+  name: string;
+  value: string;
+};
 type TargetForm = {
   id: string;
   name: string;
@@ -43,10 +73,17 @@ type TargetForm = {
   selectorLabels: SelectorLabelRow[];
   priorityGroup: number;
   weight: number;
+  agentLoadBalancing: PublicRouteTargetLoadBalancing;
   tlsSkipVerify: boolean;
   responseHeaderTimeoutMillis: number;
+  upstreamRequestHeaders: UpstreamHeaderForm[];
+  upstreamBasicAuth: BasicAuthForm;
+  healthCheck: HealthCheckForm;
   staticStatusCode: number;
+  staticResponseHeaders: ResponseHeaderForm[];
   staticResponseBody: string;
+  staticResponseBodyMode: PublicResponseBodyMode;
+  staticResponseTemplateId: string;
 };
 
 const props = defineProps<{
@@ -109,6 +146,24 @@ const exactAgentOptions = computed(() => [
     value: agent.publicId,
   })),
 ]);
+
+function defaultBasicAuthForm(): BasicAuthForm {
+  return { enabled: false, username: "", password: "", passwordSet: false };
+}
+
+function defaultHealthCheckForm(): HealthCheckForm {
+  return {
+    enabled: false,
+    method: "GET",
+    path: "/",
+    intervalMillis: 10000,
+    timeoutMillis: 2000,
+    healthyThreshold: 2,
+    unhealthyThreshold: 2,
+    expectedStatusMin: 200,
+    expectedStatusMax: 399,
+  };
+}
 
 const routeForm = reactive({
   id: "",
@@ -177,10 +232,17 @@ function defaultTarget(index = routeForm.targets.length): TargetForm {
     selectorLabels: [newSelectorRow()],
     priorityGroup: 0,
     weight: 100,
+    agentLoadBalancing: PublicRouteTargetLoadBalancing.ROUND_ROBIN,
     tlsSkipVerify: false,
     responseHeaderTimeoutMillis: 60000,
+    upstreamRequestHeaders: [],
+    upstreamBasicAuth: defaultBasicAuthForm(),
+    healthCheck: defaultHealthCheckForm(),
     staticStatusCode: 200,
+    staticResponseHeaders: [],
     staticResponseBody: "",
+    staticResponseBodyMode: PublicResponseBodyMode.INLINE,
+    staticResponseTemplateId: "0",
   };
 }
 
@@ -203,11 +265,54 @@ function resetForm() {
   routeForm.enabled = true;
 }
 
-function targetFormFromProto(target: PublicRouteTarget): TargetForm {
+function upstreamHeadersFromProto(target: PublicRouteTarget, mode: "edit" | "clone"): UpstreamHeaderForm[] {
+  const preserveSecretReferences = mode === "edit";
+  return target.upstreamRequestHeaders
+    .filter((header) => preserveSecretReferences || header.valueSet || header.value !== "")
+    .map((header, index) => ({
+      id: preserveSecretReferences ? header.id.toString() : "",
+      targetId: preserveSecretReferences ? header.targetId.toString() : "",
+      name: header.name,
+      value: header.value,
+      sensitive: header.sensitive,
+      valueSet: preserveSecretReferences ? header.valueSet : header.value !== "",
+      position: Number(header.position || BigInt(index)),
+    }));
+}
+
+function basicAuthFromProto(target: PublicRouteTarget, mode: "edit" | "clone"): BasicAuthForm {
+  const auth = target.upstreamBasicAuth;
+  if (!auth?.enabled) return defaultBasicAuthForm();
+  if (mode === "clone" && auth.password === "" && auth.passwordSet) return defaultBasicAuthForm();
+  return {
+    enabled: auth.enabled,
+    username: auth.username,
+    password: auth.password,
+    passwordSet: auth.passwordSet || auth.password !== "",
+  };
+}
+
+function healthCheckFromProto(target: PublicRouteTarget): HealthCheckForm {
+  const check = target.healthCheck;
+  if (!check) return defaultHealthCheckForm();
+  return {
+    enabled: check.enabled,
+    method: check.method || "GET",
+    path: check.path || "/",
+    intervalMillis: Number(check.intervalMillis || 10000n),
+    timeoutMillis: Number(check.timeoutMillis || 2000n),
+    healthyThreshold: Number(check.healthyThreshold || 2n),
+    unhealthyThreshold: Number(check.unhealthyThreshold || 2n),
+    expectedStatusMin: Number(check.expectedStatusMin || 200n),
+    expectedStatusMax: Number(check.expectedStatusMax || 399n),
+  };
+}
+
+function targetFormFromProto(target: PublicRouteTarget, mode: "edit" | "clone"): TargetForm {
   const labels = target.agentSelector?.matchLabels ?? {};
   const selectorLabels = selectorRowsFromLabels(labels);
   return {
-    id: target.id.toString(),
+    id: mode === "clone" ? "" : target.id.toString(),
     name: target.name,
     enabled: target.enabled,
     targetType: target.targetType || PublicRouteTargetType.PROXY,
@@ -216,10 +321,17 @@ function targetFormFromProto(target: PublicRouteTarget): TargetForm {
     selectorLabels: selectorLabels.length ? selectorLabels.map(cloneSelectorRow) : [newSelectorRow()],
     priorityGroup: Number(target.priorityGroup || 0n),
     weight: Number(target.weight || 100n),
+    agentLoadBalancing: target.agentLoadBalancing || PublicRouteTargetLoadBalancing.ROUND_ROBIN,
     tlsSkipVerify: target.tlsSkipVerify,
     responseHeaderTimeoutMillis: Number(target.upstreamResponseHeaderTimeoutMillis || 60000n),
+    upstreamRequestHeaders: upstreamHeadersFromProto(target, mode),
+    upstreamBasicAuth: basicAuthFromProto(target, mode),
+    healthCheck: healthCheckFromProto(target),
     staticStatusCode: Number(target.staticStatusCode || 200n),
+    staticResponseHeaders: target.staticResponseHeaders.map((header) => ({ name: header.name, value: header.value })),
     staticResponseBody: target.staticResponseBody,
+    staticResponseBodyMode: target.staticResponseBodyMode || PublicResponseBodyMode.INLINE,
+    staticResponseTemplateId: (target.staticResponseTemplateId || 0n).toString(),
   };
 }
 
@@ -236,7 +348,7 @@ function populateRouteForm(route: PublicRoute, mode: "edit" | "clone") {
   routeForm.pathSecurityMode = route.pathSecurityMode || PublicRoutePathSecurityMode.STRICT;
   routeForm.targetLoadBalancing = route.targetLoadBalancing || PublicRouteTargetLoadBalancing.ROUND_ROBIN;
   routeForm.isDefault = route.isDefault;
-  routeForm.targets = action === PublicRouteAction.REDIRECT ? [] : route.targets.map(targetFormFromProto);
+  routeForm.targets = action === PublicRouteAction.REDIRECT ? [] : route.targets.map((target) => targetFormFromProto(target, mode));
   if (action !== PublicRouteAction.REDIRECT && !routeForm.targets.length) routeForm.targets = [defaultTarget(0)];
   routeForm.redirectTargetMode = route.redirectTargetMode || PublicRouteRedirectTargetMode.SAME_HOST_PATH;
   routeForm.redirectTarget = route.redirectTarget;
@@ -291,6 +403,41 @@ function selectorPayload(target: TargetForm): { matchLabels: Record<string, stri
   return { matchLabels: selectorRowsToRecord(target.selectorLabels) };
 }
 
+function upstreamHeaderPayload(header: UpstreamHeaderForm, index: number) {
+  return {
+    id: BigInt(header.id || "0"),
+    targetId: BigInt(header.targetId || "0"),
+    name: header.name,
+    value: header.value,
+    sensitive: header.sensitive,
+    valueSet: header.valueSet || header.value !== "",
+    position: BigInt(index),
+  };
+}
+
+function basicAuthPayload(auth: BasicAuthForm) {
+  return {
+    enabled: auth.enabled,
+    username: auth.username,
+    password: auth.password,
+    passwordSet: auth.passwordSet || auth.password !== "",
+  };
+}
+
+function healthCheckPayload(check: HealthCheckForm) {
+  return {
+    enabled: check.enabled,
+    method: check.method || "GET",
+    path: check.path || "/",
+    intervalMillis: BigInt(Math.max(1, check.intervalMillis || 10000)),
+    timeoutMillis: BigInt(Math.max(1, check.timeoutMillis || 2000)),
+    healthyThreshold: BigInt(Math.max(1, check.healthyThreshold || 2)),
+    unhealthyThreshold: BigInt(Math.max(1, check.unhealthyThreshold || 2)),
+    expectedStatusMin: BigInt(Math.max(100, check.expectedStatusMin || 200)),
+    expectedStatusMax: BigInt(Math.max(100, check.expectedStatusMax || 399)),
+  };
+}
+
 function targetPayload(target: TargetForm, index: number) {
   const isStatic = target.targetType === PublicRouteTargetType.STATIC;
   return {
@@ -304,27 +451,17 @@ function targetPayload(target: TargetForm, index: number) {
     url: isStatic ? "" : target.url.trim(),
     transport: isStatic ? PublicRouteTargetTransport.DIRECT : target.transport,
     agentSelector: selectorPayload(target),
-    agentLoadBalancing: PublicRouteTargetLoadBalancing.ROUND_ROBIN,
+    agentLoadBalancing: isStatic ? PublicRouteTargetLoadBalancing.ROUND_ROBIN : target.agentLoadBalancing,
     tlsSkipVerify: !isStatic && target.tlsSkipVerify,
     upstreamResponseHeaderTimeoutMillis: BigInt(Math.max(1, target.responseHeaderTimeoutMillis || 60000)),
-    upstreamRequestHeaders: [],
-    upstreamBasicAuth: { enabled: false, username: "", password: "", passwordSet: false },
-    healthCheck: {
-      enabled: false,
-      method: "GET",
-      path: "/",
-      intervalMillis: 10000n,
-      timeoutMillis: 2000n,
-      healthyThreshold: 2n,
-      unhealthyThreshold: 2n,
-      expectedStatusMin: 200n,
-      expectedStatusMax: 399n,
-    },
+    upstreamRequestHeaders: isStatic ? [] : target.upstreamRequestHeaders.map(upstreamHeaderPayload),
+    upstreamBasicAuth: isStatic ? defaultBasicAuthForm() : basicAuthPayload(target.upstreamBasicAuth),
+    healthCheck: isStatic ? healthCheckPayload(defaultHealthCheckForm()) : healthCheckPayload(target.healthCheck),
     staticStatusCode: BigInt(isStatic ? target.staticStatusCode || 200 : 200),
-    staticResponseHeaders: [],
+    staticResponseHeaders: isStatic ? target.staticResponseHeaders.map((header) => ({ name: header.name, value: header.value })) : [],
     staticResponseBody: isStatic ? target.staticResponseBody : "",
-    staticResponseBodyMode: PublicResponseBodyMode.INLINE,
-    staticResponseTemplateId: 0n,
+    staticResponseBodyMode: isStatic ? target.staticResponseBodyMode : PublicResponseBodyMode.INLINE,
+    staticResponseTemplateId: BigInt(isStatic ? target.staticResponseTemplateId || "0" : "0"),
   };
 }
 

--- a/web/management/src/composables/useDashboardRefresh.ts
+++ b/web/management/src/composables/useDashboardRefresh.ts
@@ -1,5 +1,10 @@
 import { computed, onScopeDispose, ref, watch, type Ref } from "vue";
-import { localManagementClient, managementClient, setActiveManagementClientBase } from "@/api/managementClient";
+import {
+  createManagementClient,
+  createRoutedManagementClient,
+  localManagementClient,
+  type ManagementClient,
+} from "@/api/managementClient";
 import { messageFromError } from "@/lib/errors";
 import {
   EnvironmentTrustState,
@@ -25,6 +30,7 @@ export function useDashboardRefresh({ currentUser, error, isBusy, isLoading }: D
   const isRefreshing = ref(false);
   const pendingDashboardReload = ref(false);
   const refreshTimer = ref<number | null>(null);
+  const remoteManagementClients = new Map<string, ManagementClient>();
 
   const environmentOptions = computed(() => [
     { id: "0", name: "Local", enabled: true, trustState: EnvironmentTrustState.TRUSTED },
@@ -38,19 +44,41 @@ export function useDashboardRefresh({ currentUser, error, isBusy, isLoading }: D
   const environmentSelectOptions = computed(() => environmentOptions.value.map((environment) => ({
     label: `${environment.name}${environment.enabled ? "" : " (disabled)"}`,
     value: environment.id,
+    disabled: environment.id !== "0" && (environment.trustState !== EnvironmentTrustState.TRUSTED || !environment.enabled),
   })));
   const selectedRemoteEnvironment = computed(() => {
     if (selectedEnvironmentId.value === "0") return null;
     return environments.value.find((environment) => environment.id.toString() === selectedEnvironmentId.value) ?? null;
   });
-  const selectedEnvironmentLabel = computed(() => selectedRemoteEnvironment.value?.name ?? "Local");
+  const selectedEnvironmentLabel = computed(() => {
+    if (selectedEnvironmentId.value === "0") return "Local";
+    return selectedRemoteEnvironment.value?.name ?? "Unavailable environment";
+  });
   const selectedEnvironmentBlocked = computed(() => {
+    if (selectedEnvironmentId.value !== "0" && !selectedRemoteEnvironment.value) {
+      return "Selected environment is no longer available.";
+    }
     const environment = selectedRemoteEnvironment.value;
     if (!environment) return "";
     if (!environment.enabled) return "Environment is disabled.";
     if (environment.trustState !== EnvironmentTrustState.TRUSTED) return "Environment certificate must be trusted before management requests can run.";
     return "";
   });
+  const selectedManagementClient = computed(() => {
+    const environment = selectedRemoteEnvironment.value;
+    if (!environment) return localManagementClient;
+    const baseUrl = remoteEnvironmentBaseUrl(environment.id);
+    let client = remoteManagementClients.get(baseUrl);
+    if (!client) {
+      client = createManagementClient(baseUrl);
+      remoteManagementClients.set(baseUrl, client);
+    }
+    return client;
+  });
+  const managementClient = createRoutedManagementClient(
+    () => selectedManagementClient.value,
+    () => selectedEnvironmentBlocked.value,
+  );
 
   function loadSelectedEnvironmentId(): string {
     try {
@@ -68,26 +96,35 @@ export function useDashboardRefresh({ currentUser, error, isBusy, isLoading }: D
     }
   }
 
+  function remoteEnvironmentBaseUrl(environmentId: bigint | string): string {
+    return `${window.location.origin}/environments/${environmentId.toString()}`;
+  }
+
+  function pruneRemoteManagementClients() {
+    const activeBaseUrls = new Set(environments.value.map((environment) => remoteEnvironmentBaseUrl(environment.id)));
+    for (const baseUrl of remoteManagementClients.keys()) {
+      if (!activeBaseUrls.has(baseUrl)) {
+        remoteManagementClients.delete(baseUrl);
+      }
+    }
+  }
+
   async function loadEnvironments() {
     if (!currentUser.value) {
       environments.value = [];
+      remoteManagementClients.clear();
       selectedEnvironmentId.value = "0";
       return;
     }
     const resp = await localManagementClient.listEnvironments({});
     environments.value = resp.environments;
-    if (selectedEnvironmentId.value !== "0" && !environments.value.some((environment) => environment.id.toString() === selectedEnvironmentId.value && environment.enabled)) {
+    pruneRemoteManagementClients();
+    if (selectedEnvironmentId.value !== "0" && !environments.value.some((environment) => environment.id.toString() === selectedEnvironmentId.value)) {
       selectedEnvironmentId.value = "0";
     }
   }
 
-  function syncSelectedEnvironmentClient() {
-    const environment = selectedRemoteEnvironment.value;
-    if (!environment) {
-      setActiveManagementClientBase(window.location.origin);
-    } else {
-      setActiveManagementClientBase(`${window.location.origin}/environments/${environment.id.toString()}`);
-    }
+  function syncSelectedEnvironmentSelection() {
     persistSelectedEnvironmentId();
   }
 
@@ -100,8 +137,9 @@ export function useDashboardRefresh({ currentUser, error, isBusy, isLoading }: D
     stopAutoRefresh();
     clearDashboardState();
     environments.value = [];
+    remoteManagementClients.clear();
     selectedEnvironmentId.value = "0";
-    syncSelectedEnvironmentClient();
+    syncSelectedEnvironmentSelection();
   }
 
   async function loadDashboard() {
@@ -112,20 +150,27 @@ export function useDashboardRefresh({ currentUser, error, isBusy, isLoading }: D
     isRefreshing.value = true;
     error.value = null;
     const loadEnvironmentId = selectedEnvironmentId.value;
+    const loadBlockedReason = selectedEnvironmentBlocked.value;
+    if (loadBlockedReason) {
+      clearDashboardState();
+      pendingDashboardReload.value = false;
+      isRefreshing.value = false;
+      return;
+    }
+    const loadClient = selectedManagementClient.value;
     try {
-      syncSelectedEnvironmentClient();
       const [dashboardResp, publicProxyResp] = await Promise.all([
-        managementClient.getDashboard({}),
-        managementClient.getPublicProxyConfig({}),
+        loadClient.getDashboard({}),
+        loadClient.getPublicProxyConfig({}),
       ]);
-      if (loadEnvironmentId !== selectedEnvironmentId.value) {
+      if (loadEnvironmentId !== selectedEnvironmentId.value || loadBlockedReason !== selectedEnvironmentBlocked.value) {
         pendingDashboardReload.value = true;
         return;
       }
       dashboard.value = dashboardResp;
       publicProxyConfig.value = publicProxyResp;
     } catch (err) {
-      if (loadEnvironmentId === selectedEnvironmentId.value) {
+      if (loadEnvironmentId === selectedEnvironmentId.value && loadBlockedReason === selectedEnvironmentBlocked.value) {
         error.value = messageFromError(err);
       } else {
         pendingDashboardReload.value = true;
@@ -143,7 +188,7 @@ export function useDashboardRefresh({ currentUser, error, isBusy, isLoading }: D
     stopAutoRefresh();
     if (!currentUser.value) return;
     refreshTimer.value = window.setInterval(() => {
-      if (!currentUser.value || isBusy.value || isRefreshing.value) return;
+      if (!currentUser.value || selectedEnvironmentBlocked.value || isBusy.value || isRefreshing.value) return;
       void loadDashboard();
     }, 5000);
   }
@@ -159,15 +204,16 @@ export function useDashboardRefresh({ currentUser, error, isBusy, isLoading }: D
 
   async function loadAuthenticatedData() {
     await loadEnvironments();
-    syncSelectedEnvironmentClient();
+    syncSelectedEnvironmentSelection();
     await loadDashboard();
     startAutoRefresh();
   }
 
-  watch(selectedEnvironmentId, () => {
-    syncSelectedEnvironmentClient();
+  watch([selectedEnvironmentId, selectedEnvironmentBlocked], () => {
+    syncSelectedEnvironmentSelection();
     if (!currentUser.value) return;
     clearDashboardState();
+    if (selectedEnvironmentBlocked.value) return;
     if (isLoading.value) {
       pendingDashboardReload.value = true;
       return;
@@ -183,6 +229,7 @@ export function useDashboardRefresh({ currentUser, error, isBusy, isLoading }: D
     selectedEnvironmentLabel,
     selectedEnvironmentBlocked,
     environmentSelectOptions,
+    managementClient,
     isRefreshing,
     loadEnvironments,
     loadDashboard,

--- a/web/management/src/composables/useManagementClient.ts
+++ b/web/management/src/composables/useManagementClient.ts
@@ -1,7 +1,7 @@
 import { inject } from "vue";
-import { managementClient, type ManagementClient } from "@/api/managementClient";
+import { localManagementClient, type ManagementClient } from "@/api/managementClient";
 import { managementClientKey } from "@/composables/managementContextKeys";
 
 export function useManagementClient(): ManagementClient {
-  return inject(managementClientKey, managementClient);
+  return inject(managementClientKey, localManagementClient);
 }

--- a/web/management/src/views/Traffic.vue
+++ b/web/management/src/views/Traffic.vue
@@ -2,7 +2,7 @@
 import { computed, h, inject, onBeforeUnmount, onMounted, ref, shallowRef, watch } from "vue";
 import { NAlert, NButton, NCheckbox, NDataTable, NRadioButton, NRadioGroup, NTag } from "naive-ui";
 import type { DataTableColumns } from "naive-ui";
-import { dashboardKey, publicProxyConfigKey, selectedEnvironmentIdKey } from "@/composables/managementContextKeys";
+import { dashboardKey, publicProxyConfigKey, selectedEnvironmentBlockedKey, selectedEnvironmentIdKey } from "@/composables/managementContextKeys";
 import { useManagementClient } from "@/composables/useManagementClient";
 import DisabledHint from "@/components/DisabledHint.vue";
 import PublicProxyEditorHost from "@/components/editors/PublicProxyEditorHost.vue";
@@ -23,6 +23,7 @@ const managementClient = useManagementClient();
 const dashboard = inject(dashboardKey, computed(() => null));
 const publicProxyConfig = inject(publicProxyConfigKey, computed(() => null));
 const selectedEnvironmentId = inject(selectedEnvironmentIdKey, computed(() => "0"));
+const selectedEnvironmentBlocked = inject(selectedEnvironmentBlockedKey, computed(() => ""));
 
 const config = computed(() => publicProxyConfig?.value ?? null);
 
@@ -116,6 +117,7 @@ const streamStateTagType = computed(() => {
 });
 
 async function loadTraceSettings(loadVersion: number) {
+  if (selectedEnvironmentBlocked.value) return;
   try {
     const resp = await managementClient.getTrafficTraceSettings({});
     if (loadVersion !== traceSettingsLoadVersion) return;
@@ -140,7 +142,7 @@ async function setTraceLevel(level: TrafficTraceLevel) {
 }
 
 async function updateTraceSettings(enabled: boolean, level: TrafficTraceLevel) {
-  if (isTraceBusy.value) return;
+  if (isTraceBusy.value || selectedEnvironmentBlocked.value) return;
   isTraceBusy.value = true;
   streamError.value = "";
   try {
@@ -169,7 +171,7 @@ function applyTraceSettings(settings: TrafficTraceSettings | null) {
 }
 
 function startTraceStream() {
-  if (streamController || !traceSettings.value?.enabled) return;
+  if (streamController || !traceSettings.value?.enabled || selectedEnvironmentBlocked.value) return;
   clearRetryTimer();
   streamController = new AbortController();
   streamState.value = "connecting";
@@ -324,16 +326,19 @@ function streamStateLabel(): string {
 onMounted(() => {
   window.addEventListener("pagehide", handlePageHide);
   traceSettingsLoadVersion += 1;
-  void loadTraceSettings(traceSettingsLoadVersion);
+  if (!selectedEnvironmentBlocked.value) {
+    void loadTraceSettings(traceSettingsLoadVersion);
+  }
 });
 
-watch(selectedEnvironmentId, () => {
+watch([selectedEnvironmentId, selectedEnvironmentBlocked], () => {
   traceSettingsLoadVersion += 1;
   stopTraceStream("idle");
   traceStore.clear();
   selectedRequestId.value = null;
   traceSettings.value = null;
   streamError.value = "";
+  if (selectedEnvironmentBlocked.value) return;
   void loadTraceSettings(traceSettingsLoadVersion);
 });
 


### PR DESCRIPTION
## Summary
- refresh public proxy snapshots after TLS/ACME mutations and use real active request counters for least-active route target balancing
- preserve masked sensitive upstream headers and basic-auth passwords on route updates while keeping omission as deletion
- tighten management UI SPA fallback behavior and replace global mutable management client state with app-scoped routed clients
- preserve hidden route-target fields in the route editor and block disabled/untrusted remote environment calls before fetch

## Verification
- go test ./...
- cd web/management && bun test src
- cd web/management && bun run typecheck
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-environment management client routing with environment blocking capabilities.
  * Enhanced public route target configuration with upstream headers, basic auth, health checks, and response settings.

* **Bug Fixes**
  * Fixed management UI SPA fallback to properly restrict to HTML requests and prevent asset path fallback.
  * Improved least-active load balancing to use actual in-flight request counts.
  * Fixed sensitive header masking in API responses with correct metadata.

* **Improvements**
  * Route updates now preserve existing sensitive credentials.
  * Proxy snapshot refreshed after ACME renewal and TLS operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->