### PR TITLE
Add traffic policy workbench UI

### DIFF
--- a/docs/concepts/cache.md
+++ b/docs/concepts/cache.md
@@ -26,7 +26,7 @@ Requests are never cached when they include:
 - WebSocket or other upgrade headers,
 - methods other than `GET` or `HEAD`.
 
-Requests with `Cookie` bypass cache by default. A cache rule can explicitly enable `allow_cookie_requests` for precise public asset matches, such as hashed JavaScript, CSS, images, or fonts. Cookie values are ignored for the cache key and are never stored.
+Requests with `Cookie` always bypass shared cache. The legacy `allow_cookie_requests` field may still appear in older configuration, but it is preserved only for compatibility and has no runtime effect.
 
 Responses are never cached when they include `Set-Cookie`, `Cache-Control: no-store`, `private`, or `no-cache`, `Vary: *`, `Vary: Cookie`, `Vary: Authorization`, a disallowed status code, or a body larger than the rule maximum object size.
 

--- a/web/management/src/components/editors/PublicCacheRuleEditorModal.vue
+++ b/web/management/src/components/editors/PublicCacheRuleEditorModal.vue
@@ -155,7 +155,7 @@ const submitDisabledReason = computed(() => {
   if (varyHeadersValidationReason.value) return varyHeadersValidationReason.value;
   if (cacheStatusCodesValidationReason.value) return cacheStatusCodesValidationReason.value;
   if (policyMatchValidationReason(form.match)) return policyMatchValidationReason(form.match);
-  if (form.allowCookieRequests && !form.allowCookieRequestsAcknowledged) return "Acknowledge the Cookie cache key behavior.";
+  if (form.allowCookieRequests && !form.allowCookieRequestsAcknowledged) return "Acknowledge the legacy Cookie flag behavior.";
   return "";
 });
 const submitDisabled = computed(() => Boolean(submitDisabledReason.value));
@@ -449,13 +449,13 @@ defineExpose({ openCreate, openEdit, close });
       <section class="layout-grid space-lg round-md framed frame-standard muted-bg pad-lg">
         <h4 class="copy-sm weight-semibold base-text">Cache behavior</h4>
         <p class="copy-xs line-normal muted-text">
-          Authorization requests are always bypassed. Cookie requests are cached only when this rule allows them. Responses with Set-Cookie, no-store, private, or no-cache are never cached.
+          Authorization and Cookie requests always bypass shared cache. Responses with Set-Cookie, no-store, private, or no-cache are never cached.
         </p>
         <NCheckbox v-model:checked="form.allowCookieRequests" class="round-md framed frame-standard muted-bg pad-md">
           <span class="layout-grid space-2xs">
-            <span class="weight-medium base-text">Cache requests with Cookie headers</span>
+            <span class="weight-medium base-text">Preserve legacy Cookie opt-in flag</span>
             <span class="copy-xs line-normal muted-text">
-              Enable this only for public static asset rules. Cookie values are ignored and are never part of the cache key.
+              This compatibility flag has no runtime effect; Cookie requests still bypass shared cache.
             </span>
           </span>
         </NCheckbox>
@@ -465,9 +465,9 @@ defineExpose({ openCreate, openEdit, close });
           class="round-md framed frame-standard panel-bg pad-md"
         >
           <span class="layout-grid space-2xs">
-            <span class="weight-medium base-text">I understand Cookie is ignored in this cache key</span>
+            <span class="weight-medium base-text">I understand Cookie requests still bypass cache</span>
             <span class="copy-xs line-normal muted-text">
-              Only use this for responses that are identical for every visitor, even when the request includes cookies.
+              Keep this only when preserving legacy configuration shape; clear it for new cache rules.
             </span>
           </span>
         </NCheckbox>
@@ -490,7 +490,7 @@ defineExpose({ openCreate, openEdit, close });
           </label>
         </div>
         <p class="copy-xs line-normal muted-text">
-          Responses with Set-Cookie, private/no-store/no-cache, Vary: Cookie, or Vary: Authorization are never stored, even when cookie requests are enabled above.
+          Responses with Set-Cookie, private/no-store/no-cache, Vary: Cookie, or Vary: Authorization are never stored.
         </p>
       </section>
 

--- a/web/management/src/components/editors/PublicPolicyMatchEditor.vue
+++ b/web/management/src/components/editors/PublicPolicyMatchEditor.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import { NButton, NButtonGroup, NInput } from "naive-ui";
 import PolicyMatchGroupEditor from "@/components/editors/PolicyMatchGroupEditor.vue";
 import {
+  builderToCEL,
   policyMatchValidationReason,
   syncGeneratedExpressionForExpertMode,
   type PolicyMatchForm,
@@ -10,6 +12,14 @@ import {
 const props = defineProps<{
   form: PolicyMatchForm;
 }>();
+
+const matchSummary = computed(() => {
+  if (props.form.mode === "expression") {
+    const expression = props.form.expression.trim();
+    return expression ? expression : "true";
+  }
+  return builderToCEL(props.form.root) || "true";
+});
 
 function switchMode(mode: "builder" | "expression") {
   if (mode === props.form.mode) return;
@@ -44,10 +54,12 @@ defineExpose({ validationReason });
         spellcheck="false"
         placeholder='method == "POST" && path_prefix(path, "/login")'
       />
+      <p class="match-expression-summary mono-text">{{ matchSummary }}</p>
     </div>
 
     <div v-else class="builder-panel">
       <PolicyMatchGroupEditor :group="form.root" root />
+      <p class="match-expression-summary mono-text">{{ matchSummary }}</p>
       <p v-if="validationReason()" class="field-error">{{ validationReason() }}</p>
     </div>
   </section>
@@ -94,5 +106,19 @@ defineExpose({ validationReason });
 .field-error {
   color: var(--app-error);
   font-size: 0.78rem;
+}
+
+.match-expression-summary {
+  max-height: 4.5rem;
+  overflow: auto;
+  border: 1px solid var(--app-border-subtle);
+  border-radius: 5px;
+  background: var(--app-panel);
+  color: var(--app-text-muted);
+  font-size: 0.72rem;
+  line-height: 1.45;
+  padding: 0.5rem 0.625rem;
+  text-transform: none;
+  letter-spacing: 0;
 }
 </style>

--- a/web/management/src/components/editors/PublicResponseTemplateEditorModal.vue
+++ b/web/management/src/components/editors/PublicResponseTemplateEditorModal.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
-import { computed, inject, reactive, ref } from "vue";
+import { computed, defineAsyncComponent, inject, reactive, ref } from "vue";
 import { NButton, NInput, NModal, NSelect } from "naive-ui";
 import { isBusyKey, runManagementActionKey } from "@/composables/managementContextKeys";
 import { useManagementClient } from "@/composables/useManagementClient";
 import DisabledHint from "@/components/DisabledHint.vue";
-import HtmlTemplateEditor from "@/components/editors/HtmlTemplateEditor.vue";
 import { BUSY_REASON } from "@/lib/disabledReasons";
 import { modalCardStyle } from "@/lib/naiveUi";
 import {
@@ -14,6 +13,7 @@ import {
 
 const managementClient = useManagementClient();
 
+const HtmlTemplateEditor = defineAsyncComponent(() => import("@/components/editors/HtmlTemplateEditor.vue"));
 
 const emit = defineEmits<{
   (event: "saved"): void;

--- a/web/management/src/components/traffic-policy/TrafficPolicyExecutionOrderStrip.vue
+++ b/web/management/src/components/traffic-policy/TrafficPolicyExecutionOrderStrip.vue
@@ -1,0 +1,480 @@
+<script setup lang="ts">
+import { computed, type Component } from "vue";
+import {
+  Database as DatabaseIcon,
+  Gauge as GaugeIcon,
+  ListOrdered as ListOrderedIcon,
+  Network as NetworkIcon,
+  Route as RouteIcon,
+  Send as SendIcon,
+  Server as ServerIcon,
+  ShieldCheck as ShieldCheckIcon,
+  SlidersHorizontal as SlidersIcon,
+} from "@lucide/vue";
+import { NTag } from "naive-ui";
+
+type ExecutionStageState = "match" | "unknown" | "no-match";
+type AttentionTone = "neutral" | "info" | "success" | "warning" | "error";
+type NaiveTagType = "default" | "info" | "success" | "warning" | "error";
+type ExecutionStageIcon =
+  | "listener"
+  | "waf"
+  | "rate-limit"
+  | "traffic-shaper"
+  | "route"
+  | "cache"
+  | "target"
+  | "response";
+
+type AttentionTag = {
+  label: string;
+  tone?: AttentionTone;
+  title?: string;
+};
+
+type ExecutionStage = {
+  key: string;
+  label: string;
+  description?: string;
+  state?: ExecutionStageState;
+  tags?: readonly AttentionTag[];
+  icon?: ExecutionStageIcon;
+  disabled?: boolean;
+};
+
+defineOptions({
+  name: "TrafficPolicyExecutionOrderStrip",
+});
+
+const props = withDefaults(defineProps<{
+  modelValue?: string;
+  stages?: readonly ExecutionStage[];
+  title?: string;
+  description?: string;
+  ariaLabel?: string;
+  selectable?: boolean;
+}>(), {
+  title: "Execution Order",
+  description: "",
+  ariaLabel: "Traffic policy execution order",
+  selectable: false,
+});
+
+const emit = defineEmits<{
+  (event: "update:modelValue", value: string): void;
+  (event: "select", stage: ExecutionStage): void;
+}>();
+
+const defaultExecutionStages: readonly ExecutionStage[] = [
+  {
+    key: "listener",
+    label: "Listener",
+    description: "Protocol, host, path, IP",
+    icon: "listener",
+  },
+  {
+    key: "waf",
+    label: "WAF",
+    description: "Block, challenge, queue",
+    icon: "waf",
+  },
+  {
+    key: "rate-limit",
+    label: "Rate Limits",
+    description: "Request budgets",
+    icon: "rate-limit",
+  },
+  {
+    key: "traffic-shaper",
+    label: "Traffic Shaper",
+    description: "Bandwidth budgets",
+    icon: "traffic-shaper",
+  },
+  {
+    key: "route",
+    label: "Route",
+    description: "Public route match",
+    icon: "route",
+  },
+  {
+    key: "cache",
+    label: "Cache",
+    description: "Lookup and store",
+    icon: "cache",
+  },
+  {
+    key: "target",
+    label: "Target",
+    description: "Backend selection",
+    icon: "target",
+  },
+  {
+    key: "response",
+    label: "Response",
+    description: "Final handling",
+    icon: "response",
+  },
+];
+
+const visibleStages = computed(() => props.stages?.length ? props.stages : defaultExecutionStages);
+const selectedKey = computed(() => props.modelValue || visibleStages.value[0]?.key || "");
+
+const iconByName: Record<ExecutionStageIcon, Component> = {
+  listener: NetworkIcon,
+  waf: ShieldCheckIcon,
+  "rate-limit": GaugeIcon,
+  "traffic-shaper": SlidersIcon,
+  route: RouteIcon,
+  cache: DatabaseIcon,
+  target: ServerIcon,
+  response: SendIcon,
+};
+
+function selectStage(stage: ExecutionStage) {
+  if (!props.selectable || stage.disabled) return;
+  emit("update:modelValue", stage.key);
+  emit("select", stage);
+}
+
+function stageClasses(stage: ExecutionStage): Array<string | Record<string, boolean>> {
+  return [
+    stage.state ? `tp-order-strip__stage--${stage.state}` : "",
+    {
+      "tp-order-strip__stage--active": props.selectable && selectedKey.value === stage.key,
+      "tp-order-strip__stage--static": !props.selectable,
+      "tp-order-strip__stage--disabled": stage.disabled === true,
+    },
+  ];
+}
+
+function iconFor(stage: ExecutionStage): Component {
+  return stage.icon ? iconByName[stage.icon] : ListOrderedIcon;
+}
+
+function stateLabel(state?: ExecutionStageState): string {
+  switch (state) {
+    case "match":
+      return "Match";
+    case "no-match":
+      return "No match";
+    case "unknown":
+      return "Unknown";
+    default:
+      return "";
+  }
+}
+
+function stateTagType(state?: ExecutionStageState): NaiveTagType {
+  switch (state) {
+    case "match":
+      return "success";
+    case "unknown":
+      return "warning";
+    case "no-match":
+      return "default";
+    default:
+      return "default";
+  }
+}
+
+function attentionTagType(tone?: AttentionTone): NaiveTagType {
+  switch (tone) {
+    case "success":
+      return "success";
+    case "warning":
+      return "warning";
+    case "error":
+      return "error";
+    case "info":
+      return "info";
+    default:
+      return "default";
+  }
+}
+</script>
+
+<template>
+  <section class="tp-order-strip surface-card" :aria-label="ariaLabel">
+    <div v-if="title || description" class="tp-order-strip__header">
+      <div class="tp-order-strip__heading">
+        <h3 v-if="title" class="tp-order-strip__title">{{ title }}</h3>
+        <p v-if="description" class="tp-order-strip__description">{{ description }}</p>
+      </div>
+    </div>
+
+    <ol class="tp-order-strip__rail">
+      <li
+        v-for="(stage, index) in visibleStages"
+        :key="stage.key"
+        class="tp-order-strip__item"
+        :class="{ 'tp-order-strip__item--last': index === visibleStages.length - 1 }"
+      >
+        <button
+          v-if="selectable"
+          class="tp-order-strip__stage"
+          :class="stageClasses(stage)"
+          type="button"
+          :disabled="stage.disabled"
+          :aria-current="selectedKey === stage.key ? 'step' : undefined"
+          @click="selectStage(stage)"
+        >
+          <span class="tp-order-strip__icon" aria-hidden="true">
+            <component :is="iconFor(stage)" class="tp-order-strip__icon-svg" />
+          </span>
+          <span class="tp-order-strip__content">
+            <span class="tp-order-strip__label">{{ stage.label }}</span>
+            <span v-if="stage.description" class="tp-order-strip__stage-description">
+              {{ stage.description }}
+            </span>
+          </span>
+          <span class="tp-order-strip__status">
+            <NTag v-if="stage.state" size="small" :bordered="false" :type="stateTagType(stage.state)">
+              {{ stateLabel(stage.state) }}
+            </NTag>
+            <NTag
+              v-for="tag in stage.tags || []"
+              :key="`${stage.key}-${tag.label}`"
+              size="small"
+              :bordered="false"
+              :type="attentionTagType(tag.tone)"
+              :title="tag.title || tag.label"
+            >
+              {{ tag.label }}
+            </NTag>
+          </span>
+        </button>
+        <div v-else class="tp-order-strip__stage" :class="stageClasses(stage)">
+          <span class="tp-order-strip__icon" aria-hidden="true">
+            <component :is="iconFor(stage)" class="tp-order-strip__icon-svg" />
+          </span>
+          <span class="tp-order-strip__content">
+            <span class="tp-order-strip__label">{{ stage.label }}</span>
+            <span v-if="stage.description" class="tp-order-strip__stage-description">
+              {{ stage.description }}
+            </span>
+          </span>
+          <span class="tp-order-strip__status">
+            <NTag v-if="stage.state" size="small" :bordered="false" :type="stateTagType(stage.state)">
+              {{ stateLabel(stage.state) }}
+            </NTag>
+            <NTag
+              v-for="tag in stage.tags || []"
+              :key="`${stage.key}-${tag.label}`"
+              size="small"
+              :bordered="false"
+              :type="attentionTagType(tag.tone)"
+              :title="tag.title || tag.label"
+            >
+              {{ tag.label }}
+            </NTag>
+          </span>
+        </div>
+      </li>
+    </ol>
+  </section>
+</template>
+
+<style scoped>
+.tp-order-strip {
+  overflow: hidden;
+}
+
+.tp-order-strip__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--app-border-subtle);
+  padding: 0.875rem 1rem;
+}
+
+.tp-order-strip__heading {
+  min-width: 0;
+}
+
+.tp-order-strip__title {
+  margin: 0;
+  color: var(--app-text);
+  font-size: 0.95rem;
+  font-weight: 650;
+  letter-spacing: 0;
+}
+
+.tp-order-strip__description {
+  margin: 0.25rem 0 0;
+  color: var(--app-text-muted);
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.tp-order-strip__rail {
+  display: grid;
+  grid-auto-columns: minmax(9.5rem, 1fr);
+  grid-auto-flow: column;
+  gap: 0;
+  margin: 0;
+  overflow-x: auto;
+  padding: 0;
+  list-style: none;
+}
+
+.tp-order-strip__item {
+  position: relative;
+  min-width: 0;
+}
+
+.tp-order-strip__item::after {
+  position: absolute;
+  top: 1.75rem;
+  right: -0.5rem;
+  z-index: 1;
+  width: 1rem;
+  height: 1px;
+  background: var(--app-border);
+  content: "";
+}
+
+.tp-order-strip__item--last::after {
+  display: none;
+}
+
+.tp-order-strip__stage {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1.875rem minmax(0, 1fr);
+  grid-template-rows: minmax(2.5rem, auto) auto;
+  gap: 0.5rem 0.625rem;
+  width: 100%;
+  min-height: 6.5rem;
+  border: 0;
+  border-right: 1px solid var(--app-border-subtle);
+  border-left: 3px solid transparent;
+  background: var(--app-panel);
+  color: var(--app-text);
+  cursor: pointer;
+  padding: 0.75rem 0.875rem;
+  text-align: left;
+  transition: background-color 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.tp-order-strip__stage:hover,
+.tp-order-strip__stage:focus-visible {
+  background: var(--app-panel-muted);
+}
+
+.tp-order-strip__stage:focus-visible {
+  outline: 2px solid var(--app-accent);
+  outline-offset: -2px;
+}
+
+.tp-order-strip__stage:disabled,
+.tp-order-strip__stage--disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+
+.tp-order-strip__stage--static {
+  cursor: default;
+}
+
+.tp-order-strip__stage--static:hover {
+  background: var(--app-panel);
+}
+
+.tp-order-strip__stage--active {
+  background: color-mix(in srgb, var(--app-accent-soft) 60%, var(--app-panel));
+  box-shadow: inset 0 0 0 1px var(--app-accent-soft);
+}
+
+.tp-order-strip__stage--match {
+  border-left-color: var(--app-success);
+}
+
+.tp-order-strip__stage--unknown {
+  border-left-color: var(--app-warning);
+}
+
+.tp-order-strip__stage--no-match {
+  border-left-color: var(--app-border);
+}
+
+.tp-order-strip__icon {
+  display: inline-flex;
+  width: 1.875rem;
+  height: 1.875rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
+  background: var(--app-panel-muted);
+  color: var(--app-text-muted);
+}
+
+.tp-order-strip__stage--active .tp-order-strip__icon {
+  border-color: color-mix(in srgb, var(--app-accent) 44%, var(--app-border));
+  color: var(--app-accent);
+}
+
+.tp-order-strip__icon-svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.tp-order-strip__content {
+  display: grid;
+  min-width: 0;
+  align-content: start;
+  gap: 0.125rem;
+}
+
+.tp-order-strip__label {
+  overflow: hidden;
+  color: var(--app-text);
+  font-size: 0.84rem;
+  font-weight: 650;
+  letter-spacing: 0;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tp-order-strip__stage-description {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--app-text-muted);
+  font-size: 0.72rem;
+  letter-spacing: 0;
+  line-height: 1.3;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.tp-order-strip__status {
+  display: flex;
+  grid-column: 1 / -1;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.tp-order-strip__status :deep(.n-tag) {
+  max-width: 100%;
+}
+
+.tp-order-strip__status :deep(.n-tag__content) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 760px) {
+  .tp-order-strip__rail {
+    grid-auto-columns: minmax(12rem, 76vw);
+  }
+
+  .tp-order-strip__stage {
+    min-height: 6rem;
+  }
+}
+</style>

--- a/web/management/src/components/traffic-policy/TrafficPolicyExecutionOrderStrip.vue
+++ b/web/management/src/components/traffic-policy/TrafficPolicyExecutionOrderStrip.vue
@@ -47,23 +47,15 @@ defineOptions({
 });
 
 const props = withDefaults(defineProps<{
-  modelValue?: string;
   stages?: readonly ExecutionStage[];
   title?: string;
   description?: string;
   ariaLabel?: string;
-  selectable?: boolean;
 }>(), {
   title: "Execution Order",
   description: "",
   ariaLabel: "Traffic policy execution order",
-  selectable: false,
 });
-
-const emit = defineEmits<{
-  (event: "update:modelValue", value: string): void;
-  (event: "select", stage: ExecutionStage): void;
-}>();
 
 const defaultExecutionStages: readonly ExecutionStage[] = [
   {
@@ -117,7 +109,6 @@ const defaultExecutionStages: readonly ExecutionStage[] = [
 ];
 
 const visibleStages = computed(() => props.stages?.length ? props.stages : defaultExecutionStages);
-const selectedKey = computed(() => props.modelValue || visibleStages.value[0]?.key || "");
 
 const iconByName: Record<ExecutionStageIcon, Component> = {
   listener: NetworkIcon,
@@ -130,18 +121,10 @@ const iconByName: Record<ExecutionStageIcon, Component> = {
   response: SendIcon,
 };
 
-function selectStage(stage: ExecutionStage) {
-  if (!props.selectable || stage.disabled) return;
-  emit("update:modelValue", stage.key);
-  emit("select", stage);
-}
-
 function stageClasses(stage: ExecutionStage): Array<string | Record<string, boolean>> {
   return [
     stage.state ? `tp-order-strip__stage--${stage.state}` : "",
     {
-      "tp-order-strip__stage--active": props.selectable && selectedKey.value === stage.key,
-      "tp-order-strip__stage--static": !props.selectable,
       "tp-order-strip__stage--disabled": stage.disabled === true,
     },
   ];
@@ -209,41 +192,7 @@ function attentionTagType(tone?: AttentionTone): NaiveTagType {
         class="tp-order-strip__item"
         :class="{ 'tp-order-strip__item--last': index === visibleStages.length - 1 }"
       >
-        <button
-          v-if="selectable"
-          class="tp-order-strip__stage"
-          :class="stageClasses(stage)"
-          type="button"
-          :disabled="stage.disabled"
-          :aria-current="selectedKey === stage.key ? 'step' : undefined"
-          @click="selectStage(stage)"
-        >
-          <span class="tp-order-strip__icon" aria-hidden="true">
-            <component :is="iconFor(stage)" class="tp-order-strip__icon-svg" />
-          </span>
-          <span class="tp-order-strip__content">
-            <span class="tp-order-strip__label">{{ stage.label }}</span>
-            <span v-if="stage.description" class="tp-order-strip__stage-description">
-              {{ stage.description }}
-            </span>
-          </span>
-          <span class="tp-order-strip__status">
-            <NTag v-if="stage.state" size="small" :bordered="false" :type="stateTagType(stage.state)">
-              {{ stateLabel(stage.state) }}
-            </NTag>
-            <NTag
-              v-for="tag in stage.tags || []"
-              :key="`${stage.key}-${tag.label}`"
-              size="small"
-              :bordered="false"
-              :type="attentionTagType(tag.tone)"
-              :title="tag.title || tag.label"
-            >
-              {{ tag.label }}
-            </NTag>
-          </span>
-        </button>
-        <div v-else class="tp-order-strip__stage" :class="stageClasses(stage)">
+        <div class="tp-order-strip__stage" :class="stageClasses(stage)">
           <span class="tp-order-strip__icon" aria-hidden="true">
             <component :is="iconFor(stage)" class="tp-order-strip__icon-svg" />
           </span>
@@ -351,39 +300,15 @@ function attentionTagType(tone?: AttentionTone): NaiveTagType {
   border-left: 3px solid transparent;
   background: var(--app-panel);
   color: var(--app-text);
-  cursor: pointer;
+  cursor: default;
   padding: 0.75rem 0.875rem;
   text-align: left;
   transition: background-color 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
 }
 
-.tp-order-strip__stage:hover,
-.tp-order-strip__stage:focus-visible {
-  background: var(--app-panel-muted);
-}
-
-.tp-order-strip__stage:focus-visible {
-  outline: 2px solid var(--app-accent);
-  outline-offset: -2px;
-}
-
-.tp-order-strip__stage:disabled,
 .tp-order-strip__stage--disabled {
   cursor: not-allowed;
   opacity: 0.58;
-}
-
-.tp-order-strip__stage--static {
-  cursor: default;
-}
-
-.tp-order-strip__stage--static:hover {
-  background: var(--app-panel);
-}
-
-.tp-order-strip__stage--active {
-  background: color-mix(in srgb, var(--app-accent-soft) 60%, var(--app-panel));
-  box-shadow: inset 0 0 0 1px var(--app-accent-soft);
 }
 
 .tp-order-strip__stage--match {
@@ -408,11 +333,6 @@ function attentionTagType(tone?: AttentionTone): NaiveTagType {
   border-radius: 6px;
   background: var(--app-panel-muted);
   color: var(--app-text-muted);
-}
-
-.tp-order-strip__stage--active .tp-order-strip__icon {
-  border-color: color-mix(in srgb, var(--app-accent) 44%, var(--app-border));
-  color: var(--app-accent);
 }
 
 .tp-order-strip__icon-svg {

--- a/web/management/src/components/traffic-policy/TrafficPolicyRequestPlayground.vue
+++ b/web/management/src/components/traffic-policy/TrafficPolicyRequestPlayground.vue
@@ -1,56 +1,28 @@
 <script setup lang="ts">
 import { RotateCcw as ResetIcon } from "@lucide/vue";
-import { NButton, NInput, NSelect, NTag } from "naive-ui";
+import { NButton, NCheckbox, NInput, NSelect, NTag } from "naive-ui";
 import type {
   TrafficPolicyAttentionWarning,
   TrafficPolicyMatchState,
+  TrafficPolicyPlaygroundStage,
+  TrafficPolicyPreviewForm,
 } from "@/lib/trafficPolicyWorkbench";
-
-type PreviewForm = {
-  method: string;
-  protocol: string;
-  host: string;
-  path: string;
-  remoteIp: string;
-  headersText: string;
-  cookiesText: string;
-  queryText: string;
-  routeId: string;
-  targetId: string;
-};
 
 type SelectOption = {
   label: string;
   value: string;
 };
 
-type PlaygroundStageItem = {
-  id: bigint;
-  name: string;
-  priority: bigint;
-  state: TrafficPolicyMatchState;
-  reason: string;
-  selected: boolean;
-  skipped: boolean;
-};
-
-type PlaygroundStage = {
-  key: string;
-  label: string;
-  mode: "first" | "all";
-  items: PlaygroundStageItem[];
-};
-
 const props = defineProps<{
-  modelValue: PreviewForm;
-  stages: PlaygroundStage[];
+  modelValue: TrafficPolicyPreviewForm;
+  stages: TrafficPolicyPlaygroundStage[];
   routeOptions: SelectOption[];
   targetOptions: SelectOption[];
   globalAttention: TrafficPolicyAttentionWarning[];
 }>();
 
 const emit = defineEmits<{
-  "update:modelValue": [value: PreviewForm];
+  "update:modelValue": [value: TrafficPolicyPreviewForm];
   reset: [];
 }>();
 
@@ -60,10 +32,10 @@ const protocolOptions = [
   { label: "HTTP", value: "http" },
 ];
 
-function updateField<K extends keyof PreviewForm>(key: K, value: PreviewForm[K] | null) {
+function updateField<K extends keyof TrafficPolicyPreviewForm>(key: K, value: TrafficPolicyPreviewForm[K]) {
   emit("update:modelValue", {
     ...props.modelValue,
-    [key]: value ?? "",
+    [key]: value,
   });
 }
 
@@ -125,6 +97,15 @@ function statusLabel(status: TrafficPolicyMatchState): string {
           <label class="field-label request-span-two">
             Remote IP
             <NInput :value="modelValue.remoteIp" size="small" placeholder="198.51.100.10" @update:value="(value) => updateField('remoteIp', value)" />
+          </label>
+          <label class="field-label request-body-field">
+            Request
+            <NCheckbox
+              :checked="modelValue.hasRequestBody"
+              @update:checked="(value) => updateField('hasRequestBody', Boolean(value))"
+            >
+              Has body
+            </NCheckbox>
           </label>
           <label class="field-label">
             Route
@@ -295,6 +276,18 @@ function statusLabel(status: TrafficPolicyMatchState): string {
 
 .request-map-input {
   font-size: 0.75rem;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.request-body-field {
+  align-content: end;
+}
+
+.request-body-field :deep(.n-checkbox__label) {
+  color: var(--app-text);
+  font-size: 0.78rem;
+  font-weight: 500;
   letter-spacing: 0;
   text-transform: none;
 }

--- a/web/management/src/components/traffic-policy/TrafficPolicyRequestPlayground.vue
+++ b/web/management/src/components/traffic-policy/TrafficPolicyRequestPlayground.vue
@@ -1,0 +1,374 @@
+<script setup lang="ts">
+import { RotateCcw as ResetIcon } from "@lucide/vue";
+import { NButton, NInput, NSelect, NTag } from "naive-ui";
+import type {
+  TrafficPolicyAttentionWarning,
+  TrafficPolicyMatchState,
+} from "@/lib/trafficPolicyWorkbench";
+
+type PreviewForm = {
+  method: string;
+  protocol: string;
+  host: string;
+  path: string;
+  remoteIp: string;
+  headersText: string;
+  cookiesText: string;
+  queryText: string;
+  routeId: string;
+  targetId: string;
+};
+
+type SelectOption = {
+  label: string;
+  value: string;
+};
+
+type PlaygroundStageItem = {
+  id: bigint;
+  name: string;
+  priority: bigint;
+  state: TrafficPolicyMatchState;
+  reason: string;
+  selected: boolean;
+  skipped: boolean;
+};
+
+type PlaygroundStage = {
+  key: string;
+  label: string;
+  mode: "first" | "all";
+  items: PlaygroundStageItem[];
+};
+
+const props = defineProps<{
+  modelValue: PreviewForm;
+  stages: PlaygroundStage[];
+  routeOptions: SelectOption[];
+  targetOptions: SelectOption[];
+  globalAttention: TrafficPolicyAttentionWarning[];
+}>();
+
+const emit = defineEmits<{
+  "update:modelValue": [value: PreviewForm];
+  reset: [];
+}>();
+
+const methodOptions = ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"].map((value) => ({ label: value, value }));
+const protocolOptions = [
+  { label: "HTTPS", value: "https" },
+  { label: "HTTP", value: "http" },
+];
+
+function updateField<K extends keyof PreviewForm>(key: K, value: PreviewForm[K] | null) {
+  emit("update:modelValue", {
+    ...props.modelValue,
+    [key]: value ?? "",
+  });
+}
+
+function statusType(status: TrafficPolicyMatchState): "success" | "warning" | "default" {
+  if (status === "match") return "success";
+  if (status === "unknown") return "warning";
+  return "default";
+}
+
+function statusLabel(status: TrafficPolicyMatchState): string {
+  if (status === "match") return "Match";
+  if (status === "unknown") return "Unknown";
+  return "No match";
+}
+</script>
+
+<template>
+  <section class="policy-playground" aria-label="Traffic policy request playground">
+    <div class="policy-playground-head">
+      <div>
+        <h4 class="copy-sm weight-semibold base-text">Request Preview</h4>
+        <p class="copy-xs muted-text">Builder rules are evaluated locally; CEL-only rules stay marked unknown.</p>
+      </div>
+      <NButton secondary size="small" @click="emit('reset')">
+        <template #icon><ResetIcon class="icon-sm" /></template>
+        Reset
+      </NButton>
+    </div>
+
+    <div class="policy-playground-grid">
+      <div class="policy-playground-form">
+        <div class="request-fields">
+          <label class="field-label">
+            Method
+            <NSelect
+              :value="modelValue.method"
+              size="small"
+              :options="methodOptions"
+              @update:value="(value) => updateField('method', String(value))"
+            />
+          </label>
+          <label class="field-label">
+            Protocol
+            <NSelect
+              :value="modelValue.protocol"
+              size="small"
+              :options="protocolOptions"
+              @update:value="(value) => updateField('protocol', String(value))"
+            />
+          </label>
+          <label class="field-label request-span-two">
+            Host
+            <NInput :value="modelValue.host" size="small" placeholder="app.example.com" @update:value="(value) => updateField('host', value)" />
+          </label>
+          <label class="field-label request-span-two">
+            Path
+            <NInput :value="modelValue.path" size="small" placeholder="/assets/app.js" @update:value="(value) => updateField('path', value)" />
+          </label>
+          <label class="field-label request-span-two">
+            Remote IP
+            <NInput :value="modelValue.remoteIp" size="small" placeholder="198.51.100.10" @update:value="(value) => updateField('remoteIp', value)" />
+          </label>
+          <label class="field-label">
+            Route
+            <NSelect
+              :value="modelValue.routeId"
+              size="small"
+              clearable
+              filterable
+              :options="routeOptions"
+              placeholder="Any"
+              @update:value="(value) => updateField('routeId', value ? String(value) : '')"
+            />
+          </label>
+          <label class="field-label">
+            Target
+            <NSelect
+              :value="modelValue.targetId"
+              size="small"
+              clearable
+              filterable
+              :options="targetOptions"
+              placeholder="Any"
+              @update:value="(value) => updateField('targetId', value ? String(value) : '')"
+            />
+          </label>
+        </div>
+
+        <div class="request-maps">
+          <label class="field-label">
+            Headers
+            <NInput
+              :value="modelValue.headersText"
+              type="textarea"
+              class="request-map-input mono-text"
+              placeholder="X-Plan: pro"
+              :autosize="{ minRows: 3, maxRows: 6 }"
+              @update:value="(value) => updateField('headersText', value)"
+            />
+          </label>
+          <label class="field-label">
+            Cookies
+            <NInput
+              :value="modelValue.cookiesText"
+              type="textarea"
+              class="request-map-input mono-text"
+              placeholder="sid=abc"
+              :autosize="{ minRows: 3, maxRows: 6 }"
+              @update:value="(value) => updateField('cookiesText', value)"
+            />
+          </label>
+          <label class="field-label">
+            Query
+            <NInput
+              :value="modelValue.queryText"
+              type="textarea"
+              class="request-map-input mono-text"
+              placeholder="debug=1"
+              :autosize="{ minRows: 3, maxRows: 6 }"
+              @update:value="(value) => updateField('queryText', value)"
+            />
+          </label>
+        </div>
+      </div>
+
+      <div class="policy-playground-results">
+        <div v-if="globalAttention.length" class="global-attention">
+          <NTag
+            v-for="(item, index) in globalAttention"
+            :key="`${item.code}-${item.ruleId?.toString() || 'global'}-${index.toString()}`"
+            size="small"
+            :bordered="false"
+            :type="item.code === 'cache-settings-disabled' ? 'warning' : 'info'"
+          >
+            {{ item.message }}
+          </NTag>
+        </div>
+
+        <div v-for="stage in stages" :key="stage.key" class="stage-preview">
+          <div class="stage-preview-head">
+            <div>
+              <h5>{{ stage.label }}</h5>
+              <p>{{ stage.mode === 'all' ? 'All matching rules are considered' : 'First matching candidate wins' }}</p>
+            </div>
+            <NTag size="small" :bordered="false" type="info">{{ stage.items.length.toString() }}</NTag>
+          </div>
+
+          <div v-if="stage.items.length" class="stage-preview-list">
+            <div
+              v-for="item in stage.items"
+              :key="`${stage.key}-${item.id.toString()}`"
+              class="stage-preview-row"
+              :class="{ 'stage-preview-row--selected': item.selected, 'stage-preview-row--skipped': item.skipped }"
+            >
+              <div class="min-width-zero">
+                <p class="clip-text copy-xs weight-medium base-text">
+                  {{ item.name || `#${item.id.toString()}` }}
+                </p>
+                <p class="clip-text copy-2xs muted-text">
+                  P{{ item.priority.toString() }} / {{ item.reason }}
+                </p>
+              </div>
+              <NTag size="small" :bordered="false" :type="statusType(item.state)">
+                {{ item.skipped ? 'Skipped' : statusLabel(item.state) }}
+              </NTag>
+            </div>
+          </div>
+
+          <p v-else class="stage-preview-empty">No rules configured.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.policy-playground {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.policy-playground-head,
+.stage-preview-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.policy-playground-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.policy-playground-form,
+.policy-playground-results {
+  display: grid;
+  align-content: start;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.request-fields,
+.request-maps {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.request-fields {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.request-span-two {
+  grid-column: 1 / -1;
+}
+
+.field-label {
+  display: grid;
+  gap: 0.375rem;
+  min-width: 0;
+  color: var(--app-text-muted);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.request-map-input {
+  font-size: 0.75rem;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.global-attention {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.global-attention :deep(.n-tag) {
+  max-width: 100%;
+  height: auto;
+}
+
+.global-attention :deep(.n-tag__content) {
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.stage-preview {
+  display: grid;
+  gap: 0.625rem;
+  min-width: 0;
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
+  background: var(--app-panel-muted);
+  padding: 0.75rem;
+}
+
+.stage-preview-head h5 {
+  color: var(--app-text);
+  font-size: 0.78rem;
+  font-weight: 650;
+}
+
+.stage-preview-head p,
+.stage-preview-empty {
+  color: var(--app-text-muted);
+  font-size: 0.7rem;
+}
+
+.stage-preview-list {
+  display: grid;
+  gap: 0.375rem;
+}
+
+.stage-preview-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 2.5rem;
+  border: 1px solid var(--app-border-subtle);
+  border-radius: 5px;
+  background: var(--app-panel);
+  padding: 0.5rem 0.625rem;
+}
+
+.stage-preview-row--selected {
+  border-color: color-mix(in srgb, var(--app-success) 34%, var(--app-border));
+}
+
+.stage-preview-row--skipped {
+  opacity: 0.68;
+}
+
+@media (min-width: 1100px) {
+  .policy-playground-grid {
+    grid-template-columns: minmax(20rem, 0.85fr) minmax(28rem, 1.15fr);
+  }
+
+  .request-maps {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+</style>

--- a/web/management/src/lib/publicProxyLabels.ts
+++ b/web/management/src/lib/publicProxyLabels.ts
@@ -441,7 +441,7 @@ export function cacheRuleSummary(rule: PublicCacheRule): string {
   const ttl = durationMillisLabel(rule.ttlMillis);
   const statuses = rule.cacheStatusCodes.length ? rule.cacheStatusCodes.join(",") : "200,203,204,301,308";
   const maxMb = Math.max(1, Math.round(Number(rule.maxObjectBytes || 0n) / 1024 / 1024));
-  const cookies = rule.allowCookieRequests ? " / cookie requests" : "";
+  const cookies = rule.allowCookieRequests ? " / legacy cookie flag" : "";
   return `${cacheTtlModeLabel(rule.ttlMode)} ${ttl} / status ${statuses} / max ${maxMb.toString()} MiB${cookies}`;
 }
 

--- a/web/management/src/lib/trafficPolicyWorkbench.test.ts
+++ b/web/management/src/lib/trafficPolicyWorkbench.test.ts
@@ -26,12 +26,15 @@ import {
   type PublicWafRule,
 } from "@/gen/proto/p2pstream/v1/management_pb";
 import {
+  buildTrafficPolicyPlaygroundStages,
+  defaultTrafficPolicyPreviewForm,
   evaluateTrafficPolicyMatch,
   previewTrafficPolicyStages,
   runtimeOrderedCacheRules,
   runtimeOrderedRateLimitRules,
   runtimeOrderedTrafficShaperRules,
   runtimeOrderedWafRules,
+  trafficPolicyPreviewFormToRequest,
   trafficPolicyAttentionWarnings,
   type TrafficPolicySyntheticRequest,
 } from "@/lib/trafficPolicyWorkbench";
@@ -57,6 +60,18 @@ describe("trafficPolicyWorkbench", () => {
     expect(evaluateTrafficPolicyMatch(rule, syntheticRequest({ remoteIp: "203.0.113.10", cookies: { sid: "abc-123" } })).state).toBe("miss");
   });
 
+  test("treats invalid CIDR inputs as misses", () => {
+    const invalidCidrRule = builderRule([
+      condition({ field: PublicPolicyMatchField.REMOTE_IP, operator: PublicPolicyMatchConditionOperator.CIDR, values: ["not-a-cidr"] }),
+    ]);
+    const invalidIpRule = builderRule([
+      condition({ field: PublicPolicyMatchField.REMOTE_IP, operator: PublicPolicyMatchConditionOperator.CIDR, values: ["198.51.100.0/24"] }),
+    ]);
+
+    expect(evaluateTrafficPolicyMatch(invalidCidrRule, syntheticRequest()).state).toBe("miss");
+    expect(evaluateTrafficPolicyMatch(invalidIpRule, syntheticRequest({ remoteIp: "not-an-ip" })).state).toBe("miss");
+  });
+
   test("returns match for empty rules and unknown for CEL-only or regex rules", () => {
     expect(evaluateTrafficPolicyMatch(undefined, syntheticRequest()).state).toBe("match");
     expect(evaluateTrafficPolicyMatch(create(PublicPolicyMatchRuleSchema), syntheticRequest()).state).toBe("match");
@@ -78,6 +93,27 @@ describe("trafficPolicyWorkbench", () => {
       ]),
     ], PublicPolicyMatchBooleanOperator.ANY);
     expect(evaluateTrafficPolicyMatch(anyWithUnknown, syntheticRequest()).state).toBe("unknown");
+  });
+
+  test("converts preview form text fields into synthetic requests", () => {
+    const form = defaultTrafficPolicyPreviewForm();
+    Object.assign(form, {
+      hasRequestBody: true,
+      headersText: "X-Plan: pro\nX-Plan: enterprise\nEmpty",
+      cookiesText: "sid=first; sid=second\nmode=dark",
+      queryText: "debug=1\nrole=ops",
+      routeId: "10",
+      targetId: "20",
+    });
+
+    const request = trafficPolicyPreviewFormToRequest(form);
+
+    expect(request.hasRequestBody).toBe(true);
+    expect(request.headers).toEqual({ "x-plan": ["pro", "enterprise"], empty: [""] });
+    expect(request.cookies).toEqual({ sid: "first", mode: "dark" });
+    expect(request.query).toEqual({ debug: ["1"], role: ["ops"] });
+    expect(request.routeId).toBe("10");
+    expect(request.targetId).toBe("20");
   });
 
   test("sorts all policy kinds by runtime priority then id", () => {
@@ -141,6 +177,38 @@ describe("trafficPolicyWorkbench", () => {
     expect(preview.cache?.rule.id).toBe(31n);
   });
 
+  test("keeps later first-match rules uncertain after an unknown selected candidate", () => {
+    const stages = buildTrafficPolicyPlaygroundStages({
+      wafRules: [
+        wafRule({ id: 1n, priority: 1n, activationMode: PublicWafActivationMode.AUTOMATIC, matchRule: pathRule("/api") }),
+        wafRule({ id: 2n, priority: 2n, matchRule: pathRule("/api") }),
+      ],
+    }, syntheticRequest());
+    const wafStage = stages.find((stage) => stage.key === "waf");
+
+    expect(wafStage?.items.map((item) => [item.id, item.state, item.selected, item.skipped])).toEqual([
+      [1n, "unknown", true, false],
+      [2n, "unknown", false, false],
+    ]);
+    expect(wafStage?.items[1].reason).toBe("May still apply; earlier preview result is unknown.");
+  });
+
+  test("skips later first-match rules after a confirmed selected candidate", () => {
+    const stages = buildTrafficPolicyPlaygroundStages({
+      trafficShaperRules: [
+        trafficShaperRule({ id: 20n, priority: 1n, matchRule: pathRule("/api") }),
+        trafficShaperRule({ id: 21n, priority: 2n, matchRule: pathRule("/api") }),
+      ],
+    }, syntheticRequest());
+    const trafficShaperStage = stages.find((stage) => stage.key === "traffic-shaper");
+
+    expect(trafficShaperStage?.items.map((item) => [item.id, item.state, item.selected, item.skipped])).toEqual([
+      [20n, "match", true, false],
+      [21n, "miss", false, true],
+    ]);
+    expect(trafficShaperStage?.items[1].reason).toBe("Skipped after earlier confirmed match");
+  });
+
   test("treats automatic WAF activation as unknown after a rule match", () => {
     const preview = previewTrafficPolicyStages({
       wafRules: [
@@ -167,18 +235,33 @@ describe("trafficPolicyWorkbench", () => {
     expect(previewTrafficPolicyStages(config, syntheticRequest({ cookies: { sid: "abc-123" } })).cache).toBeNull();
     expect(previewTrafficPolicyStages(config, syntheticRequest({ headers: { Range: ["bytes=0-10"] }, cookies: {} })).cache).toBeNull();
     expect(previewTrafficPolicyStages(config, syntheticRequest({ headers: { Connection: ["upgrade"] }, cookies: {} })).cache).toBeNull();
+    expect(previewTrafficPolicyStages(config, syntheticRequest({ hasRequestBody: true, cookies: {} })).cache).toBeNull();
   });
 
   test("marks encoded path separator cache behavior unknown", () => {
-    const preview = previewTrafficPolicyStages({
+    const config = {
       cacheSettings: create(PublicCacheSettingsSchema, { enabled: true }),
-      cacheRules: [cacheRule({ id: 30n, priority: 1n, matchRule: builderRule() })],
-    }, syntheticRequest({ path: "/api%2fusers/42.json", cookies: {} }));
+      cacheRules: [
+        cacheRule({ id: 30n, priority: 1n, matchRule: builderRule() }),
+        cacheRule({ id: 31n, priority: 2n, matchRule: builderRule() }),
+      ],
+    };
+    const request = syntheticRequest({ path: "/api%2fusers/42.json", cookies: {} });
+    const preview = previewTrafficPolicyStages(config, request);
+    const cacheStage = buildTrafficPolicyPlaygroundStages(config, request).find((stage) => stage.key === "cache");
 
     expect(preview.cache?.rule.id).toBe(30n);
     expect(preview.cache?.result).toEqual({
       state: "unknown",
       reason: "Encoded path separator cache behavior depends on route path security settings.",
+      canFallThrough: false,
+    });
+    expect(cacheStage?.items[1]).toMatchObject({
+      id: 31n,
+      state: "unknown",
+      selected: false,
+      skipped: false,
+      reason: "Not evaluated because stage eligibility is unknown.",
     });
   });
 

--- a/web/management/src/lib/trafficPolicyWorkbench.test.ts
+++ b/web/management/src/lib/trafficPolicyWorkbench.test.ts
@@ -1,0 +1,346 @@
+import { describe, expect, test } from "bun:test";
+import { create } from "@bufbuild/protobuf";
+import {
+  PublicCacheRuleSchema,
+  PublicCacheSettingsSchema,
+  PublicPolicyMatchBooleanOperator,
+  PublicPolicyMatchBuilderSchema,
+  PublicPolicyMatchConditionOperator,
+  PublicPolicyMatchConditionSchema,
+  PublicPolicyMatchField,
+  PublicPolicyMatchGroupSchema,
+  PublicPolicyMatchRuleSchema,
+  PublicRateLimitRuleSchema,
+  PublicTrafficShaperRuleSchema,
+  PublicWafActivationMode,
+  PublicWafCaptchaProviderSchema,
+  PublicWafRuleAction,
+  PublicWafRuleSchema,
+  type PublicCacheRule,
+  type PublicPolicyMatchCondition,
+  type PublicPolicyMatchGroup,
+  type PublicPolicyMatchRule,
+  type PublicRateLimitRule,
+  type PublicTrafficShaperRule,
+  type PublicWafCaptchaProvider,
+  type PublicWafRule,
+} from "@/gen/proto/p2pstream/v1/management_pb";
+import {
+  evaluateTrafficPolicyMatch,
+  previewTrafficPolicyStages,
+  runtimeOrderedCacheRules,
+  runtimeOrderedRateLimitRules,
+  runtimeOrderedTrafficShaperRules,
+  runtimeOrderedWafRules,
+  trafficPolicyAttentionWarnings,
+  type TrafficPolicySyntheticRequest,
+} from "@/lib/trafficPolicyWorkbench";
+
+describe("trafficPolicyWorkbench", () => {
+  test("evaluates builder match operators against a synthetic request", () => {
+    const rule = builderRule([
+      condition({ field: PublicPolicyMatchField.METHOD, operator: PublicPolicyMatchConditionOperator.EQUALS, values: ["get"] }),
+      condition({ field: PublicPolicyMatchField.PROTOCOL, operator: PublicPolicyMatchConditionOperator.EQUALS, values: ["HTTPS"] }),
+      condition({ field: PublicPolicyMatchField.HOST, operator: PublicPolicyMatchConditionOperator.HOST_PATTERN, values: ["*.example.test."] }),
+      condition({ field: PublicPolicyMatchField.PATH, operator: PublicPolicyMatchConditionOperator.PREFIX, values: ["/api"] }),
+      condition({ field: PublicPolicyMatchField.PATH, operator: PublicPolicyMatchConditionOperator.SUFFIX, values: [".json"] }),
+      condition({ field: PublicPolicyMatchField.PATH, operator: PublicPolicyMatchConditionOperator.CONTAINS, values: ["/users/"] }),
+      condition({ field: PublicPolicyMatchField.REMOTE_IP, operator: PublicPolicyMatchConditionOperator.CIDR, values: ["198.51.100.0/24"] }),
+      condition({ field: PublicPolicyMatchField.HEADER, name: "X-Plan", operator: PublicPolicyMatchConditionOperator.PRESENT }),
+      condition({ field: PublicPolicyMatchField.HEADER, name: "X-Plan", operator: PublicPolicyMatchConditionOperator.IN, values: ["free", "pro"] }),
+      condition({ field: PublicPolicyMatchField.COOKIE, name: "sid", operator: PublicPolicyMatchConditionOperator.PREFIX, values: ["abc"] }),
+      condition({ field: PublicPolicyMatchField.QUERY_PARAM, name: "role", operator: PublicPolicyMatchConditionOperator.EQUALS, values: ["ops"] }),
+    ]);
+
+    expect(evaluateTrafficPolicyMatch(rule, syntheticRequest({ cookies: { sid: "abc-123" } })).state).toBe("match");
+    expect(evaluateTrafficPolicyMatch(rule, syntheticRequest({ path: "/apiv2/users/42.json", cookies: { sid: "abc-123" } })).state).toBe("miss");
+    expect(evaluateTrafficPolicyMatch(rule, syntheticRequest({ remoteIp: "203.0.113.10", cookies: { sid: "abc-123" } })).state).toBe("miss");
+  });
+
+  test("returns match for empty rules and unknown for CEL-only or regex rules", () => {
+    expect(evaluateTrafficPolicyMatch(undefined, syntheticRequest()).state).toBe("match");
+    expect(evaluateTrafficPolicyMatch(create(PublicPolicyMatchRuleSchema), syntheticRequest()).state).toBe("match");
+    expect(evaluateTrafficPolicyMatch(celRule('method == "GET"'), syntheticRequest()).state).toBe("unknown");
+
+    const regexRule = builderRule([
+      condition({ field: PublicPolicyMatchField.PATH, operator: PublicPolicyMatchConditionOperator.MATCHES, values: ["^/api/users/[0-9]+\\.json$"] }),
+    ]);
+    expect(evaluateTrafficPolicyMatch(regexRule, syntheticRequest())).toEqual({
+      state: "unknown",
+      reason: "Regex policy matches are not evaluated in the browser.",
+    });
+
+    const anyWithUnknown = builderRule([
+      condition({ field: PublicPolicyMatchField.METHOD, operator: PublicPolicyMatchConditionOperator.EQUALS, values: ["POST"] }),
+    ], [
+      group([
+        condition({ field: PublicPolicyMatchField.PATH, operator: PublicPolicyMatchConditionOperator.MATCHES, values: ["["] }),
+      ]),
+    ], PublicPolicyMatchBooleanOperator.ANY);
+    expect(evaluateTrafficPolicyMatch(anyWithUnknown, syntheticRequest()).state).toBe("unknown");
+  });
+
+  test("sorts all policy kinds by runtime priority then id", () => {
+    expect(runtimeOrderedWafRules([
+      wafRule({ id: 3n, priority: 2n }),
+      wafRule({ id: 2n, priority: 1n }),
+      wafRule({ id: 1n, priority: 1n }),
+    ]).map((rule) => rule.id)).toEqual([1n, 2n, 3n]);
+    expect(runtimeOrderedRateLimitRules([
+      rateLimitRule({ id: 3n, priority: 2n }),
+      rateLimitRule({ id: 2n, priority: 1n }),
+      rateLimitRule({ id: 1n, priority: 1n }),
+    ]).map((rule) => rule.id)).toEqual([1n, 2n, 3n]);
+    expect(runtimeOrderedTrafficShaperRules([
+      trafficShaperRule({ id: 3n, priority: 2n }),
+      trafficShaperRule({ id: 2n, priority: 1n }),
+      trafficShaperRule({ id: 1n, priority: 1n }),
+    ]).map((rule) => rule.id)).toEqual([1n, 2n, 3n]);
+    expect(runtimeOrderedCacheRules([
+      cacheRule({ id: 3n, priority: 2n }),
+      cacheRule({ id: 2n, priority: 1n }),
+      cacheRule({ id: 1n, priority: 1n }),
+    ]).map((rule) => rule.id)).toEqual([1n, 2n, 3n]);
+  });
+
+  test("previews first-match stages and all matching rate limits", () => {
+    const pathMatch = builderRule([
+      condition({ field: PublicPolicyMatchField.PATH, operator: PublicPolicyMatchConditionOperator.PREFIX, values: ["/api"] }),
+    ]);
+    const pathMiss = builderRule([
+      condition({ field: PublicPolicyMatchField.PATH, operator: PublicPolicyMatchConditionOperator.PREFIX, values: ["/admin"] }),
+    ]);
+    const preview = previewTrafficPolicyStages({
+      wafRules: [
+        wafRule({ id: 3n, priority: 0n, enabled: false, matchRule: pathMatch }),
+        wafRule({ id: 1n, priority: 1n, matchRule: celRule('path.startsWith("/api")') }),
+        wafRule({ id: 2n, priority: 2n, matchRule: pathMatch }),
+      ],
+      rateLimitRules: [
+        rateLimitRule({ id: 10n, priority: 1n, matchRule: pathMatch }),
+        rateLimitRule({ id: 11n, priority: 2n, matchRule: celRule('path.startsWith("/api")') }),
+        rateLimitRule({ id: 12n, priority: 3n, matchRule: pathMiss }),
+      ],
+      trafficShaperRules: [
+        trafficShaperRule({ id: 20n, priority: 1n, matchRule: pathMiss }),
+        trafficShaperRule({ id: 21n, priority: 2n, matchRule: pathMatch }),
+      ],
+      cacheRules: [
+        cacheRule({ id: 30n, priority: 1n, routeIds: [11n], targetIds: [20n], matchRule: pathMatch }),
+        cacheRule({ id: 31n, priority: 2n, routeIds: [10n], targetIds: [20n], matchRule: pathMatch }),
+      ],
+    }, syntheticRequest({ routeId: 10n, targetId: 20n, cookies: {} }));
+
+    expect(preview.waf?.rule.id).toBe(1n);
+    expect(preview.waf?.result.state).toBe("unknown");
+    expect(preview.rateLimits.map((candidate) => [candidate.rule.id, candidate.result.state])).toEqual([
+      [10n, "match"],
+      [11n, "unknown"],
+    ]);
+    expect(preview.trafficShaper?.rule.id).toBe(21n);
+    expect(preview.cache?.rule.id).toBe(31n);
+  });
+
+  test("treats automatic WAF activation as unknown after a rule match", () => {
+    const preview = previewTrafficPolicyStages({
+      wafRules: [
+        wafRule({ id: 1n, priority: 1n, activationMode: PublicWafActivationMode.AUTOMATIC, matchRule: pathRule("/api") }),
+        wafRule({ id: 2n, priority: 2n, matchRule: pathRule("/api") }),
+      ],
+    }, syntheticRequest());
+
+    expect(preview.waf?.rule.id).toBe(1n);
+    expect(preview.waf?.result).toEqual({
+      state: "unknown",
+      reason: "Automatic WAF activation depends on live trigger state.",
+    });
+  });
+
+  test("does not select cache rules for runtime cache bypass requests", () => {
+    const config = {
+      cacheSettings: create(PublicCacheSettingsSchema, { enabled: true }),
+      cacheRules: [cacheRule({ id: 30n, priority: 1n, matchRule: pathRule("/api") })],
+    };
+
+    expect(previewTrafficPolicyStages(config, syntheticRequest({ method: "POST", cookies: {} })).cache).toBeNull();
+    expect(previewTrafficPolicyStages(config, syntheticRequest({ headers: { Authorization: ["Bearer token"] }, cookies: {} })).cache).toBeNull();
+    expect(previewTrafficPolicyStages(config, syntheticRequest({ cookies: { sid: "abc-123" } })).cache).toBeNull();
+    expect(previewTrafficPolicyStages(config, syntheticRequest({ headers: { Range: ["bytes=0-10"] }, cookies: {} })).cache).toBeNull();
+    expect(previewTrafficPolicyStages(config, syntheticRequest({ headers: { Connection: ["upgrade"] }, cookies: {} })).cache).toBeNull();
+  });
+
+  test("marks encoded path separator cache behavior unknown", () => {
+    const preview = previewTrafficPolicyStages({
+      cacheSettings: create(PublicCacheSettingsSchema, { enabled: true }),
+      cacheRules: [cacheRule({ id: 30n, priority: 1n, matchRule: builderRule() })],
+    }, syntheticRequest({ path: "/api%2fusers/42.json", cookies: {} }));
+
+    expect(preview.cache?.rule.id).toBe(30n);
+    expect(preview.cache?.result).toEqual({
+      state: "unknown",
+      reason: "Encoded path separator cache behavior depends on route path security settings.",
+    });
+  });
+
+  test("emits attention warnings for policy risks", () => {
+    const warnings = trafficPolicyAttentionWarnings({
+      wafCaptchaProviders: [
+        captchaProvider({ id: 7n, enabled: false }),
+        captchaProvider({ id: 8n, enabled: true, secretKeySet: false }),
+      ],
+      wafRules: [
+        wafRule({ id: 1n, priority: 1n, action: PublicWafRuleAction.CAPTCHA, captchaProviderId: 99n }),
+        wafRule({ id: 2n, priority: 1n, enabled: false, matchRule: pathRule("/waf") }),
+        wafRule({ id: 3n, priority: 2n, action: PublicWafRuleAction.CAPTCHA, captchaProviderId: 7n, matchRule: pathRule("/captcha") }),
+        wafRule({ id: 4n, priority: 1n, matchRule: pathRule("/waf-enabled") }),
+        wafRule({ id: 5n, priority: 3n, action: PublicWafRuleAction.CAPTCHA, captchaProviderId: 8n, matchRule: pathRule("/captcha-secret") }),
+      ],
+      rateLimitRules: [
+        rateLimitRule({ id: 10n, priority: 1n }),
+        rateLimitRule({ id: 11n, priority: 1n, enabled: false, matchRule: pathRule("/rate") }),
+        rateLimitRule({ id: 12n, priority: 1n, matchRule: pathRule("/rate-enabled") }),
+      ],
+      trafficShaperRules: [
+        trafficShaperRule({ id: 20n, priority: 1n }),
+        trafficShaperRule({ id: 21n, priority: 1n, matchRule: pathRule("/shape") }),
+      ],
+      cacheSettings: create(PublicCacheSettingsSchema, { enabled: false }),
+      cacheRules: [
+        cacheRule({ id: 30n, priority: 1n, allowCookieRequests: true }),
+        cacheRule({ id: 31n, priority: 1n, matchRule: pathRule("/cache") }),
+        cacheRule({ id: 32n, priority: 2n, enabled: false, allowCookieRequests: true }),
+      ],
+    });
+
+    expect(warnings.filter((warning) => warning.code === "duplicate-priority").map((warning) => warning.policyKind).sort()).toEqual([
+      "cache",
+      "rate-limit",
+      "traffic-shaper",
+      "waf",
+    ]);
+    expect(warnings.map((warning) => warning.code)).toContain("disabled-rule");
+    expect(warnings.map((warning) => warning.code)).toContain("any-request-rule");
+    expect(warnings.map((warning) => warning.code)).toContain("captcha-provider-missing");
+    expect(warnings.map((warning) => warning.code)).toContain("captcha-provider-disabled");
+    expect(warnings.map((warning) => warning.code)).toContain("captcha-provider-secret-missing");
+    expect(warnings.map((warning) => warning.code)).toContain("cache-settings-disabled");
+    expect(warnings.map((warning) => warning.code)).toContain("cache-allows-cookie-requests");
+    expect(warnings.some((warning) => warning.ruleId === 2n && warning.code === "any-request-rule")).toBe(false);
+    expect(warnings.some((warning) => warning.ruleId === 32n && warning.code === "cache-allows-cookie-requests")).toBe(false);
+  });
+});
+
+function syntheticRequest(overrides: Partial<TrafficPolicySyntheticRequest> = {}): TrafficPolicySyntheticRequest {
+  return {
+    method: "GET",
+    protocol: "https",
+    host: "api.example.test:443",
+    path: "/api/users/42.json",
+    remoteIp: "198.51.100.23",
+    headers: { "X-Plan": ["trial", "pro"] },
+    cookies: {},
+    query: { role: ["viewer", "ops"] },
+    routeId: 10n,
+    targetId: 20n,
+    ...overrides,
+  };
+}
+
+function pathRule(prefix: string): PublicPolicyMatchRule {
+  return builderRule([
+    condition({ field: PublicPolicyMatchField.PATH, operator: PublicPolicyMatchConditionOperator.PREFIX, values: [prefix] }),
+  ]);
+}
+
+function celRule(expression: string): PublicPolicyMatchRule {
+  return create(PublicPolicyMatchRuleSchema, { celExpression: expression });
+}
+
+function builderRule(
+  conditions: PublicPolicyMatchCondition[] = [],
+  groups: PublicPolicyMatchGroup[] = [],
+  operator = PublicPolicyMatchBooleanOperator.ALL,
+): PublicPolicyMatchRule {
+  return create(PublicPolicyMatchRuleSchema, {
+    builder: create(PublicPolicyMatchBuilderSchema, {
+      root: group(conditions, groups, operator),
+    }),
+  });
+}
+
+function group(
+  conditions: PublicPolicyMatchCondition[] = [],
+  groups: PublicPolicyMatchGroup[] = [],
+  operator = PublicPolicyMatchBooleanOperator.ALL,
+): PublicPolicyMatchGroup {
+  return create(PublicPolicyMatchGroupSchema, {
+    operator,
+    conditions,
+    groups,
+  });
+}
+
+function condition(overrides: Partial<PublicPolicyMatchCondition>): PublicPolicyMatchCondition {
+  return create(PublicPolicyMatchConditionSchema, {
+    field: overrides.field ?? PublicPolicyMatchField.PATH,
+    name: overrides.name ?? "",
+    operator: overrides.operator ?? PublicPolicyMatchConditionOperator.EQUALS,
+    values: overrides.values ? [...overrides.values] : [],
+    negated: overrides.negated ?? false,
+  });
+}
+
+function rateLimitRule(overrides: Partial<PublicRateLimitRule>): PublicRateLimitRule {
+  return create(PublicRateLimitRuleSchema, {
+    id: overrides.id ?? 1n,
+    name: overrides.name ?? `rate-${overrides.id?.toString() ?? "1"}`,
+    priority: overrides.priority ?? 1n,
+    enabled: overrides.enabled ?? true,
+    matchRule: overrides.matchRule,
+  });
+}
+
+function trafficShaperRule(overrides: Partial<PublicTrafficShaperRule>): PublicTrafficShaperRule {
+  return create(PublicTrafficShaperRuleSchema, {
+    id: overrides.id ?? 1n,
+    name: overrides.name ?? `shape-${overrides.id?.toString() ?? "1"}`,
+    priority: overrides.priority ?? 1n,
+    enabled: overrides.enabled ?? true,
+    matchRule: overrides.matchRule,
+  });
+}
+
+function wafRule(overrides: Partial<PublicWafRule>): PublicWafRule {
+  return create(PublicWafRuleSchema, {
+    id: overrides.id ?? 1n,
+    name: overrides.name ?? `waf-${overrides.id?.toString() ?? "1"}`,
+    priority: overrides.priority ?? 1n,
+    enabled: overrides.enabled ?? true,
+    activationMode: overrides.activationMode ?? PublicWafActivationMode.ALWAYS,
+    action: overrides.action ?? PublicWafRuleAction.BLOCK,
+    captchaProviderId: overrides.captchaProviderId ?? 0n,
+    matchRule: overrides.matchRule,
+  });
+}
+
+function cacheRule(overrides: Partial<PublicCacheRule>): PublicCacheRule {
+  return create(PublicCacheRuleSchema, {
+    id: overrides.id ?? 1n,
+    name: overrides.name ?? `cache-${overrides.id?.toString() ?? "1"}`,
+    priority: overrides.priority ?? 1n,
+    enabled: overrides.enabled ?? true,
+    routeIds: overrides.routeIds ?? [],
+    targetIds: overrides.targetIds ?? [],
+    matchRule: overrides.matchRule,
+    allowCookieRequests: overrides.allowCookieRequests ?? false,
+  });
+}
+
+function captchaProvider(overrides: Partial<PublicWafCaptchaProvider>): PublicWafCaptchaProvider {
+  return create(PublicWafCaptchaProviderSchema, {
+    id: overrides.id ?? 1n,
+    name: overrides.name ?? `provider-${overrides.id?.toString() ?? "1"}`,
+    enabled: overrides.enabled ?? true,
+    secretKeySet: overrides.secretKeySet ?? true,
+  });
+}

--- a/web/management/src/lib/trafficPolicyWorkbench.ts
+++ b/web/management/src/lib/trafficPolicyWorkbench.ts
@@ -1,0 +1,847 @@
+import {
+  PublicPolicyMatchBooleanOperator,
+  PublicPolicyMatchConditionOperator,
+  PublicPolicyMatchField,
+  PublicWafActivationMode,
+  PublicWafRuleAction,
+  type GetPublicProxyConfigResponse,
+  type PublicCacheRule,
+  type PublicPolicyMatchCondition,
+  type PublicPolicyMatchGroup,
+  type PublicPolicyMatchRule,
+  type PublicRateLimitRule,
+  type PublicTrafficShaperRule,
+  type PublicWafCaptchaProvider,
+  type PublicWafRule,
+} from "@/gen/proto/p2pstream/v1/management_pb";
+
+export type TrafficPolicyKind = "waf" | "rate-limit" | "traffic-shaper" | "cache";
+export type TrafficPolicyMatchState = "match" | "miss" | "unknown";
+export type TrafficPolicyValueMap = Record<string, string | readonly string[] | null | undefined>;
+export type TrafficPolicyCookieMap = Record<string, string | null | undefined>;
+export type TrafficPolicyId = bigint | number | string;
+
+export type TrafficPolicySyntheticRequest = {
+  method: string;
+  protocol: string;
+  host: string;
+  path: string;
+  remoteIp: string;
+  headers?: TrafficPolicyValueMap;
+  cookies?: TrafficPolicyCookieMap;
+  query?: TrafficPolicyValueMap;
+  routeId?: TrafficPolicyId | null;
+  targetId?: TrafficPolicyId | null;
+};
+
+export type TrafficPolicyMatchResult = {
+  state: TrafficPolicyMatchState;
+  reason?: string;
+};
+
+export type TrafficPolicyStageCandidate<T> = {
+  rule: T;
+  result: TrafficPolicyMatchResult;
+};
+
+export type TrafficPolicyStagePreview = {
+  waf: TrafficPolicyStageCandidate<PublicWafRule> | null;
+  rateLimits: TrafficPolicyStageCandidate<PublicRateLimitRule>[];
+  trafficShaper: TrafficPolicyStageCandidate<PublicTrafficShaperRule> | null;
+  cache: TrafficPolicyStageCandidate<PublicCacheRule> | null;
+};
+
+export type TrafficPolicyWorkbenchConfig = Partial<Pick<
+  GetPublicProxyConfigResponse,
+  "rateLimitRules" | "trafficShaperRules" | "wafRules" | "wafCaptchaProviders" | "cacheSettings" | "cacheRules"
+>>;
+
+export type TrafficPolicyAttentionWarningCode =
+  | "duplicate-priority"
+  | "disabled-rule"
+  | "any-request-rule"
+  | "captcha-provider-missing"
+  | "captcha-provider-disabled"
+  | "captcha-provider-secret-missing"
+  | "cache-settings-disabled"
+  | "cache-allows-cookie-requests";
+
+export type TrafficPolicyAttentionWarning = {
+  code: TrafficPolicyAttentionWarningCode;
+  message: string;
+  policyKind?: TrafficPolicyKind;
+  ruleId?: bigint;
+  ruleIds?: bigint[];
+  providerId?: bigint;
+  priority?: bigint;
+};
+
+type NormalizedTrafficPolicyRequest = {
+  method: string;
+  protocol: string;
+  host: string;
+  path: string;
+  remoteIp: string;
+  headers: Map<string, string[]>;
+  cookies: Map<string, string>;
+  query: Map<string, string[]>;
+  routeId: bigint | null;
+  targetId: bigint | null;
+};
+
+type ConstantMatchState = "always-match" | "always-miss" | "variable";
+
+const MATCH_RESULT: TrafficPolicyMatchResult = { state: "match" };
+const MISS_RESULT: TrafficPolicyMatchResult = { state: "miss" };
+
+export function runtimeOrderedWafRules(rules: readonly PublicWafRule[]): PublicWafRule[] {
+  return runtimeOrderedRules(rules);
+}
+
+export function runtimeOrderedRateLimitRules(rules: readonly PublicRateLimitRule[]): PublicRateLimitRule[] {
+  return runtimeOrderedRules(rules);
+}
+
+export function runtimeOrderedTrafficShaperRules(rules: readonly PublicTrafficShaperRule[]): PublicTrafficShaperRule[] {
+  return runtimeOrderedRules(rules);
+}
+
+export function runtimeOrderedCacheRules(rules: readonly PublicCacheRule[]): PublicCacheRule[] {
+  return runtimeOrderedRules(rules);
+}
+
+export function evaluateTrafficPolicyMatch(
+  matchRule: PublicPolicyMatchRule | undefined,
+  request: TrafficPolicySyntheticRequest,
+): TrafficPolicyMatchResult {
+  return evaluateTrafficPolicyMatchForRequest(matchRule, normalizeTrafficPolicyRequest(request));
+}
+
+export function trafficPolicyRuleMatchesAnyRequest(matchRule: PublicPolicyMatchRule | undefined): boolean {
+  if (!matchRule) return true;
+  if (matchRule.builder?.root) return constantGroupState(matchRule.builder.root) === "always-match";
+  const expression = matchRule.celExpression.trim();
+  return expression === "" || expression === "true";
+}
+
+export function previewTrafficPolicyStages(
+  config: TrafficPolicyWorkbenchConfig,
+  request: TrafficPolicySyntheticRequest,
+): TrafficPolicyStagePreview {
+  const normalized = normalizeTrafficPolicyRequest(request);
+  return {
+    waf: firstMatchingCandidate(runtimeOrderedWafRules(config.wafRules ?? []), (rule) => {
+      return evaluateWafRule(rule, normalized);
+    }),
+    rateLimits: allMatchingCandidates(runtimeOrderedRateLimitRules(config.rateLimitRules ?? []), (rule) => {
+      return evaluateTrafficPolicyMatchForRequest(rule.matchRule, normalized);
+    }),
+    trafficShaper: firstMatchingCandidate(runtimeOrderedTrafficShaperRules(config.trafficShaperRules ?? []), (rule) => {
+      return evaluateTrafficPolicyMatchForRequest(rule.matchRule, normalized);
+    }),
+    cache: firstMatchingCandidate(runtimeOrderedCacheRules(config.cacheRules ?? []), (rule) => {
+      return evaluateCacheRule(rule, normalized, config.cacheSettings?.enabled !== false);
+    }),
+  };
+}
+
+export function trafficPolicyAttentionWarnings(config: TrafficPolicyWorkbenchConfig): TrafficPolicyAttentionWarning[] {
+  const warnings: TrafficPolicyAttentionWarning[] = [];
+  const rateLimitRules = config.rateLimitRules ?? [];
+  const trafficShaperRules = config.trafficShaperRules ?? [];
+  const wafRules = config.wafRules ?? [];
+  const cacheRules = config.cacheRules ?? [];
+
+  warnings.push(...duplicatePriorityWarnings("waf", wafRules));
+  warnings.push(...duplicatePriorityWarnings("rate-limit", rateLimitRules));
+  warnings.push(...duplicatePriorityWarnings("traffic-shaper", trafficShaperRules));
+  warnings.push(...duplicatePriorityWarnings("cache", cacheRules));
+
+  warnings.push(...ruleShapeWarnings("waf", wafRules));
+  warnings.push(...ruleShapeWarnings("rate-limit", rateLimitRules));
+  warnings.push(...ruleShapeWarnings("traffic-shaper", trafficShaperRules));
+  warnings.push(...ruleShapeWarnings("cache", cacheRules));
+
+  warnings.push(...captchaProviderWarnings(wafRules, config.wafCaptchaProviders ?? []));
+
+  if ((config.cacheSettings?.enabled === false) && cacheRules.some((rule) => rule.enabled)) {
+    warnings.push({
+      code: "cache-settings-disabled",
+      policyKind: "cache",
+      message: "Cache settings are disabled while one or more cache rules are enabled.",
+    });
+  }
+
+  for (const rule of cacheRules) {
+    if (!rule.enabled || !rule.allowCookieRequests) continue;
+    warnings.push({
+      code: "cache-allows-cookie-requests",
+      policyKind: "cache",
+      ruleId: rule.id,
+      message: `Cache rule ${ruleDisplayName(rule)} preserves the legacy Cookie opt-in flag; Cookie requests still bypass shared cache.`,
+    });
+  }
+
+  return warnings;
+}
+
+function runtimeOrderedRules<T extends { priority: bigint; id: bigint }>(rules: readonly T[]): T[] {
+  return [...rules].sort((a, b) => {
+    if (a.priority !== b.priority) return a.priority < b.priority ? -1 : 1;
+    if (a.id === b.id) return 0;
+    return a.id < b.id ? -1 : 1;
+  });
+}
+
+function evaluateTrafficPolicyMatchForRequest(
+  matchRule: PublicPolicyMatchRule | undefined,
+  request: NormalizedTrafficPolicyRequest,
+): TrafficPolicyMatchResult {
+  if (!matchRule) return MATCH_RESULT;
+  if (matchRule.builder?.root) return evaluateGroup(matchRule.builder.root, request);
+  if (matchRule.celExpression.trim()) return unknownResult("CEL-only rules cannot be evaluated in the browser.");
+  return MATCH_RESULT;
+}
+
+function evaluateWafRule(rule: PublicWafRule, request: NormalizedTrafficPolicyRequest): TrafficPolicyMatchResult {
+  const match = evaluateTrafficPolicyMatchForRequest(rule.matchRule, request);
+  if (match.state !== "match") return match;
+  if (rule.activationMode === PublicWafActivationMode.AUTOMATIC) {
+    return unknownResult("Automatic WAF activation depends on live trigger state.");
+  }
+  return match;
+}
+
+function evaluateCacheRule(rule: PublicCacheRule, request: NormalizedTrafficPolicyRequest, cacheSettingsEnabled: boolean): TrafficPolicyMatchResult {
+  const bypass = cacheRequestBypassResult(request, cacheSettingsEnabled);
+  if (bypass) return bypass;
+  return andResults([
+    evaluateTrafficPolicyMatchForRequest(rule.matchRule, request),
+    evaluateIdFilter(rule.routeIds, request.routeId, "Route filter cannot be evaluated without a synthetic route id."),
+    evaluateIdFilter(rule.targetIds, request.targetId, "Target filter cannot be evaluated without a synthetic target id."),
+  ]);
+}
+
+function evaluateGroup(group: PublicPolicyMatchGroup, request: NormalizedTrafficPolicyRequest): TrafficPolicyMatchResult {
+  const parts = [
+    ...group.conditions.map((condition) => evaluateCondition(condition, request)),
+    ...group.groups.map((child) => evaluateGroup(child, request)),
+  ];
+  const joined = group.operator === PublicPolicyMatchBooleanOperator.ANY
+    ? orResults(parts)
+    : andResults(parts);
+  return group.negated ? negateResult(joined) : joined;
+}
+
+function evaluateCondition(
+  condition: PublicPolicyMatchCondition,
+  request: NormalizedTrafficPolicyRequest,
+): TrafficPolicyMatchResult {
+  switch (condition.field) {
+    case PublicPolicyMatchField.HEADER:
+      return evaluateMultiValueCondition(
+        request.headers,
+        condition.name.trim().toLowerCase(),
+        condition.operator,
+        condition.values,
+        condition.negated,
+        condition,
+      );
+    case PublicPolicyMatchField.QUERY_PARAM:
+      return evaluateMultiValueCondition(
+        request.query,
+        condition.name.trim(),
+        condition.operator,
+        condition.values,
+        condition.negated,
+        condition,
+      );
+    case PublicPolicyMatchField.COOKIE:
+      return evaluateSingleValueCondition(
+        request.cookies,
+        condition.name.trim(),
+        condition.operator,
+        condition.values,
+        condition.negated,
+        condition,
+      );
+    case PublicPolicyMatchField.METHOD:
+      return evaluateScalarCondition(request.method, condition, condition.values.map(normalizeMethodValue));
+    case PublicPolicyMatchField.PROTOCOL:
+      return evaluateScalarCondition(request.protocol, condition, condition.values.map(normalizeProtocolValue));
+    case PublicPolicyMatchField.HOST:
+      return evaluateScalarCondition(request.host, condition, condition.values.map((value) => normalizeHostValue(value, condition.operator)));
+    case PublicPolicyMatchField.PATH:
+      return evaluateScalarCondition(request.path, condition, condition.values.map((value) => value.trim()));
+    case PublicPolicyMatchField.REMOTE_IP:
+      return evaluateScalarCondition(request.remoteIp, condition, condition.values.map((value) => value.trim()));
+    default:
+      return unknownResult("Policy match field is not supported by the workbench.");
+  }
+}
+
+function evaluateMultiValueCondition(
+  valuesByName: Map<string, string[]>,
+  name: string,
+  operator: PublicPolicyMatchConditionOperator,
+  expectedValues: readonly string[],
+  negated: boolean,
+  condition: PublicPolicyMatchCondition,
+): TrafficPolicyMatchResult {
+  if (!name) return unknownResult("Header, cookie, and query conditions require a name.");
+  if (operator === PublicPolicyMatchConditionOperator.PRESENT) {
+    return maybeNegate(valuesByName.has(name) ? MATCH_RESULT : MISS_RESULT, negated);
+  }
+  if (!operatorAllowedForStringField(operator)) return unknownResult("Policy match operator is not valid for this field.");
+  const actualValues = valuesByName.get(name) ?? [];
+  const result = actualValues.length
+    ? evaluateAnyActualValue(actualValues, operator, normalizeExpectedValues(condition, expectedValues), condition.field)
+    : MISS_RESULT;
+  return maybeNegate(result, negated);
+}
+
+function evaluateSingleValueCondition(
+  valuesByName: Map<string, string>,
+  name: string,
+  operator: PublicPolicyMatchConditionOperator,
+  expectedValues: readonly string[],
+  negated: boolean,
+  condition: PublicPolicyMatchCondition,
+): TrafficPolicyMatchResult {
+  if (!name) return unknownResult("Header, cookie, and query conditions require a name.");
+  if (operator === PublicPolicyMatchConditionOperator.PRESENT) {
+    return maybeNegate(valuesByName.has(name) ? MATCH_RESULT : MISS_RESULT, negated);
+  }
+  if (!operatorAllowedForStringField(operator)) return unknownResult("Policy match operator is not valid for this field.");
+  const value = valuesByName.get(name);
+  const result = value === undefined
+    ? MISS_RESULT
+    : evaluateAnyActualValue([value], operator, normalizeExpectedValues(condition, expectedValues), condition.field);
+  return maybeNegate(result, negated);
+}
+
+function evaluateScalarCondition(
+  actualValue: string,
+  condition: PublicPolicyMatchCondition,
+  normalizedExpectedValues: readonly string[],
+): TrafficPolicyMatchResult {
+  if (condition.operator === PublicPolicyMatchConditionOperator.PRESENT) {
+    return unknownResult("The present operator is only supported for headers, cookies, and query params.");
+  }
+  if (!operatorAllowedForScalarField(condition.operator, condition.field)) {
+    return unknownResult("Policy match operator is not valid for this field.");
+  }
+  const result = evaluateAnyActualValue([actualValue], condition.operator, normalizedExpectedValues, condition.field);
+  return maybeNegate(result, condition.negated);
+}
+
+function normalizeExpectedValues(
+  condition: PublicPolicyMatchCondition,
+  expectedValues: readonly string[],
+): string[] {
+  switch (condition.field) {
+    case PublicPolicyMatchField.METHOD:
+      return expectedValues.map(normalizeMethodValue);
+    case PublicPolicyMatchField.PROTOCOL:
+      return expectedValues.map(normalizeProtocolValue);
+    case PublicPolicyMatchField.HOST:
+      return expectedValues.map((value) => normalizeHostValue(value, condition.operator));
+    case PublicPolicyMatchField.PATH:
+    case PublicPolicyMatchField.REMOTE_IP:
+      return expectedValues.map((value) => value.trim());
+    default:
+      return [...expectedValues];
+  }
+}
+
+function evaluateAnyActualValue(
+  actualValues: readonly string[],
+  operator: PublicPolicyMatchConditionOperator,
+  expectedValues: readonly string[],
+  field: PublicPolicyMatchField,
+): TrafficPolicyMatchResult {
+  if (!expectedValues.length) return unknownResult("Comparison conditions require at least one value.");
+  if (operator === PublicPolicyMatchConditionOperator.IN) {
+    const expected = new Set(expectedValues);
+    return actualValues.some((value) => expected.has(value)) ? MATCH_RESULT : MISS_RESULT;
+  }
+  const results: TrafficPolicyMatchResult[] = [];
+  for (const actualValue of actualValues) {
+    for (const expectedValue of expectedValues) {
+      results.push(evaluateSingleComparison(actualValue, operator, expectedValue, field));
+    }
+  }
+  return orResults(results);
+}
+
+function evaluateSingleComparison(
+  actualValue: string,
+  operator: PublicPolicyMatchConditionOperator,
+  expectedValue: string,
+  field: PublicPolicyMatchField,
+): TrafficPolicyMatchResult {
+  switch (operator) {
+    case PublicPolicyMatchConditionOperator.EQUALS:
+      return actualValue === expectedValue ? MATCH_RESULT : MISS_RESULT;
+    case PublicPolicyMatchConditionOperator.PREFIX:
+      return field === PublicPolicyMatchField.PATH
+        ? (pathPrefixMatches(actualValue, expectedValue) ? MATCH_RESULT : MISS_RESULT)
+        : (actualValue.startsWith(expectedValue) ? MATCH_RESULT : MISS_RESULT);
+    case PublicPolicyMatchConditionOperator.SUFFIX:
+      return actualValue.endsWith(expectedValue) ? MATCH_RESULT : MISS_RESULT;
+    case PublicPolicyMatchConditionOperator.CONTAINS:
+      return actualValue.includes(expectedValue) ? MATCH_RESULT : MISS_RESULT;
+    case PublicPolicyMatchConditionOperator.MATCHES:
+      return evaluateRegex(actualValue, expectedValue);
+    case PublicPolicyMatchConditionOperator.CIDR:
+      return evaluateCidr(actualValue, expectedValue);
+    case PublicPolicyMatchConditionOperator.HOST_PATTERN:
+      return expectedValue ? (hostMatchesPattern(actualValue, expectedValue) ? MATCH_RESULT : MISS_RESULT) : unknownResult("Host pattern is empty.");
+    default:
+      return unknownResult("Policy match operator is not supported by the workbench.");
+  }
+}
+
+function operatorAllowedForScalarField(
+  operator: PublicPolicyMatchConditionOperator,
+  field: PublicPolicyMatchField,
+): boolean {
+  if (operator === PublicPolicyMatchConditionOperator.CIDR) return field === PublicPolicyMatchField.REMOTE_IP;
+  if (operator === PublicPolicyMatchConditionOperator.HOST_PATTERN) return field === PublicPolicyMatchField.HOST;
+  return operatorAllowedForStringField(operator);
+}
+
+function operatorAllowedForStringField(operator: PublicPolicyMatchConditionOperator): boolean {
+  switch (operator) {
+    case PublicPolicyMatchConditionOperator.EQUALS:
+    case PublicPolicyMatchConditionOperator.PREFIX:
+    case PublicPolicyMatchConditionOperator.SUFFIX:
+    case PublicPolicyMatchConditionOperator.CONTAINS:
+    case PublicPolicyMatchConditionOperator.MATCHES:
+    case PublicPolicyMatchConditionOperator.IN:
+      return true;
+    default:
+      return false;
+  }
+}
+
+function evaluateRegex(actualValue: string, pattern: string): TrafficPolicyMatchResult {
+  void actualValue;
+  void pattern;
+  return unknownResult("Regex policy matches are not evaluated in the browser.");
+}
+
+function evaluateCidr(actualIp: string, rawCidr: string): TrafficPolicyMatchResult {
+  const parsedIp = parseIpAddress(actualIp);
+  const parsedCidr = parseCidr(rawCidr);
+  if (!parsedIp || !parsedCidr) return unknownResult("CIDR comparison could not be parsed.");
+  if (parsedIp.length !== parsedCidr.address.length) return MISS_RESULT;
+  return ipBytesInPrefix(parsedIp, parsedCidr.address, parsedCidr.prefixBits) ? MATCH_RESULT : MISS_RESULT;
+}
+
+function evaluateIdFilter(ids: readonly bigint[], actualId: bigint | null, unknownReason: string): TrafficPolicyMatchResult {
+  if (!ids.length) return MATCH_RESULT;
+  if (actualId === null) return unknownResult(unknownReason);
+  return ids.some((id) => id === actualId) ? MATCH_RESULT : MISS_RESULT;
+}
+
+function firstMatchingCandidate<T extends { enabled: boolean }>(
+  rules: readonly T[],
+  evaluate: (rule: T) => TrafficPolicyMatchResult,
+): TrafficPolicyStageCandidate<T> | null {
+  for (const rule of rules) {
+    if (!rule.enabled) continue;
+    const result = evaluate(rule);
+    if (result.state !== "miss") return { rule, result };
+  }
+  return null;
+}
+
+function allMatchingCandidates<T extends { enabled: boolean }>(
+  rules: readonly T[],
+  evaluate: (rule: T) => TrafficPolicyMatchResult,
+): TrafficPolicyStageCandidate<T>[] {
+  const candidates: TrafficPolicyStageCandidate<T>[] = [];
+  for (const rule of rules) {
+    if (!rule.enabled) continue;
+    const result = evaluate(rule);
+    if (result.state !== "miss") candidates.push({ rule, result });
+  }
+  return candidates;
+}
+
+function andResults(results: readonly TrafficPolicyMatchResult[]): TrafficPolicyMatchResult {
+  if (!results.length) return MATCH_RESULT;
+  const miss = results.find((result) => result.state === "miss");
+  if (miss) return MISS_RESULT;
+  const unknown = results.find((result) => result.state === "unknown");
+  return unknown ?? MATCH_RESULT;
+}
+
+function orResults(results: readonly TrafficPolicyMatchResult[]): TrafficPolicyMatchResult {
+  if (!results.length) return MATCH_RESULT;
+  const match = results.find((result) => result.state === "match");
+  if (match) return MATCH_RESULT;
+  const unknown = results.find((result) => result.state === "unknown");
+  return unknown ?? MISS_RESULT;
+}
+
+function maybeNegate(result: TrafficPolicyMatchResult, negated: boolean): TrafficPolicyMatchResult {
+  return negated ? negateResult(result) : result;
+}
+
+function negateResult(result: TrafficPolicyMatchResult): TrafficPolicyMatchResult {
+  if (result.state === "match") return MISS_RESULT;
+  if (result.state === "miss") return MATCH_RESULT;
+  return result;
+}
+
+function unknownResult(reason: string): TrafficPolicyMatchResult {
+  return { state: "unknown", reason };
+}
+
+function cacheRequestBypassResult(request: NormalizedTrafficPolicyRequest, cacheSettingsEnabled: boolean): TrafficPolicyMatchResult | null {
+  if (!cacheSettingsEnabled) return MISS_RESULT;
+  if (request.method !== "GET" && request.method !== "HEAD") return missResult("Cache bypass: only GET and HEAD requests are cacheable.");
+  if (hasHeader(request.headers, "authorization")) return missResult("Cache bypass: Authorization requests are never cached.");
+  if (request.cookies.size || hasHeader(request.headers, "cookie")) return missResult("Cache bypass: Cookie requests are never cached.");
+  if (hasHeader(request.headers, "range")) return missResult("Cache bypass: Range requests are never cached.");
+  if (headerEquals(request.headers, "connection", "upgrade") || hasHeader(request.headers, "upgrade")) {
+    return missResult("Cache bypass: upgraded requests are never cached.");
+  }
+  if (hasEncodedPathSeparator(request.path)) {
+    return unknownResult("Encoded path separator cache behavior depends on route path security settings.");
+  }
+  return null;
+}
+
+function missResult(reason: string): TrafficPolicyMatchResult {
+  return { state: "miss", reason };
+}
+
+function hasHeader(headers: Map<string, string[]>, name: string): boolean {
+  return (headers.get(name.toLowerCase()) ?? []).some((value) => value.trim() !== "");
+}
+
+function headerEquals(headers: Map<string, string[]>, name: string, expected: string): boolean {
+  return (headers.get(name.toLowerCase()) ?? []).some((value) => value.trim().toLowerCase() === expected);
+}
+
+function hasEncodedPathSeparator(path: string): boolean {
+  const lowerPath = path.toLowerCase();
+  return lowerPath.includes("%2f") || lowerPath.includes("%5c");
+}
+
+function normalizeTrafficPolicyRequest(request: TrafficPolicySyntheticRequest): NormalizedTrafficPolicyRequest {
+  return {
+    method: normalizeMethodValue(request.method),
+    protocol: normalizeProtocolValue(request.protocol),
+    host: normalizeRequestHost(request.host),
+    path: request.path.trim() || "/",
+    remoteIp: request.remoteIp.trim(),
+    headers: normalizeMultiValueMap(request.headers, true),
+    cookies: normalizeCookieMap(request.cookies),
+    query: normalizeMultiValueMap(request.query, false),
+    routeId: normalizePolicyId(request.routeId),
+    targetId: normalizePolicyId(request.targetId),
+  };
+}
+
+function normalizeMultiValueMap(values: TrafficPolicyValueMap | undefined, lowerCaseKeys: boolean): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  for (const [rawName, rawValue] of Object.entries(values ?? {})) {
+    if (rawValue === null || rawValue === undefined) continue;
+    const name = lowerCaseKeys ? rawName.trim().toLowerCase() : rawName.trim();
+    if (!name) continue;
+    const normalizedValue = Array.isArray(rawValue) ? [...rawValue] : [rawValue];
+    map.set(name, normalizedValue.map((value) => value));
+  }
+  return map;
+}
+
+function normalizeCookieMap(values: TrafficPolicyCookieMap | undefined): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const [rawName, rawValue] of Object.entries(values ?? {})) {
+    if (rawValue === null || rawValue === undefined) continue;
+    const name = rawName.trim();
+    if (!name) continue;
+    if (!map.has(name)) map.set(name, rawValue);
+  }
+  return map;
+}
+
+function normalizePolicyId(value: TrafficPolicyId | null | undefined): bigint | null {
+  if (value === null || value === undefined || value === "") return null;
+  if (typeof value === "bigint") return value;
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) ? BigInt(value) : null;
+  }
+  try {
+    return BigInt(value.trim());
+  } catch {
+    return null;
+  }
+}
+
+function normalizeMethodValue(value: string): string {
+  return value.trim().toUpperCase();
+}
+
+function normalizeProtocolValue(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function normalizeHostValue(value: string, operator: PublicPolicyMatchConditionOperator): string {
+  const host = value.trim().toLowerCase();
+  return operator === PublicPolicyMatchConditionOperator.HOST_PATTERN
+    ? host.replace(/\.$/, "")
+    : normalizeRequestHost(host);
+}
+
+function normalizeRequestHost(value: string): string {
+  let host = value.trim().toLowerCase();
+  if (host.startsWith("[")) {
+    const end = host.indexOf("]");
+    if (end >= 0) return normalizeBareRequestHost(host.slice(1, end));
+  }
+  const lastColon = host.lastIndexOf(":");
+  if (lastColon > -1 && host.indexOf(":") === lastColon) {
+    host = host.slice(0, lastColon);
+  }
+  return normalizeBareRequestHost(host);
+}
+
+function normalizeBareRequestHost(value: string): string {
+  const host = value.trim().toLowerCase().replace(/^\[|\]$/g, "");
+  return host.includes(":") ? host : host.replace(/\.$/, "");
+}
+
+function pathPrefixMatches(requestPath: string, pathPrefix: string): boolean {
+  const prefix = pathPrefix.trim();
+  const path = requestPath || "/";
+  if (!prefix || prefix === "/") return true;
+  if (!path.startsWith(prefix)) return false;
+  if (path.length === prefix.length) return true;
+  if (prefix.endsWith("/")) return true;
+  return path[prefix.length] === "/";
+}
+
+function hostMatchesPattern(host: string, pattern: string): boolean {
+  const normalizedHost = normalizeRequestHost(host);
+  const normalizedPattern = pattern.trim().toLowerCase().replace(/\.$/, "");
+  if (!normalizedPattern) return true;
+  if (!normalizedPattern.startsWith("*.")) return normalizedHost === normalizedPattern;
+  const suffix = normalizedPattern.slice(1);
+  return normalizedHost.endsWith(suffix) && normalizedHost.length > suffix.length - 1;
+}
+
+function parseCidr(value: string): { address: Uint8Array; prefixBits: number } | null {
+  const raw = value.trim();
+  const slash = raw.indexOf("/");
+  if (slash < 1 || slash !== raw.lastIndexOf("/")) return null;
+  const address = parseIpAddress(raw.slice(0, slash));
+  if (!address) return null;
+  const prefixText = raw.slice(slash + 1);
+  if (!/^\d+$/.test(prefixText)) return null;
+  const prefixBits = Number(prefixText);
+  if (!Number.isInteger(prefixBits) || prefixBits < 0 || prefixBits > address.length * 8) return null;
+  return { address, prefixBits };
+}
+
+function parseIpAddress(value: string): Uint8Array | null {
+  const raw = value.trim().replace(/^\[|\]$/g, "");
+  return raw.includes(":") ? parseIpv6Address(raw) : parseIpv4Address(raw);
+}
+
+function parseIpv4Address(value: string): Uint8Array | null {
+  const parts = value.split(".");
+  if (parts.length !== 4) return null;
+  const bytes = parts.map((part) => {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const parsed = Number(part);
+    return parsed >= 0 && parsed <= 255 ? parsed : null;
+  });
+  if (bytes.some((byte) => byte === null)) return null;
+  return Uint8Array.from(bytes as number[]);
+}
+
+function parseIpv6Address(value: string): Uint8Array | null {
+  let raw = value.trim().toLowerCase();
+  if (!raw || raw.includes("%")) return null;
+  if (raw.includes(".")) {
+    const lastColon = raw.lastIndexOf(":");
+    if (lastColon < 0) return null;
+    const ipv4 = parseIpv4Address(raw.slice(lastColon + 1));
+    if (!ipv4) return null;
+    const high = ((ipv4[0] << 8) | ipv4[1]).toString(16);
+    const low = ((ipv4[2] << 8) | ipv4[3]).toString(16);
+    raw = `${raw.slice(0, lastColon)}:${high}:${low}`;
+  }
+  const compressed = raw.split("::");
+  if (compressed.length > 2) return null;
+  const left = compressed[0] ? compressed[0].split(":") : [];
+  const right = compressed.length === 2 && compressed[1] ? compressed[1].split(":") : [];
+  if (left.some((part) => part === "") || right.some((part) => part === "")) return null;
+  const missing = compressed.length === 2 ? 8 - left.length - right.length : 0;
+  if (missing < 0) return null;
+  const parts = compressed.length === 2
+    ? [...left, ...Array.from({ length: missing }, () => "0"), ...right]
+    : left;
+  if (parts.length !== 8) return null;
+  const bytes = new Uint8Array(16);
+  for (let index = 0; index < parts.length; index += 1) {
+    const part = parts[index];
+    if (!/^[0-9a-f]{1,4}$/.test(part)) return null;
+    const value16 = Number.parseInt(part, 16);
+    bytes[index * 2] = value16 >> 8;
+    bytes[index * 2 + 1] = value16 & 0xff;
+  }
+  return bytes;
+}
+
+function ipBytesInPrefix(ip: Uint8Array, prefix: Uint8Array, prefixBits: number): boolean {
+  const fullBytes = Math.floor(prefixBits / 8);
+  for (let index = 0; index < fullBytes; index += 1) {
+    if (ip[index] !== prefix[index]) return false;
+  }
+  const remainingBits = prefixBits % 8;
+  if (remainingBits === 0) return true;
+  const mask = (0xff << (8 - remainingBits)) & 0xff;
+  return (ip[fullBytes] & mask) === (prefix[fullBytes] & mask);
+}
+
+function duplicatePriorityWarnings<T extends { id: bigint; priority: bigint; enabled?: boolean }>(
+  kind: TrafficPolicyKind,
+  rules: readonly T[],
+): TrafficPolicyAttentionWarning[] {
+  const byPriority = new Map<string, T[]>();
+  for (const rule of rules.filter((rule) => rule.enabled !== false)) {
+    const key = rule.priority.toString();
+    const bucket = byPriority.get(key) ?? [];
+    bucket.push(rule);
+    byPriority.set(key, bucket);
+  }
+  const warnings: TrafficPolicyAttentionWarning[] = [];
+  for (const bucket of byPriority.values()) {
+    if (bucket.length < 2) continue;
+    warnings.push({
+      code: "duplicate-priority",
+      policyKind: kind,
+      priority: bucket[0].priority,
+      ruleIds: bucket.map((rule) => rule.id),
+      message: `${policyKindLabel(kind)} priority ${bucket[0].priority.toString()} is used by ${bucket.length.toString()} enabled rules.`,
+    });
+  }
+  return warnings;
+}
+
+function ruleShapeWarnings<T extends { id: bigint; name: string; enabled: boolean; matchRule?: PublicPolicyMatchRule | undefined }>(
+  kind: TrafficPolicyKind,
+  rules: readonly T[],
+): TrafficPolicyAttentionWarning[] {
+  const warnings: TrafficPolicyAttentionWarning[] = [];
+  for (const rule of rules) {
+    if (!rule.enabled) {
+      warnings.push({
+        code: "disabled-rule",
+        policyKind: kind,
+        ruleId: rule.id,
+        message: `${policyKindLabel(kind)} rule ${ruleDisplayName(rule)} is disabled.`,
+      });
+    }
+    if (rule.enabled && trafficPolicyRuleMatchesAnyRequest(rule.matchRule)) {
+      warnings.push({
+        code: "any-request-rule",
+        policyKind: kind,
+        ruleId: rule.id,
+        message: `${policyKindLabel(kind)} rule ${ruleDisplayName(rule)} applies to any request.`,
+      });
+    }
+  }
+  return warnings;
+}
+
+function captchaProviderWarnings(
+  rules: readonly PublicWafRule[],
+  providers: readonly PublicWafCaptchaProvider[],
+): TrafficPolicyAttentionWarning[] {
+  const providerById = new Map(providers.map((provider) => [provider.id.toString(), provider]));
+  const warnings: TrafficPolicyAttentionWarning[] = [];
+  for (const rule of rules) {
+    if (!rule.enabled) continue;
+    if (rule.action !== PublicWafRuleAction.CAPTCHA) continue;
+    const provider = providerById.get(rule.captchaProviderId.toString());
+    if (!provider) {
+      warnings.push({
+        code: "captcha-provider-missing",
+        policyKind: "waf",
+        ruleId: rule.id,
+        providerId: rule.captchaProviderId,
+        message: `WAF captcha rule ${ruleDisplayName(rule)} references a missing captcha provider.`,
+      });
+    } else if (!provider.enabled) {
+      warnings.push({
+        code: "captcha-provider-disabled",
+        policyKind: "waf",
+        ruleId: rule.id,
+        providerId: provider.id,
+        message: `WAF captcha rule ${ruleDisplayName(rule)} uses disabled captcha provider ${provider.name || provider.id.toString()}.`,
+      });
+    } else if (!provider.secretKeySet) {
+      warnings.push({
+        code: "captcha-provider-secret-missing",
+        policyKind: "waf",
+        ruleId: rule.id,
+        providerId: provider.id,
+        message: `WAF captcha rule ${ruleDisplayName(rule)} uses captcha provider ${provider.name || provider.id.toString()} without a saved secret.`,
+      });
+    }
+  }
+  return warnings;
+}
+
+function constantGroupState(group: PublicPolicyMatchGroup): ConstantMatchState {
+  const parts: ConstantMatchState[] = [
+    ...group.conditions.map((): ConstantMatchState => "variable"),
+    ...group.groups.map(constantGroupState),
+  ];
+  const joined = group.operator === PublicPolicyMatchBooleanOperator.ANY
+    ? constantOrState(parts)
+    : constantAndState(parts);
+  return group.negated ? negateConstantState(joined) : joined;
+}
+
+function constantAndState(parts: readonly ConstantMatchState[]): ConstantMatchState {
+  if (!parts.length) return "always-match";
+  if (parts.some((part) => part === "always-miss")) return "always-miss";
+  return parts.every((part) => part === "always-match") ? "always-match" : "variable";
+}
+
+function constantOrState(parts: readonly ConstantMatchState[]): ConstantMatchState {
+  if (!parts.length) return "always-match";
+  if (parts.some((part) => part === "always-match")) return "always-match";
+  return parts.every((part) => part === "always-miss") ? "always-miss" : "variable";
+}
+
+function negateConstantState(state: ConstantMatchState): ConstantMatchState {
+  if (state === "always-match") return "always-miss";
+  if (state === "always-miss") return "always-match";
+  return "variable";
+}
+
+function ruleDisplayName(rule: { id: bigint; name: string }): string {
+  return rule.name.trim() || `#${rule.id.toString()}`;
+}
+
+function policyKindLabel(kind: TrafficPolicyKind): string {
+  switch (kind) {
+    case "rate-limit":
+      return "Rate limit";
+    case "traffic-shaper":
+      return "Traffic shaper";
+    case "cache":
+      return "Cache";
+    default:
+      return "WAF";
+  }
+}

--- a/web/management/src/lib/trafficPolicyWorkbench.ts
+++ b/web/management/src/lib/trafficPolicyWorkbench.ts
@@ -27,6 +27,7 @@ export type TrafficPolicySyntheticRequest = {
   host: string;
   path: string;
   remoteIp: string;
+  hasRequestBody?: boolean;
   headers?: TrafficPolicyValueMap;
   cookies?: TrafficPolicyCookieMap;
   query?: TrafficPolicyValueMap;
@@ -34,9 +35,24 @@ export type TrafficPolicySyntheticRequest = {
   targetId?: TrafficPolicyId | null;
 };
 
+export type TrafficPolicyPreviewForm = {
+  method: string;
+  protocol: string;
+  host: string;
+  path: string;
+  remoteIp: string;
+  hasRequestBody: boolean;
+  headersText: string;
+  cookiesText: string;
+  queryText: string;
+  routeId: string;
+  targetId: string;
+};
+
 export type TrafficPolicyMatchResult = {
   state: TrafficPolicyMatchState;
   reason?: string;
+  canFallThrough?: boolean;
 };
 
 export type TrafficPolicyStageCandidate<T> = {
@@ -49,6 +65,23 @@ export type TrafficPolicyStagePreview = {
   rateLimits: TrafficPolicyStageCandidate<PublicRateLimitRule>[];
   trafficShaper: TrafficPolicyStageCandidate<PublicTrafficShaperRule> | null;
   cache: TrafficPolicyStageCandidate<PublicCacheRule> | null;
+};
+
+export type TrafficPolicyPlaygroundStageItem = {
+  id: bigint;
+  name: string;
+  priority: bigint;
+  state: TrafficPolicyMatchState;
+  reason: string;
+  selected: boolean;
+  skipped: boolean;
+};
+
+export type TrafficPolicyPlaygroundStage = {
+  key: TrafficPolicyKind;
+  label: string;
+  mode: "first" | "all";
+  items: TrafficPolicyPlaygroundStageItem[];
 };
 
 export type TrafficPolicyWorkbenchConfig = Partial<Pick<
@@ -82,6 +115,7 @@ type NormalizedTrafficPolicyRequest = {
   host: string;
   path: string;
   remoteIp: string;
+  hasRequestBody: boolean;
   headers: Map<string, string[]>;
   cookies: Map<string, string>;
   query: Map<string, string[]>;
@@ -124,6 +158,38 @@ export function trafficPolicyRuleMatchesAnyRequest(matchRule: PublicPolicyMatchR
   return expression === "" || expression === "true";
 }
 
+export function defaultTrafficPolicyPreviewForm(): TrafficPolicyPreviewForm {
+  return {
+    method: "GET",
+    protocol: "https",
+    host: "app.example.com",
+    path: "/",
+    remoteIp: "198.51.100.10",
+    hasRequestBody: false,
+    headersText: "X-Plan: pro",
+    cookiesText: "",
+    queryText: "",
+    routeId: "",
+    targetId: "",
+  };
+}
+
+export function trafficPolicyPreviewFormToRequest(form: TrafficPolicyPreviewForm): TrafficPolicySyntheticRequest {
+  return {
+    method: form.method,
+    protocol: form.protocol,
+    host: form.host,
+    path: form.path,
+    remoteIp: form.remoteIp,
+    hasRequestBody: form.hasRequestBody,
+    headers: parseRepeatedMap(form.headersText, true),
+    cookies: parseCookieMap(form.cookiesText),
+    query: parseRepeatedMap(form.queryText, false),
+    routeId: form.routeId || null,
+    targetId: form.targetId || null,
+  };
+}
+
 export function previewTrafficPolicyStages(
   config: TrafficPolicyWorkbenchConfig,
   request: TrafficPolicySyntheticRequest,
@@ -143,6 +209,19 @@ export function previewTrafficPolicyStages(
       return evaluateCacheRule(rule, normalized, config.cacheSettings?.enabled !== false);
     }),
   };
+}
+
+export function buildTrafficPolicyPlaygroundStages(
+  config: TrafficPolicyWorkbenchConfig,
+  request: TrafficPolicySyntheticRequest,
+): TrafficPolicyPlaygroundStage[] {
+  const preview = previewTrafficPolicyStages(config, request);
+  return [
+    stageFromFirstCandidate("waf", "WAF", runtimeOrderedWafRules(config.wafRules ?? []), preview.waf),
+    stageFromRateLimitCandidates(runtimeOrderedRateLimitRules(config.rateLimitRules ?? []), preview.rateLimits),
+    stageFromFirstCandidate("traffic-shaper", "Traffic shaper", runtimeOrderedTrafficShaperRules(config.trafficShaperRules ?? []), preview.trafficShaper),
+    stageFromFirstCandidate("cache", "Cache", runtimeOrderedCacheRules(config.cacheRules ?? []), preview.cache),
+  ];
 }
 
 export function trafficPolicyAttentionWarnings(config: TrafficPolicyWorkbenchConfig): TrafficPolicyAttentionWarning[] {
@@ -434,7 +513,7 @@ function evaluateRegex(actualValue: string, pattern: string): TrafficPolicyMatch
 function evaluateCidr(actualIp: string, rawCidr: string): TrafficPolicyMatchResult {
   const parsedIp = parseIpAddress(actualIp);
   const parsedCidr = parseCidr(rawCidr);
-  if (!parsedIp || !parsedCidr) return unknownResult("CIDR comparison could not be parsed.");
+  if (!parsedIp || !parsedCidr) return MISS_RESULT;
   if (parsedIp.length !== parsedCidr.address.length) return MISS_RESULT;
   return ipBytesInPrefix(parsedIp, parsedCidr.address, parsedCidr.prefixBits) ? MATCH_RESULT : MISS_RESULT;
 }
@@ -470,6 +549,81 @@ function allMatchingCandidates<T extends { enabled: boolean }>(
   return candidates;
 }
 
+function stageFromFirstCandidate<T extends { id: bigint; name: string; priority: bigint; enabled: boolean }>(
+  key: Exclude<TrafficPolicyKind, "rate-limit">,
+  label: string,
+  rules: readonly T[],
+  candidate: TrafficPolicyStageCandidate<T> | null,
+): TrafficPolicyPlaygroundStage {
+  const selectedId = candidate?.rule.id;
+  const selectedResult = candidate?.result ?? null;
+  const selectedResultCanFallThrough = selectedResult?.state === "unknown" && selectedResult.canFallThrough !== false;
+  const selectedResultBlocksLater = selectedResult?.state === "match";
+  let passedSelected = false;
+  return {
+    key,
+    label,
+    mode: "first",
+    items: rules.map((rule) => {
+      const selected = selectedId !== undefined && rule.id === selectedId;
+      const selectedRuleResult = selected ? selectedResult : null;
+      const afterSelected = Boolean(rule.enabled && passedSelected && !selected);
+      if (selected) passedSelected = true;
+
+      let state: TrafficPolicyMatchState = selectedRuleResult?.state ?? "miss";
+      let reason = selectedRuleResult ? (selectedRuleResult.reason || "Selected by preview") : "No match in preview";
+      let skipped = false;
+
+      if (!rule.enabled) {
+        reason = "Rule is disabled";
+      } else if (afterSelected && selectedResultBlocksLater) {
+        skipped = true;
+        reason = "Skipped after earlier confirmed match";
+      } else if (afterSelected && selectedResultCanFallThrough) {
+        state = "unknown";
+        reason = "May still apply; earlier preview result is unknown.";
+      } else if (afterSelected) {
+        state = "unknown";
+        reason = "Not evaluated because stage eligibility is unknown.";
+      }
+
+      return {
+        id: rule.id,
+        name: rule.name,
+        priority: rule.priority,
+        state,
+        reason,
+        selected,
+        skipped,
+      };
+    }),
+  };
+}
+
+function stageFromRateLimitCandidates(
+  rules: readonly PublicRateLimitRule[],
+  candidates: readonly TrafficPolicyStageCandidate<PublicRateLimitRule>[],
+): TrafficPolicyPlaygroundStage {
+  const candidateById = new Map(candidates.map((candidate) => [candidate.rule.id.toString(), candidate]));
+  return {
+    key: "rate-limit",
+    label: "Rate limits",
+    mode: "all",
+    items: rules.map((rule) => {
+      const candidate = candidateById.get(rule.id.toString());
+      return {
+        id: rule.id,
+        name: rule.name,
+        priority: rule.priority,
+        state: candidate?.result.state ?? "miss",
+        reason: candidate?.result.reason || (rule.enabled ? "No match in preview" : "Rule is disabled"),
+        selected: Boolean(candidate),
+        skipped: false,
+      };
+    }),
+  };
+}
+
 function andResults(results: readonly TrafficPolicyMatchResult[]): TrafficPolicyMatchResult {
   if (!results.length) return MATCH_RESULT;
   const miss = results.find((result) => result.state === "miss");
@@ -496,8 +650,8 @@ function negateResult(result: TrafficPolicyMatchResult): TrafficPolicyMatchResul
   return result;
 }
 
-function unknownResult(reason: string): TrafficPolicyMatchResult {
-  return { state: "unknown", reason };
+function unknownResult(reason: string, canFallThrough = true): TrafficPolicyMatchResult {
+  return canFallThrough ? { state: "unknown", reason } : { state: "unknown", reason, canFallThrough: false };
 }
 
 function cacheRequestBypassResult(request: NormalizedTrafficPolicyRequest, cacheSettingsEnabled: boolean): TrafficPolicyMatchResult | null {
@@ -509,8 +663,9 @@ function cacheRequestBypassResult(request: NormalizedTrafficPolicyRequest, cache
   if (headerEquals(request.headers, "connection", "upgrade") || hasHeader(request.headers, "upgrade")) {
     return missResult("Cache bypass: upgraded requests are never cached.");
   }
+  if (request.hasRequestBody) return missResult("Cache bypass: requests with a body are never cached.");
   if (hasEncodedPathSeparator(request.path)) {
-    return unknownResult("Encoded path separator cache behavior depends on route path security settings.");
+    return unknownResult("Encoded path separator cache behavior depends on route path security settings.", false);
   }
   return null;
 }
@@ -539,6 +694,7 @@ function normalizeTrafficPolicyRequest(request: TrafficPolicySyntheticRequest): 
     host: normalizeRequestHost(request.host),
     path: request.path.trim() || "/",
     remoteIp: request.remoteIp.trim(),
+    hasRequestBody: request.hasRequestBody === true,
     headers: normalizeMultiValueMap(request.headers, true),
     cookies: normalizeCookieMap(request.cookies),
     query: normalizeMultiValueMap(request.query, false),
@@ -557,6 +713,42 @@ function normalizeMultiValueMap(values: TrafficPolicyValueMap | undefined, lower
     map.set(name, normalizedValue.map((value) => value));
   }
   return map;
+}
+
+function parseRepeatedMap(text: string, lowerCaseKeys: boolean): Record<string, string[]> {
+  const parsed: Record<string, string[]> = {};
+  for (const line of text.split(/\r?\n/)) {
+    const item = parseKeyValueLine(line);
+    if (!item) continue;
+    const key = lowerCaseKeys ? item.key.toLowerCase() : item.key;
+    const values = parsed[key] ?? [];
+    values.push(item.value);
+    parsed[key] = values;
+  }
+  return parsed;
+}
+
+function parseCookieMap(text: string): Record<string, string> {
+  const parsed: Record<string, string> = {};
+  for (const part of text.split(/\r?\n|;/)) {
+    const item = parseKeyValueLine(part);
+    if (!item) continue;
+    if (parsed[item.key] !== undefined) continue;
+    parsed[item.key] = item.value;
+  }
+  return parsed;
+}
+
+function parseKeyValueLine(line: string): { key: string; value: string } | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  const colon = trimmed.indexOf(":");
+  const equals = trimmed.indexOf("=");
+  const separator = colon >= 0 && (equals < 0 || colon < equals) ? colon : equals;
+  if (separator < 0) return { key: trimmed, value: "" };
+  const key = trimmed.slice(0, separator).trim();
+  if (!key) return null;
+  return { key, value: trimmed.slice(separator + 1).trim() };
 }
 
 function normalizeCookieMap(values: TrafficPolicyCookieMap | undefined): Map<string, string> {

--- a/web/management/src/router.ts
+++ b/web/management/src/router.ts
@@ -1,17 +1,18 @@
 import { createRouter, createWebHashHistory } from 'vue-router';
-import Overview from './views/Overview.vue';
-import Diagnostics from './views/Diagnostics.vue';
-import Traffic from './views/Traffic.vue';
-import Monitor from './views/Monitor.vue';
-import AgentHealth from './views/AgentHealth.vue';
-import Settings from './views/Settings.vue';
-import SettingsApiTokens from './views/SettingsApiTokens.vue';
-import SettingsEnvironments from './views/SettingsEnvironments.vue';
-import ProxyConfig from './views/ProxyConfig.vue';
-import TrafficPolicies from './views/TrafficPolicies.vue';
-import ResponseTemplates from './views/ResponseTemplates.vue';
-import TlsConfig from './views/TlsConfig.vue';
-import NotFound from './views/NotFound.vue';
+
+const Overview = () => import('./views/Overview.vue');
+const Diagnostics = () => import('./views/Diagnostics.vue');
+const Traffic = () => import('./views/Traffic.vue');
+const Monitor = () => import('./views/Monitor.vue');
+const AgentHealth = () => import('./views/AgentHealth.vue');
+const Settings = () => import('./views/Settings.vue');
+const SettingsApiTokens = () => import('./views/SettingsApiTokens.vue');
+const SettingsEnvironments = () => import('./views/SettingsEnvironments.vue');
+const ProxyConfig = () => import('./views/ProxyConfig.vue');
+const TrafficPolicies = () => import('./views/TrafficPolicies.vue');
+const ResponseTemplates = () => import('./views/ResponseTemplates.vue');
+const TlsConfig = () => import('./views/TlsConfig.vue');
+const NotFound = () => import('./views/NotFound.vue');
 
 const routes = [
   { path: '/', redirect: '/overview' },

--- a/web/management/src/views/TrafficPolicies.vue
+++ b/web/management/src/views/TrafficPolicies.vue
@@ -40,17 +40,18 @@ import {
 } from "@/lib/publicProxyLabels";
 import { modalCardStyle, naiveTagType } from "@/lib/naiveUi";
 import {
-  previewTrafficPolicyStages,
+  buildTrafficPolicyPlaygroundStages,
+  defaultTrafficPolicyPreviewForm,
   runtimeOrderedCacheRules,
   runtimeOrderedRateLimitRules,
   runtimeOrderedTrafficShaperRules,
   runtimeOrderedWafRules,
+  trafficPolicyPreviewFormToRequest,
   trafficPolicyAttentionWarnings,
   type TrafficPolicyAttentionWarning,
   type TrafficPolicyKind,
-  type TrafficPolicyMatchState,
-  type TrafficPolicyStageCandidate,
-  type TrafficPolicySyntheticRequest,
+  type TrafficPolicyPlaygroundStage,
+  type TrafficPolicyPreviewForm,
 } from "@/lib/trafficPolicyWorkbench";
 import type {
   PublicCacheRule,
@@ -72,33 +73,6 @@ type PolicySectionSummary = {
   description: string;
 };
 type PolicyFilterStatus = "all" | "enabled" | "disabled";
-type TrafficPolicyPreviewForm = {
-  method: string;
-  protocol: string;
-  host: string;
-  path: string;
-  remoteIp: string;
-  headersText: string;
-  cookiesText: string;
-  queryText: string;
-  routeId: string;
-  targetId: string;
-};
-type PlaygroundStageItem = {
-  id: bigint;
-  name: string;
-  priority: bigint;
-  state: TrafficPolicyMatchState;
-  reason: string;
-  selected: boolean;
-  skipped: boolean;
-};
-type PlaygroundStage = {
-  key: string;
-  label: string;
-  mode: "first" | "all";
-  items: PlaygroundStageItem[];
-};
 
 const managementClient = useManagementClient();
 const route = useRoute();
@@ -132,26 +106,7 @@ const policyFilterStatusOptions = [
   { label: "Disabled", value: "disabled" },
 ];
 const previewForm = reactive<TrafficPolicyPreviewForm>(defaultTrafficPolicyPreviewForm());
-const previewRequest = computed<TrafficPolicySyntheticRequest>(() => ({
-  method: previewForm.method,
-  protocol: previewForm.protocol,
-  host: previewForm.host,
-  path: previewForm.path,
-  remoteIp: previewForm.remoteIp,
-  headers: parseRepeatedMap(previewForm.headersText, true),
-  cookies: parseCookieMap(previewForm.cookiesText),
-  query: parseRepeatedMap(previewForm.queryText, false),
-  routeId: previewForm.routeId || null,
-  targetId: previewForm.targetId || null,
-}));
-const policyStagePreview = computed(() => previewTrafficPolicyStages({
-  rateLimitRules: rateLimitRules.value,
-  trafficShaperRules: trafficShaperRules.value,
-  wafRules: wafRules.value,
-  wafCaptchaProviders: wafCaptchaProviders.value,
-  cacheSettings: cacheSettings.value ?? undefined,
-  cacheRules: cacheRules.value,
-}, previewRequest.value));
+const previewRequest = computed(() => trafficPolicyPreviewFormToRequest(previewForm));
 const policyAttention = computed(() => trafficPolicyAttentionWarnings({
   rateLimitRules: rateLimitRules.value,
   trafficShaperRules: trafficShaperRules.value,
@@ -170,12 +125,14 @@ const executionStages = computed(() => [
   { key: "cache", label: "Cache", description: "first matching cacheable request", icon: "cache" as const, tags: countTags(enabledCacheRules.value) },
   { key: "response", label: "Response", description: "upstream, cached, or terminal", icon: "response" as const },
 ]);
-const playgroundStages = computed<PlaygroundStage[]>(() => [
-  stageFromFirstCandidate("waf", "WAF", wafRules.value, policyStagePreview.value.waf),
-  stageFromRateLimitCandidates(rateLimitRules.value, policyStagePreview.value.rateLimits),
-  stageFromFirstCandidate("traffic-shaper", "Traffic shaper", trafficShaperRules.value, policyStagePreview.value.trafficShaper),
-  stageFromFirstCandidate("cache", "Cache", cacheRules.value, policyStagePreview.value.cache),
-]);
+const playgroundStages = computed<TrafficPolicyPlaygroundStage[]>(() => buildTrafficPolicyPlaygroundStages({
+  rateLimitRules: rateLimitRules.value,
+  trafficShaperRules: trafficShaperRules.value,
+  wafRules: wafRules.value,
+  wafCaptchaProviders: wafCaptchaProviders.value,
+  cacheSettings: cacheSettings.value ?? undefined,
+  cacheRules: cacheRules.value,
+}, previewRequest.value));
 const filteredRateLimitRules = computed(() => filterPolicyRules(rateLimitRules.value, "rate-limit", rateLimitSearchText));
 const filteredWafRules = computed(() => filterPolicyRules(wafRules.value, "waf", wafSearchText));
 const filteredCacheRules = computed(() => filterPolicyRules(cacheRules.value, "cache", cacheSearchText));
@@ -289,21 +246,6 @@ async function selectPolicySection(value: string | number) {
   await router.push(`/policies/${section}`);
 }
 
-function defaultTrafficPolicyPreviewForm(): TrafficPolicyPreviewForm {
-  return {
-    method: "GET",
-    protocol: "https",
-    host: "app.example.com",
-    path: "/",
-    remoteIp: "198.51.100.10",
-    headersText: "X-Plan: pro",
-    cookiesText: "",
-    queryText: "",
-    routeId: "",
-    targetId: "",
-  };
-}
-
 function updateTrafficPolicyPreview(value: TrafficPolicyPreviewForm) {
   Object.assign(previewForm, value);
 }
@@ -312,98 +254,8 @@ function resetTrafficPolicyPreview() {
   Object.assign(previewForm, defaultTrafficPolicyPreviewForm());
 }
 
-function parseRepeatedMap(text: string, lowerCaseKeys: boolean): Record<string, string[]> {
-  const parsed: Record<string, string[]> = {};
-  for (const line of text.split(/\r?\n/)) {
-    const item = parseKeyValueLine(line);
-    if (!item) continue;
-    const key = lowerCaseKeys ? item.key.toLowerCase() : item.key;
-    const values = parsed[key] ?? [];
-    values.push(item.value);
-    parsed[key] = values;
-  }
-  return parsed;
-}
-
-function parseCookieMap(text: string): Record<string, string> {
-  const parsed: Record<string, string> = {};
-  for (const part of text.split(/\r?\n|;/)) {
-    const item = parseKeyValueLine(part);
-    if (!item) continue;
-    if (parsed[item.key] !== undefined) continue;
-    parsed[item.key] = item.value;
-  }
-  return parsed;
-}
-
-function parseKeyValueLine(line: string): { key: string; value: string } | null {
-  const trimmed = line.trim();
-  if (!trimmed) return null;
-  const colon = trimmed.indexOf(":");
-  const equals = trimmed.indexOf("=");
-  const separator = colon >= 0 && (equals < 0 || colon < equals) ? colon : equals;
-  if (separator < 0) return { key: trimmed, value: "" };
-  const key = trimmed.slice(0, separator).trim();
-  if (!key) return null;
-  return { key, value: trimmed.slice(separator + 1).trim() };
-}
-
 function countTags(count: number) {
   return count ? [{ label: count.toString(), tone: "info" as const }] : [];
-}
-
-function stageFromFirstCandidate<T extends { id: bigint; name: string; priority: bigint; enabled: boolean }>(
-  key: TrafficPolicyKind,
-  label: string,
-  rules: readonly T[],
-  candidate: TrafficPolicyStageCandidate<T> | null,
-): PlaygroundStage {
-  const selectedId = candidate?.rule.id;
-  let passedSelected = false;
-  return {
-    key,
-    label,
-    mode: "first",
-    items: rules.map((rule) => {
-      const selected = selectedId !== undefined && rule.id === selectedId;
-      const skipped = Boolean(rule.enabled && passedSelected && !selected);
-      const selectedResult = selected ? candidate?.result : null;
-      if (selected) passedSelected = true;
-      return {
-        id: rule.id,
-        name: rule.name,
-        priority: rule.priority,
-        state: selectedResult?.state ?? "miss",
-        reason: selectedResult ? (selectedResult.reason || "Selected by preview") : (rule.enabled ? skipped ? "Skipped after earlier candidate" : "No match in preview" : "Rule is disabled"),
-        selected,
-        skipped,
-      };
-    }),
-  };
-}
-
-function stageFromRateLimitCandidates(
-  rules: readonly PublicRateLimitRule[],
-  candidates: readonly TrafficPolicyStageCandidate<PublicRateLimitRule>[],
-): PlaygroundStage {
-  const candidateById = new Map(candidates.map((candidate) => [candidate.rule.id.toString(), candidate]));
-  return {
-    key: "rate-limit",
-    label: "Rate limits",
-    mode: "all",
-    items: rules.map((rule) => {
-      const candidate = candidateById.get(rule.id.toString());
-      return {
-        id: rule.id,
-        name: rule.name,
-        priority: rule.priority,
-        state: candidate?.result.state ?? "miss",
-        reason: candidate?.result.reason || (rule.enabled ? "No match in preview" : "Rule is disabled"),
-        selected: Boolean(candidate),
-        skipped: false,
-      };
-    }),
-  };
 }
 
 function filterPolicyRules<T extends { enabled: boolean; id: bigint }>(

--- a/web/management/src/views/TrafficPolicies.vue
+++ b/web/management/src/views/TrafficPolicies.vue
@@ -3,11 +3,14 @@ import { computed, reactive, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { Pencil as PencilIcon } from "@lucide/vue";
 import { Plus as PlusIcon } from "@lucide/vue";
+import { Search as SearchIcon } from "@lucide/vue";
 import { Trash2 as TrashIcon } from "@lucide/vue";
-import { NButton, NCheckbox, NInputNumber, NTabPane, NTabs, NTag } from "naive-ui";
+import { NButton, NCheckbox, NInput, NInputNumber, NModal, NSelect, NTabPane, NTabs, NTag } from "naive-ui";
 import { useManagementClient } from "@/composables/useManagementClient";
 import EmptyState from "@/components/EmptyState.vue";
 import PublicProxyEditorHost from "@/components/editors/PublicProxyEditorHost.vue";
+import TrafficPolicyExecutionOrderStrip from "@/components/traffic-policy/TrafficPolicyExecutionOrderStrip.vue";
+import TrafficPolicyRequestPlayground from "@/components/traffic-policy/TrafficPolicyRequestPlayground.vue";
 import { useConfirmDialog } from "@/composables/useConfirmDialog";
 import { useManagementContext } from "@/composables/useManagementContext";
 import { BUSY_REASON } from "@/lib/disabledReasons";
@@ -25,6 +28,7 @@ import {
   rateLimitAlgorithmLabel,
   rateLimitKeySummary,
   rateLimitRuleSummary,
+  routeTargetName,
   trafficShaperBudgetSummary,
   trafficShaperKeySummary,
   trafficShaperRuleSummary,
@@ -34,8 +38,29 @@ import {
   wafProviderLabel,
   wafRuleSummary,
 } from "@/lib/publicProxyLabels";
-import { naiveTagType } from "@/lib/naiveUi";
-import type { PublicWafCaptchaProvider } from "@/gen/proto/p2pstream/v1/management_pb";
+import { modalCardStyle, naiveTagType } from "@/lib/naiveUi";
+import {
+  previewTrafficPolicyStages,
+  runtimeOrderedCacheRules,
+  runtimeOrderedRateLimitRules,
+  runtimeOrderedTrafficShaperRules,
+  runtimeOrderedWafRules,
+  trafficPolicyAttentionWarnings,
+  type TrafficPolicyAttentionWarning,
+  type TrafficPolicyKind,
+  type TrafficPolicyMatchState,
+  type TrafficPolicyStageCandidate,
+  type TrafficPolicySyntheticRequest,
+} from "@/lib/trafficPolicyWorkbench";
+import type {
+  PublicCacheRule,
+  PublicRateLimitRule,
+  PublicRoute,
+  PublicRouteTarget,
+  PublicTrafficShaperRule,
+  PublicWafCaptchaProvider,
+  PublicWafRule,
+} from "@/gen/proto/p2pstream/v1/management_pb";
 
 const policySectionKeys = ["rate-limits", "waf", "cache", "traffic-shaper"] as const;
 type PolicySectionKey = typeof policySectionKeys[number];
@@ -45,6 +70,34 @@ type PolicySectionSummary = {
   value: string;
   detail: string;
   description: string;
+};
+type PolicyFilterStatus = "all" | "enabled" | "disabled";
+type TrafficPolicyPreviewForm = {
+  method: string;
+  protocol: string;
+  host: string;
+  path: string;
+  remoteIp: string;
+  headersText: string;
+  cookiesText: string;
+  queryText: string;
+  routeId: string;
+  targetId: string;
+};
+type PlaygroundStageItem = {
+  id: bigint;
+  name: string;
+  priority: bigint;
+  state: TrafficPolicyMatchState;
+  reason: string;
+  selected: boolean;
+  skipped: boolean;
+};
+type PlaygroundStage = {
+  key: string;
+  label: string;
+  mode: "first" | "all";
+  items: PlaygroundStageItem[];
 };
 
 const managementClient = useManagementClient();
@@ -59,18 +112,88 @@ const {
 } = useManagementContext();
 
 const config = computed(() => publicProxyConfig.value ?? null);
-const rateLimitRules = computed(() => config.value?.rateLimitRules ?? []);
-const cacheRules = computed(() => config.value?.cacheRules ?? []);
+const rateLimitRules = computed(() => runtimeOrderedRateLimitRules(config.value?.rateLimitRules ?? []));
+const cacheRules = computed(() => runtimeOrderedCacheRules(config.value?.cacheRules ?? []));
 const cacheSettings = computed(() => config.value?.cacheSettings ?? null);
-const wafRules = computed(() => config.value?.wafRules ?? []);
+const wafRules = computed(() => runtimeOrderedWafRules(config.value?.wafRules ?? []));
 const wafCaptchaProviders = computed(() => config.value?.wafCaptchaProviders ?? []);
-const trafficShaperRules = computed(() => config.value?.trafficShaperRules ?? []);
+const trafficShaperRules = computed(() => runtimeOrderedTrafficShaperRules(config.value?.trafficShaperRules ?? []));
 const enabledRateLimitRules = computed(() => rateLimitRules.value.filter((rule) => rule.enabled).length);
 const enabledWafRules = computed(() => wafRules.value.filter((rule) => rule.enabled).length);
 const enabledCacheRules = computed(() => cacheRules.value.filter((rule) => rule.enabled).length);
 const enabledTrafficShapers = computed(() => trafficShaperRules.value.filter((rule) => rule.enabled).length);
+const policyFilter = reactive({
+  text: "",
+  status: "all" as PolicyFilterStatus,
+});
+const policyFilterStatusOptions = [
+  { label: "All", value: "all" },
+  { label: "Enabled", value: "enabled" },
+  { label: "Disabled", value: "disabled" },
+];
+const previewForm = reactive<TrafficPolicyPreviewForm>(defaultTrafficPolicyPreviewForm());
+const previewRequest = computed<TrafficPolicySyntheticRequest>(() => ({
+  method: previewForm.method,
+  protocol: previewForm.protocol,
+  host: previewForm.host,
+  path: previewForm.path,
+  remoteIp: previewForm.remoteIp,
+  headers: parseRepeatedMap(previewForm.headersText, true),
+  cookies: parseCookieMap(previewForm.cookiesText),
+  query: parseRepeatedMap(previewForm.queryText, false),
+  routeId: previewForm.routeId || null,
+  targetId: previewForm.targetId || null,
+}));
+const policyStagePreview = computed(() => previewTrafficPolicyStages({
+  rateLimitRules: rateLimitRules.value,
+  trafficShaperRules: trafficShaperRules.value,
+  wafRules: wafRules.value,
+  wafCaptchaProviders: wafCaptchaProviders.value,
+  cacheSettings: cacheSettings.value ?? undefined,
+  cacheRules: cacheRules.value,
+}, previewRequest.value));
+const policyAttention = computed(() => trafficPolicyAttentionWarnings({
+  rateLimitRules: rateLimitRules.value,
+  trafficShaperRules: trafficShaperRules.value,
+  wafRules: wafRules.value,
+  wafCaptchaProviders: wafCaptchaProviders.value,
+  cacheSettings: cacheSettings.value ?? undefined,
+  cacheRules: cacheRules.value,
+}));
+const globalPolicyAttention = computed(() => policyAttention.value.filter((item) => item.ruleId === undefined && !item.ruleIds?.length));
+const executionStages = computed(() => [
+  { key: "precheck", label: "Path Checks", description: "reserved endpoints + route security", icon: "listener" as const },
+  { key: "waf", label: "WAF", description: "first matching enforceable rule", icon: "waf" as const, tags: countTags(enabledWafRules.value) },
+  { key: "rate-limit", label: "Rate Limits", description: "all matching request budgets", icon: "rate-limit" as const, tags: countTags(enabledRateLimitRules.value) },
+  { key: "traffic-shaper", label: "Traffic Shaper", description: "first matching bandwidth budget", icon: "traffic-shaper" as const, tags: countTags(enabledTrafficShapers.value) },
+  { key: "route", label: "Route / Target", description: "selected before cache", icon: "route" as const },
+  { key: "cache", label: "Cache", description: "first matching cacheable request", icon: "cache" as const, tags: countTags(enabledCacheRules.value) },
+  { key: "response", label: "Response", description: "upstream, cached, or terminal", icon: "response" as const },
+]);
+const playgroundStages = computed<PlaygroundStage[]>(() => [
+  stageFromFirstCandidate("waf", "WAF", wafRules.value, policyStagePreview.value.waf),
+  stageFromRateLimitCandidates(rateLimitRules.value, policyStagePreview.value.rateLimits),
+  stageFromFirstCandidate("traffic-shaper", "Traffic shaper", trafficShaperRules.value, policyStagePreview.value.trafficShaper),
+  stageFromFirstCandidate("cache", "Cache", cacheRules.value, policyStagePreview.value.cache),
+]);
+const filteredRateLimitRules = computed(() => filterPolicyRules(rateLimitRules.value, "rate-limit", rateLimitSearchText));
+const filteredWafRules = computed(() => filterPolicyRules(wafRules.value, "waf", wafSearchText));
+const filteredCacheRules = computed(() => filterPolicyRules(cacheRules.value, "cache", cacheSearchText));
+const filteredTrafficShaperRules = computed(() => filterPolicyRules(trafficShaperRules.value, "traffic-shaper", trafficShaperSearchText));
+const isPolicyFilterActive = computed(() => Boolean(policyFilter.text.trim()) || policyFilter.status !== "all");
+const previewRouteOptions = computed(() => (config.value?.routes ?? []).map((routeItem) => ({
+  label: routeOptionLabel(routeItem),
+  value: routeItem.id.toString(),
+})));
+const previewTargetOptions = computed(() => (config.value?.routeTargets ?? [])
+  .filter((target) => !previewForm.routeId || target.routeId.toString() === previewForm.routeId)
+  .map((target) => ({
+    label: targetOptionLabel(target),
+    value: target.id.toString(),
+  })));
 
 const editorHost = ref<InstanceType<typeof PublicProxyEditorHost> | null>(null);
+const isPreviewOpen = ref(false);
 const { confirm } = useConfirmDialog();
 
 const cacheSettingsForm = reactive({
@@ -137,6 +260,19 @@ watch(cacheSettings, (settings) => {
   cacheSettingsForm.cleanupIntervalSeconds = Math.max(1, Math.round(Number(settings?.cleanupIntervalMillis ?? 60000n) / 1000));
 }, { immediate: true });
 
+watch(() => previewForm.routeId, () => {
+  if (!previewForm.targetId) return;
+  if (!previewTargetBelongsToRoute(previewForm.targetId, previewForm.routeId)) {
+    previewForm.targetId = "";
+  }
+});
+
+watch(() => previewForm.targetId, (targetId) => {
+  if (!targetId || previewForm.routeId) return;
+  const target = findPreviewTarget(targetId);
+  if (target) previewForm.routeId = target.routeId.toString();
+});
+
 async function run(action: () => Promise<void>) {
   if (!runManagementAction) return;
   await runManagementAction(action);
@@ -151,6 +287,251 @@ async function selectPolicySection(value: string | number) {
   const section = normalizePolicySection(value);
   if (section === activePolicySection.value) return;
   await router.push(`/policies/${section}`);
+}
+
+function defaultTrafficPolicyPreviewForm(): TrafficPolicyPreviewForm {
+  return {
+    method: "GET",
+    protocol: "https",
+    host: "app.example.com",
+    path: "/",
+    remoteIp: "198.51.100.10",
+    headersText: "X-Plan: pro",
+    cookiesText: "",
+    queryText: "",
+    routeId: "",
+    targetId: "",
+  };
+}
+
+function updateTrafficPolicyPreview(value: TrafficPolicyPreviewForm) {
+  Object.assign(previewForm, value);
+}
+
+function resetTrafficPolicyPreview() {
+  Object.assign(previewForm, defaultTrafficPolicyPreviewForm());
+}
+
+function parseRepeatedMap(text: string, lowerCaseKeys: boolean): Record<string, string[]> {
+  const parsed: Record<string, string[]> = {};
+  for (const line of text.split(/\r?\n/)) {
+    const item = parseKeyValueLine(line);
+    if (!item) continue;
+    const key = lowerCaseKeys ? item.key.toLowerCase() : item.key;
+    const values = parsed[key] ?? [];
+    values.push(item.value);
+    parsed[key] = values;
+  }
+  return parsed;
+}
+
+function parseCookieMap(text: string): Record<string, string> {
+  const parsed: Record<string, string> = {};
+  for (const part of text.split(/\r?\n|;/)) {
+    const item = parseKeyValueLine(part);
+    if (!item) continue;
+    if (parsed[item.key] !== undefined) continue;
+    parsed[item.key] = item.value;
+  }
+  return parsed;
+}
+
+function parseKeyValueLine(line: string): { key: string; value: string } | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  const colon = trimmed.indexOf(":");
+  const equals = trimmed.indexOf("=");
+  const separator = colon >= 0 && (equals < 0 || colon < equals) ? colon : equals;
+  if (separator < 0) return { key: trimmed, value: "" };
+  const key = trimmed.slice(0, separator).trim();
+  if (!key) return null;
+  return { key, value: trimmed.slice(separator + 1).trim() };
+}
+
+function countTags(count: number) {
+  return count ? [{ label: count.toString(), tone: "info" as const }] : [];
+}
+
+function stageFromFirstCandidate<T extends { id: bigint; name: string; priority: bigint; enabled: boolean }>(
+  key: TrafficPolicyKind,
+  label: string,
+  rules: readonly T[],
+  candidate: TrafficPolicyStageCandidate<T> | null,
+): PlaygroundStage {
+  const selectedId = candidate?.rule.id;
+  let passedSelected = false;
+  return {
+    key,
+    label,
+    mode: "first",
+    items: rules.map((rule) => {
+      const selected = selectedId !== undefined && rule.id === selectedId;
+      const skipped = Boolean(rule.enabled && passedSelected && !selected);
+      const selectedResult = selected ? candidate?.result : null;
+      if (selected) passedSelected = true;
+      return {
+        id: rule.id,
+        name: rule.name,
+        priority: rule.priority,
+        state: selectedResult?.state ?? "miss",
+        reason: selectedResult ? (selectedResult.reason || "Selected by preview") : (rule.enabled ? skipped ? "Skipped after earlier candidate" : "No match in preview" : "Rule is disabled"),
+        selected,
+        skipped,
+      };
+    }),
+  };
+}
+
+function stageFromRateLimitCandidates(
+  rules: readonly PublicRateLimitRule[],
+  candidates: readonly TrafficPolicyStageCandidate<PublicRateLimitRule>[],
+): PlaygroundStage {
+  const candidateById = new Map(candidates.map((candidate) => [candidate.rule.id.toString(), candidate]));
+  return {
+    key: "rate-limit",
+    label: "Rate limits",
+    mode: "all",
+    items: rules.map((rule) => {
+      const candidate = candidateById.get(rule.id.toString());
+      return {
+        id: rule.id,
+        name: rule.name,
+        priority: rule.priority,
+        state: candidate?.result.state ?? "miss",
+        reason: candidate?.result.reason || (rule.enabled ? "No match in preview" : "Rule is disabled"),
+        selected: Boolean(candidate),
+        skipped: false,
+      };
+    }),
+  };
+}
+
+function filterPolicyRules<T extends { enabled: boolean; id: bigint }>(
+  rules: readonly T[],
+  kind: TrafficPolicyKind,
+  searchText: (rule: T) => string,
+): T[] {
+  const needle = policyFilter.text.trim().toLowerCase();
+  return rules.filter((rule) => {
+    if (policyFilter.status === "enabled" && !rule.enabled) return false;
+    if (policyFilter.status === "disabled" && rule.enabled) return false;
+    if (!needle) return true;
+    return searchText(rule).toLowerCase().includes(needle) ||
+      policyWarningsForRule(kind, rule.id).some((warning) => warningLabel(warning).toLowerCase().includes(needle));
+  });
+}
+
+function policyWarningsForRule(kind: TrafficPolicyKind, id: bigint): TrafficPolicyAttentionWarning[] {
+  return policyAttention.value.filter((warning) => warning.policyKind === kind && (
+    warning.ruleId === id || warning.ruleIds?.some((ruleId) => ruleId === id)
+  ));
+}
+
+function visiblePolicyWarningsForRule(kind: TrafficPolicyKind, id: bigint): TrafficPolicyAttentionWarning[] {
+  return policyWarningsForRule(kind, id).filter((warning) => (
+    warning.code !== "disabled-rule" &&
+    warning.code !== "cache-allows-cookie-requests"
+  ));
+}
+
+function warningLabel(warning: TrafficPolicyAttentionWarning): string {
+  switch (warning.code) {
+    case "duplicate-priority": return "Priority tie";
+    case "disabled-rule": return "Disabled";
+    case "any-request-rule": return "Any request";
+    case "captcha-provider-missing": return "Provider missing";
+    case "captcha-provider-disabled": return "Provider disabled";
+    case "captcha-provider-secret-missing": return "Provider secret missing";
+    case "cache-settings-disabled": return "Cache disabled";
+    case "cache-allows-cookie-requests": return "Legacy Cookie flag";
+    default: return warning.message;
+  }
+}
+
+function warningSeverity(warning: TrafficPolicyAttentionWarning): string {
+  switch (warning.code) {
+    case "captcha-provider-missing":
+    case "captcha-provider-disabled":
+    case "captcha-provider-secret-missing":
+      return "danger";
+    case "duplicate-priority":
+    case "any-request-rule":
+    case "cache-settings-disabled":
+    case "cache-allows-cookie-requests":
+      return "warning";
+    default:
+      return "info";
+  }
+}
+
+function rateLimitSearchText(rule: PublicRateLimitRule): string {
+  return [
+    rule.name,
+    rule.priority.toString(),
+    rule.enabled ? "enabled" : "disabled",
+    rateLimitAlgorithmLabel(rule.algorithm),
+    rateLimitRuleSummary(rule),
+    rateLimitKeySummary(rule),
+    publicPolicyMatchSummary(rule),
+    rule.responseStatusCode.toString(),
+  ].join(" ");
+}
+
+function wafSearchText(rule: PublicWafRule): string {
+  return [
+    rule.name,
+    rule.priority.toString(),
+    rule.enabled ? "enabled" : "disabled",
+    wafActionLabel(rule.action),
+    wafActivationLabel(rule.activationMode),
+    wafRuleSummary(rule, wafCaptchaProviders.value),
+    rateLimitKeySummary(rule),
+    publicPolicyMatchSummary(rule),
+  ].join(" ");
+}
+
+function cacheSearchText(rule: PublicCacheRule): string {
+  return [
+    rule.name,
+    rule.priority.toString(),
+    rule.enabled ? "enabled" : "disabled",
+    cacheTtlModeLabel(rule.ttlMode),
+    cacheScopeLabel(rule.scope),
+    cacheRuleSummary(rule),
+    cacheQueryModeLabel(rule.queryMode),
+    cacheRuleMatchSummary(rule),
+  ].join(" ");
+}
+
+function trafficShaperSearchText(rule: PublicTrafficShaperRule): string {
+  return [
+    rule.name,
+    rule.priority.toString(),
+    rule.enabled ? "enabled" : "disabled",
+    trafficShaperScopeLabel(rule.budgetScope),
+    trafficShaperRuleSummary(rule),
+    trafficShaperBudgetSummary(rule),
+    trafficShaperKeySummary(rule),
+    publicPolicyMatchSummary(rule),
+  ].join(" ");
+}
+
+function routeOptionLabel(routeItem: PublicRoute): string {
+  return `${routeItem.hostPattern || "*"}${routeItem.pathPrefix || "/"} / P${routeItem.priority.toString()}`;
+}
+
+function targetOptionLabel(target: PublicRouteTarget): string {
+  return `${routeTargetName(target)} / route ${target.routeId.toString()}`;
+}
+
+function findPreviewTarget(targetId: string): PublicRouteTarget | undefined {
+  return (config.value?.routeTargets ?? []).find((target) => target.id.toString() === targetId);
+}
+
+function previewTargetBelongsToRoute(targetId: string, routeId: string): boolean {
+  if (!routeId) return true;
+  const target = findPreviewTarget(targetId);
+  return Boolean(target && target.routeId.toString() === routeId);
 }
 
 function openAddRateLimitRuleModal() {
@@ -257,6 +638,12 @@ async function deleteTrafficShaperRule(id: bigint) {
         <h3 class="margin-bottom-sm copy-xl weight-bold">Traffic Policy</h3>
         <p class="copy-sm muted-text">{{ activePolicyMeta.description }}</p>
       </div>
+      <div class="page-toolbar__actions">
+        <NButton secondary size="small" @click="isPreviewOpen = true">
+          <template #icon><SearchIcon class="icon-sm" /></template>
+          Request Tester
+        </NButton>
+      </div>
     </div>
 
     <section class="summary-grid summary-grid--four policy-summary-grid" aria-label="Policy type summary">
@@ -270,6 +657,24 @@ async function deleteTrafficShaperRule(id: bigint) {
         <p class="margin-top-sm copy-2xl weight-semibold base-text">{{ section.value }}</p>
         <p class="margin-top-xs copy-xs muted-text">{{ section.detail }}</p>
       </div>
+    </section>
+
+    <TrafficPolicyExecutionOrderStrip
+      :stages="executionStages"
+      description="Rules are shown in runtime order. Lower priorities run first, ties fall back to rule ID."
+    />
+
+    <section class="surface-card policy-filter-bar" aria-label="Traffic policy filters">
+      <label class="policy-filter-search">
+        <span class="copy-xs weight-semibold label-case letter-wide muted-text">Filter</span>
+        <NInput v-model:value="policyFilter.text" size="small" clearable placeholder="Rule name, match, priority, warning">
+          <template #prefix><SearchIcon class="icon-sm" /></template>
+        </NInput>
+      </label>
+      <label class="policy-filter-status">
+        <span class="copy-xs weight-semibold label-case letter-wide muted-text">State</span>
+        <NSelect v-model:value="policyFilter.status" size="small" :options="policyFilterStatusOptions" />
+      </label>
     </section>
 
     <NTabs class="policy-tabs" type="line" animated :value="activePolicySection" @update:value="selectPolicySection">
@@ -286,13 +691,22 @@ async function deleteTrafficShaperRule(id: bigint) {
         </NButton>
       </div>
       <div class="divided-list">
-        <div v-for="rule in rateLimitRules" :key="rule.id.toString()" class="layout-grid space-md pad-x-xl pad-y-lg mq-lg-one-auto">
+        <div v-for="rule in filteredRateLimitRules" :key="rule.id.toString()" class="layout-grid space-md pad-x-xl pad-y-lg mq-lg-one-auto">
           <div class="min-width-zero">
             <div class="layout-row min-width-zero wrap-items align-center space-sm">
               <p class="clip-text copy-sm weight-medium base-text">{{ rule.name }}</p>
               <NTag size="small" :bordered="false" type="info">{{ rateLimitAlgorithmLabel(rule.algorithm) }}</NTag>
               <NTag v-if="!rule.enabled" size="small" :bordered="false" type="warning">Disabled</NTag>
               <NTag size="small" :bordered="false" type="info">P{{ rule.priority.toString() }}</NTag>
+              <NTag
+                v-for="warning in visiblePolicyWarningsForRule('rate-limit', rule.id)"
+                :key="warning.code"
+                size="small"
+                :bordered="false"
+                :type="naiveTagType(warningSeverity(warning))"
+              >
+                {{ warningLabel(warning) }}
+              </NTag>
             </div>
             <p class="margin-top-xs clip-text mono-text copy-xs muted-text">{{ rateLimitRuleSummary(rule) }} / key {{ rateLimitKeySummary(rule) }}</p>
             <p class="margin-top-xs clip-text copy-xs muted-text">{{ publicPolicyMatchSummary(rule) }} / response {{ rule.responseStatusCode.toString() }}</p>
@@ -306,6 +720,11 @@ async function deleteTrafficShaperRule(id: bigint) {
             </NButton>
           </div>
         </div>
+        <EmptyState
+          v-if="rateLimitRules.length && !filteredRateLimitRules.length && isPolicyFilterActive"
+          title="No matching rate-limit rules"
+          description="Adjust the filter text or state selector."
+        />
         <EmptyState
           v-if="!rateLimitRules.length"
           title="No rate-limit rules configured"
@@ -355,7 +774,7 @@ async function deleteTrafficShaperRule(id: bigint) {
             </NButton>
           </div>
         </div>
-        <div v-for="rule in wafRules" :key="`rule-${rule.id.toString()}`" class="layout-grid space-md pad-x-xl pad-y-lg mq-lg-one-auto">
+        <div v-for="rule in filteredWafRules" :key="`rule-${rule.id.toString()}`" class="layout-grid space-md pad-x-xl pad-y-lg mq-lg-one-auto">
           <div class="min-width-zero">
             <div class="layout-row min-width-zero wrap-items align-center space-sm">
               <p class="clip-text copy-sm weight-medium base-text">{{ rule.name }}</p>
@@ -363,6 +782,15 @@ async function deleteTrafficShaperRule(id: bigint) {
               <NTag size="small" :bordered="false" type="info">{{ wafActivationLabel(rule.activationMode) }}</NTag>
               <NTag v-if="!rule.enabled" size="small" :bordered="false" type="warning">Disabled</NTag>
               <NTag size="small" :bordered="false" type="info">P{{ rule.priority.toString() }}</NTag>
+              <NTag
+                v-for="warning in visiblePolicyWarningsForRule('waf', rule.id)"
+                :key="warning.code"
+                size="small"
+                :bordered="false"
+                :type="naiveTagType(warningSeverity(warning))"
+              >
+                {{ warningLabel(warning) }}
+              </NTag>
             </div>
             <p class="margin-top-xs clip-text mono-text copy-xs muted-text">{{ wafRuleSummary(rule, wafCaptchaProviders) }} / key {{ rateLimitKeySummary(rule) }}</p>
             <p class="margin-top-xs clip-text copy-xs muted-text">{{ publicPolicyMatchSummary(rule) }}</p>
@@ -376,6 +804,11 @@ async function deleteTrafficShaperRule(id: bigint) {
             </NButton>
           </div>
         </div>
+        <EmptyState
+          v-if="wafRules.length && !filteredWafRules.length && isPolicyFilterActive"
+          title="No matching WAF rules"
+          description="Adjust the filter text or state selector."
+        />
         <EmptyState
           v-if="!wafRules.length && !wafCaptchaProviders.length"
           title="No WAF policy configured"
@@ -444,15 +877,24 @@ async function deleteTrafficShaperRule(id: bigint) {
         </div>
       </div>
       <div class="divided-list">
-        <div v-for="rule in cacheRules" :key="rule.id.toString()" class="layout-grid space-md pad-x-xl pad-y-lg mq-lg-one-auto">
+        <div v-for="rule in filteredCacheRules" :key="rule.id.toString()" class="layout-grid space-md pad-x-xl pad-y-lg mq-lg-one-auto">
           <div class="min-width-zero">
             <div class="layout-row min-width-zero wrap-items align-center space-sm">
               <p class="clip-text copy-sm weight-medium base-text">{{ rule.name }}</p>
               <NTag size="small" :bordered="false" type="info">{{ cacheTtlModeLabel(rule.ttlMode) }}</NTag>
               <NTag size="small" :bordered="false" type="info">{{ cacheScopeLabel(rule.scope) }}</NTag>
-              <NTag size="small" :bordered="false" :type="naiveTagType(rule.allowCookieRequests ? 'warn' : 'info')">{{ rule.allowCookieRequests ? 'Cookies allowed' : 'Cookies blocked' }}</NTag>
+              <NTag v-if="rule.allowCookieRequests" size="small" :bordered="false" type="warning">Legacy cookie flag</NTag>
               <NTag v-if="!rule.enabled" size="small" :bordered="false" type="warning">Disabled</NTag>
               <NTag size="small" :bordered="false" type="info">P{{ rule.priority.toString() }}</NTag>
+              <NTag
+                v-for="warning in visiblePolicyWarningsForRule('cache', rule.id)"
+                :key="warning.code"
+                size="small"
+                :bordered="false"
+                :type="naiveTagType(warningSeverity(warning))"
+              >
+                {{ warningLabel(warning) }}
+              </NTag>
             </div>
             <p class="margin-top-xs clip-text mono-text copy-xs muted-text">{{ cacheRuleSummary(rule) }} / {{ cacheQueryModeLabel(rule.queryMode) }}</p>
             <p class="margin-top-xs clip-text copy-xs muted-text">{{ cacheRuleMatchSummary(rule) }}</p>
@@ -467,9 +909,14 @@ async function deleteTrafficShaperRule(id: bigint) {
           </div>
         </div>
         <EmptyState
+          v-if="cacheRules.length && !filteredCacheRules.length && isPolicyFilterActive"
+          title="No matching cache rules"
+          description="Adjust the filter text or state selector."
+        />
+        <EmptyState
           v-if="!cacheRules.length"
           title="No cache rules configured"
-          description="Cache rules store public GET assets such as CSS, JavaScript, images, and fonts on the proxy. Authorization requests are always bypassed; cookie requests require an explicit rule opt-in."
+          description="Cache rules store public GET assets such as CSS, JavaScript, images, and fonts on the proxy. Authorization and Cookie requests always bypass shared cache."
           action-label="Add Rule"
           @action="openAddCacheRuleModal"
         />
@@ -490,13 +937,22 @@ async function deleteTrafficShaperRule(id: bigint) {
         </NButton>
       </div>
       <div class="divided-list">
-        <div v-for="rule in trafficShaperRules" :key="rule.id.toString()" class="layout-grid space-md pad-x-xl pad-y-lg mq-lg-one-auto">
+        <div v-for="rule in filteredTrafficShaperRules" :key="rule.id.toString()" class="layout-grid space-md pad-x-xl pad-y-lg mq-lg-one-auto">
           <div class="min-width-zero">
             <div class="layout-row min-width-zero wrap-items align-center space-sm">
               <p class="clip-text copy-sm weight-medium base-text">{{ rule.name }}</p>
               <NTag size="small" :bordered="false" type="info">{{ trafficShaperScopeLabel(rule.budgetScope) }}</NTag>
               <NTag v-if="!rule.enabled" size="small" :bordered="false" type="warning">Disabled</NTag>
               <NTag size="small" :bordered="false" type="info">P{{ rule.priority.toString() }}</NTag>
+              <NTag
+                v-for="warning in visiblePolicyWarningsForRule('traffic-shaper', rule.id)"
+                :key="warning.code"
+                size="small"
+                :bordered="false"
+                :type="naiveTagType(warningSeverity(warning))"
+              >
+                {{ warningLabel(warning) }}
+              </NTag>
             </div>
             <p class="margin-top-xs clip-text mono-text copy-xs muted-text">{{ trafficShaperRuleSummary(rule) }} / {{ trafficShaperBudgetSummary(rule) }}</p>
             <p class="margin-top-xs clip-text copy-xs muted-text">{{ publicPolicyMatchSummary(rule) }} / key {{ trafficShaperKeySummary(rule) }}</p>
@@ -511,6 +967,11 @@ async function deleteTrafficShaperRule(id: bigint) {
           </div>
         </div>
         <EmptyState
+          v-if="trafficShaperRules.length && !filteredTrafficShaperRules.length && isPolicyFilterActive"
+          title="No matching traffic-shaper rules"
+          description="Adjust the filter text or state selector."
+        />
+        <EmptyState
           v-if="!trafficShaperRules.length"
           title="No traffic-shaper rules configured"
           description="Traffic shapers limit bandwidth consumption per request or client to prevent saturation."
@@ -523,6 +984,27 @@ async function deleteTrafficShaperRule(id: bigint) {
     </NTabs>
 
     <PublicProxyEditorHost ref="editorHost" :config="config" />
+
+    <NModal
+      v-model:show="isPreviewOpen"
+      preset="card"
+      title="Request Tester"
+      :style="modalCardStyle('76rem')"
+      :bordered="false"
+      size="huge"
+    >
+      <div class="policy-preview-modal-body">
+        <TrafficPolicyRequestPlayground
+          :model-value="previewForm"
+          :stages="playgroundStages"
+          :route-options="previewRouteOptions"
+          :target-options="previewTargetOptions"
+          :global-attention="globalPolicyAttention"
+          @update:model-value="updateTrafficPolicyPreview"
+          @reset="resetTrafficPolicyPreview"
+        />
+      </div>
+    </NModal>
   </div>
 </template>
 
@@ -558,6 +1040,25 @@ async function deleteTrafficShaperRule(id: bigint) {
   padding-top: 0.25rem;
 }
 
+.policy-filter-bar {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+}
+
+.policy-filter-search,
+.policy-filter-status {
+  display: grid;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+.policy-preview-modal-body {
+  max-height: calc(100vh - 9rem);
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
 @media (min-width: 900px) {
   .policy-summary-grid {
     grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -566,6 +1067,11 @@ async function deleteTrafficShaperRule(id: bigint) {
   .policy-summary-card {
     min-height: 0;
     padding: 1rem;
+  }
+
+  .policy-filter-bar {
+    grid-template-columns: minmax(0, 1fr) 12rem;
+    align-items: end;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- add a traffic policy workbench with runtime ordering, rule filtering, warnings, and a request tester modal
- add conservative browser-side previews for policy matching, cache eligibility, automatic WAF activation, and CEL/regex uncertainty
- clarify legacy Cookie cache flag behavior and lazy-load heavier management UI chunks

## Review fixes included
- cache tester now respects runtime bypass gates for non-GET/HEAD, Authorization, Cookie, Range, upgrades, and encoded path uncertainty
- regex conditions return unknown instead of using browser RegExp semantics
- duplicate cookie parsing keeps the first value to match server behavior
- automatic WAF activation previews as unknown because it depends on live trigger state
- execution order strip is static on the policy page and no longer shows hidden synthetic-request states
- route/target tester selections are kept coherent

## Validation
- bun test src
- bun run typecheck
- bun run build
- git diff --check

Stacked on #106 / security/vault-transit-dek-cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a request preview tester for traffic policy evaluation.
  * Added an execution-order strip to show how policy stages run.
  * Added search and status filtering for policy rules.

* **Bug Fixes**
  * Clarified cache behavior for requests with cookies and legacy cookie settings.
  * Updated policy messaging to show that Authorization and Cookie requests bypass shared cache.

* **UI Improvements**
  * Improved rule summaries, labels, and warning tags for clearer policy review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->