### PR TITLE
Pool direct upstream transports

### DIFF
--- a/internal/server/agent_transport_pool.go
+++ b/internal/server/agent_transport_pool.go
@@ -78,7 +78,7 @@ func (p *agentTransportPool) publicRouteTargetTransport(app *App, agent *AgentCo
 		Kind:                        agentTransportKindRouteTarget,
 		AgentID:                     agent.AgentID,
 		RouteTargetID:               target.ID,
-		TargetOrigin:                target.URL,
+		TargetOrigin:                routeTargetTransportOrigin(target),
 		TLSSkipVerify:               target.TLSSkipVerify,
 		ResponseHeaderTimeoutMillis: int64(timeout / time.Millisecond),
 	}

--- a/internal/server/app_services.go
+++ b/internal/server/app_services.go
@@ -3,39 +3,41 @@ package server
 import "p2pstream/internal/config"
 
 type appServices struct {
-	agentHub        *agentHub
-	loadBalancers   *loadBalancerRegistry
-	targetHealth    *publicRouteTargetHealthMonitor
-	trafficTracer   *trafficTracer
-	rateLimiter     *publicRateLimiter
-	trafficShaper   *publicTrafficShaper
-	publicWAF       *publicWAF
-	publicCache     *publicProxyCache
-	publicACME      *publicACMEManager
-	publicConfig    *publicConfigService
-	proxyRuntime    *proxyRuntime
-	observability   *observabilityRecorder
-	auth            *authService
-	agentTransports *agentTransportPool
-	dashboardCache  *dashboardResponseCache
-	loginThrottle   *loginThrottle
-	agentAuthLocks  *agentAuthLockMap
+	agentHub         *agentHub
+	loadBalancers    *loadBalancerRegistry
+	targetHealth     *publicRouteTargetHealthMonitor
+	trafficTracer    *trafficTracer
+	rateLimiter      *publicRateLimiter
+	trafficShaper    *publicTrafficShaper
+	publicWAF        *publicWAF
+	publicCache      *publicProxyCache
+	publicACME       *publicACMEManager
+	publicConfig     *publicConfigService
+	proxyRuntime     *proxyRuntime
+	observability    *observabilityRecorder
+	auth             *authService
+	agentTransports  *agentTransportPool
+	directTransports *directTransportPool
+	dashboardCache   *dashboardResponseCache
+	loginThrottle    *loginThrottle
+	agentAuthLocks   *agentAuthLockMap
 }
 
 func newAppServices(cfg *config.Config, app *App) appServices {
 	services := appServices{
-		agentHub:        newAgentHub(),
-		loadBalancers:   newLoadBalancerRegistry(),
-		targetHealth:    newPublicRouteTargetHealthMonitor(),
-		trafficTracer:   newTrafficTracer(),
-		rateLimiter:     newPublicRateLimiter(),
-		trafficShaper:   newPublicTrafficShaper(),
-		publicWAF:       newPublicWAF(),
-		publicCache:     newPublicProxyCache(cfg.PublicCacheDir),
-		agentTransports: newAgentTransportPool(),
-		dashboardCache:  newDashboardResponseCache(),
-		loginThrottle:   newLoginThrottle(cfg.LoginThrottleMaxKeys),
-		agentAuthLocks:  newAgentAuthLockMap(),
+		agentHub:         newAgentHub(),
+		loadBalancers:    newLoadBalancerRegistry(),
+		targetHealth:     newPublicRouteTargetHealthMonitor(),
+		trafficTracer:    newTrafficTracer(),
+		rateLimiter:      newPublicRateLimiter(),
+		trafficShaper:    newPublicTrafficShaper(),
+		publicWAF:        newPublicWAF(),
+		publicCache:      newPublicProxyCache(cfg.PublicCacheDir),
+		agentTransports:  newAgentTransportPool(),
+		directTransports: newDirectTransportPool(),
+		dashboardCache:   newDashboardResponseCache(),
+		loginThrottle:    newLoginThrottle(cfg.LoginThrottleMaxKeys),
+		agentAuthLocks:   newAgentAuthLockMap(),
 	}
 	services.agentHub.onDisconnect = func(conn *AgentConn) {
 		if app != nil && app.AgentTransports != nil {
@@ -65,6 +67,7 @@ func (a *App) applyServices(services appServices) {
 	a.observabilityRecorder = services.observability
 	a.auth = services.auth
 	a.AgentTransports = services.agentTransports
+	a.DirectTransports = services.directTransports
 	a.DashboardCache = services.dashboardCache
 	a.LoginThrottle = services.loginThrottle
 	a.agentAuthLocks = services.agentAuthLocks

--- a/internal/server/direct_transport_pool.go
+++ b/internal/server/direct_transport_pool.go
@@ -1,0 +1,136 @@
+package server
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+type directTransportKey struct {
+	RouteTargetID               int64
+	TargetOrigin                string
+	TLSSkipVerify               bool
+	ResponseHeaderTimeoutMillis int64
+}
+
+type pooledDirectTransport struct {
+	key       directTransportKey
+	transport *http.Transport
+	createdAt time.Time
+}
+
+type directTransportPool struct {
+	mu      sync.Mutex
+	entries map[directTransportKey]*pooledDirectTransport
+}
+
+func newDirectTransportPool() *directTransportPool {
+	return &directTransportPool{entries: make(map[directTransportKey]*pooledDirectTransport)}
+}
+
+func (p *directTransportPool) publicRouteTargetTransport(target publicRouteTargetConfig) http.RoundTripper {
+	timeout := normalizeUpstreamResponseHeaderTimeout(target.UpstreamResponseHeaderTimeout)
+	key := directTransportKey{
+		RouteTargetID:               target.ID,
+		TargetOrigin:                routeTargetTransportOrigin(target),
+		TLSSkipVerify:               target.TLSSkipVerify,
+		ResponseHeaderTimeoutMillis: int64(timeout / time.Millisecond),
+	}
+	return p.getOrCreate(key, target.TLSSkipVerify, timeout)
+}
+
+func (p *directTransportPool) getOrCreate(key directTransportKey, tlsSkipVerify bool, timeout time.Duration) http.RoundTripper {
+	if p == nil {
+		return newDirectPooledHTTPTransport(tlsSkipVerify, timeout)
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if existing := p.entries[key]; existing != nil && existing.transport != nil {
+		return existing.transport
+	}
+	transport := newDirectPooledHTTPTransport(tlsSkipVerify, timeout)
+	p.entries[key] = &pooledDirectTransport{
+		key:       key,
+		transport: transport,
+		createdAt: time.Now(),
+	}
+	return transport
+}
+
+func newDirectPooledHTTPTransport(tlsSkipVerify bool, timeout time.Duration) *http.Transport {
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		base = &http.Transport{}
+	}
+	transport := base.Clone()
+	transport.DisableKeepAlives = false
+	transport.MaxIdleConns = 1024
+	transport.MaxIdleConnsPerHost = 32
+	transport.MaxConnsPerHost = 0
+	if transport.IdleConnTimeout < 90*time.Second {
+		transport.IdleConnTimeout = 90 * time.Second
+	}
+	transport.ResponseHeaderTimeout = timeout
+	if tlsSkipVerify {
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = &tls.Config{}
+		} else {
+			transport.TLSClientConfig = transport.TLSClientConfig.Clone()
+		}
+		transport.TLSClientConfig.InsecureSkipVerify = true
+	}
+	return transport
+}
+
+func (p *directTransportPool) closeRouteTarget(targetID int64) {
+	p.closeWhere(func(key directTransportKey) bool {
+		return key.RouteTargetID == targetID
+	})
+}
+
+func (p *directTransportPool) closeAll() {
+	p.closeWhere(func(directTransportKey) bool { return true })
+}
+
+func (p *directTransportPool) len() int {
+	if p == nil {
+		return 0
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.entries)
+}
+
+func (p *directTransportPool) closeWhere(match func(directTransportKey) bool) {
+	if p == nil {
+		return
+	}
+	var transports []*http.Transport
+	p.mu.Lock()
+	for key, entry := range p.entries {
+		if !match(key) {
+			continue
+		}
+		if entry.transport != nil {
+			transports = append(transports, entry.transport)
+		}
+		delete(p.entries, key)
+	}
+	p.mu.Unlock()
+	for _, transport := range transports {
+		transport.CloseIdleConnections()
+	}
+}
+
+func routeTargetTransportOrigin(target publicRouteTargetConfig) string {
+	if target.ParsedURL != nil && target.ParsedURL.Scheme != "" && target.ParsedURL.Host != "" {
+		return target.ParsedURL.Scheme + "://" + target.ParsedURL.Host
+	}
+	parsed, err := url.Parse(target.URL)
+	if err == nil && parsed.Scheme != "" && parsed.Host != "" {
+		return parsed.Scheme + "://" + parsed.Host
+	}
+	return target.URL
+}

--- a/internal/server/direct_transport_pool_test.go
+++ b/internal/server/direct_transport_pool_test.go
@@ -1,0 +1,208 @@
+package server
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDirectTransportPoolReusesPublicRouteTargetConnection(t *testing.T) {
+	var connections atomic.Int64
+	upstream := newCountingUpstream(t, &connections, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	app := NewApp(nil, nil)
+	target := directTransportPoolTestTarget(t, 70, upstream.URL, time.Second)
+	for i := 0; i < 3; i++ {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "http://public.test/reuse", nil)
+		proxyDirectTargetForTest(app, rec, req, target)
+		if rec.Code != http.StatusOK || rec.Body.String() != "ok" {
+			t.Fatalf("request %d response = status %d body %q, want 200 ok", i, rec.Code, rec.Body.String())
+		}
+	}
+
+	if got := connections.Load(); got != 1 {
+		t.Fatalf("upstream connections = %d, want 1", got)
+	}
+	if got := app.DirectTransports.len(); got != 1 {
+		t.Fatalf("direct transport pool len = %d, want 1", got)
+	}
+}
+
+func TestDirectTransportPoolSeparatesRouteTargetsTLSAndTimeouts(t *testing.T) {
+	app := NewApp(nil, nil)
+	target := directTransportPoolTestTarget(t, 70, "http://upstream.test:9000/base?x=1", time.Second)
+	first := app.directTargetTransport(target)
+	if first != app.directTargetTransport(target) {
+		t.Fatal("same direct route target did not reuse pooled transport")
+	}
+
+	secondTarget := target
+	secondTarget.ID = 71
+	if first == app.directTargetTransport(secondTarget) {
+		t.Fatal("different route target ids shared a direct transport")
+	}
+
+	skipVerifyTarget := target
+	skipVerifyTarget.TLSSkipVerify = true
+	skipVerifyTransport := app.directTargetTransport(skipVerifyTarget)
+	if first == skipVerifyTransport {
+		t.Fatal("different TLS skip-verify config shared a direct transport")
+	}
+	skipVerifyHTTPTransport, ok := skipVerifyTransport.(*http.Transport)
+	if !ok || skipVerifyHTTPTransport.TLSClientConfig == nil || !skipVerifyHTTPTransport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatalf("skip-verify transport TLS config = %#v, want InsecureSkipVerify", skipVerifyHTTPTransport.TLSClientConfig)
+	}
+
+	timeoutTarget := target
+	timeoutTarget.UpstreamResponseHeaderTimeout = 2 * time.Second
+	timeoutTransport := app.directTargetTransport(timeoutTarget)
+	if first == timeoutTransport {
+		t.Fatal("different response header timeout shared a direct transport")
+	}
+	timeoutHTTPTransport, ok := timeoutTransport.(*http.Transport)
+	if !ok || timeoutHTTPTransport.ResponseHeaderTimeout != 2*time.Second {
+		t.Fatalf("timeout transport ResponseHeaderTimeout = %s, want 2s", timeoutHTTPTransport.ResponseHeaderTimeout)
+	}
+}
+
+func TestDirectTransportPoolNormalizesDefaultTimeout(t *testing.T) {
+	app := NewApp(nil, nil)
+	zeroTimeoutTarget := directTransportPoolTestTarget(t, 70, "http://upstream.test:9000", 0)
+	defaultTimeoutTarget := zeroTimeoutTarget
+	defaultTimeoutTarget.UpstreamResponseHeaderTimeout = time.Duration(defaultTargetUpstreamResponseHeaderTimeoutMillis) * time.Millisecond
+
+	if app.directTargetTransport(zeroTimeoutTarget) != app.directTargetTransport(defaultTimeoutTarget) {
+		t.Fatal("zero and explicit default response header timeouts should share a direct transport")
+	}
+}
+
+func TestDirectTransportPoolCloseRouteTargetForcesNewConnection(t *testing.T) {
+	var connections atomic.Int64
+	upstream := newCountingUpstream(t, &connections, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	app := NewApp(nil, nil)
+	target := directTransportPoolTestTarget(t, 70, upstream.URL, time.Second)
+	for i := 0; i < 2; i++ {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "http://public.test/reconnect", nil)
+		proxyDirectTargetForTest(app, rec, req, target)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d status = %d, want 200", i, rec.Code)
+		}
+		if i == 0 {
+			if got := connections.Load(); got != 1 {
+				t.Fatalf("upstream connections after first request = %d, want 1", got)
+			}
+			app.DirectTransports.closeRouteTarget(target.ID)
+		}
+	}
+
+	if got := connections.Load(); got != 2 {
+		t.Fatalf("upstream connections after invalidation = %d, want 2", got)
+	}
+	if got := app.DirectTransports.len(); got != 1 {
+		t.Fatalf("direct transport pool len = %d, want 1", got)
+	}
+}
+
+func TestRouteTargetTransportReconcileEvictsChangedAndRemovedTargets(t *testing.T) {
+	app := NewApp(nil, nil)
+	agent := &AgentConn{AgentID: 7}
+	keptDirect := directTransportPoolTestTarget(t, 70, "http://direct.test:9000", time.Second)
+	changedDirect := directTransportPoolTestTarget(t, 71, "http://direct.test:9001", time.Second)
+	removedDirect := directTransportPoolTestTarget(t, 72, "http://direct.test:9002", time.Second)
+	keptAgent := directTransportPoolTestTarget(t, 80, "http://agent.test:9000", time.Second)
+	keptAgent.Transport = publicRouteTargetTransportAgent
+	changedAgent := directTransportPoolTestTarget(t, 81, "http://agent.test:9001", time.Second)
+	changedAgent.Transport = publicRouteTargetTransportAgent
+
+	keptDirectTransport := app.directTargetTransport(keptDirect)
+	changedDirectTransport := app.directTargetTransport(changedDirect)
+	_ = app.directTargetTransport(removedDirect)
+	keptAgentTransport := app.agentTargetTransport(agent, keptAgent)
+	changedAgentTransport := app.agentTargetTransport(agent, changedAgent)
+
+	previous := &publicProxySnapshot{RouteTargets: map[int64]publicRouteTargetConfig{
+		keptDirect.ID:    keptDirect,
+		changedDirect.ID: changedDirect,
+		removedDirect.ID: removedDirect,
+		keptAgent.ID:     keptAgent,
+		changedAgent.ID:  changedAgent,
+	}}
+	keptDirect.Name = "renamed"
+	changedDirect.TLSSkipVerify = true
+	keptAgent.Weight = 20
+	changedAgent.UpstreamResponseHeaderTimeout = 2 * time.Second
+	current := &publicProxySnapshot{RouteTargets: map[int64]publicRouteTargetConfig{
+		keptDirect.ID:    keptDirect,
+		changedDirect.ID: changedDirect,
+		keptAgent.ID:     keptAgent,
+		changedAgent.ID:  changedAgent,
+	}}
+
+	app.reconcileRouteTargetTransports(previous, current)
+
+	if got := app.DirectTransports.len(); got != 1 {
+		t.Fatalf("direct transport pool len after reconcile = %d, want 1", got)
+	}
+	if got := app.AgentTransports.len(); got != 1 {
+		t.Fatalf("agent transport pool len after reconcile = %d, want 1", got)
+	}
+	if got := app.directTargetTransport(keptDirect); got != keptDirectTransport {
+		t.Fatal("unchanged direct target did not keep its pooled transport")
+	}
+	if got := app.directTargetTransport(changedDirect); got == changedDirectTransport {
+		t.Fatal("changed direct target kept stale pooled transport")
+	}
+	if got := app.agentTargetTransport(agent, keptAgent); got != keptAgentTransport {
+		t.Fatal("unchanged agent target did not keep its pooled transport")
+	}
+	if got := app.agentTargetTransport(agent, changedAgent); got == changedAgentTransport {
+		t.Fatal("changed agent target kept stale pooled transport")
+	}
+}
+
+func newCountingUpstream(t *testing.T, connections *atomic.Int64, handler http.Handler) *httptest.Server {
+	t.Helper()
+	upstream := httptest.NewUnstartedServer(handler)
+	upstream.Config.ConnContext = func(ctx context.Context, conn net.Conn) context.Context {
+		connections.Add(1)
+		return ctx
+	}
+	upstream.Start()
+	return upstream
+}
+
+func proxyDirectTargetForTest(app *App, rec *httptest.ResponseRecorder, req *http.Request, target publicRouteTargetConfig) {
+	app.proxyDirectTargetRequest(rec, req, publicRouteResolution{Target: target}, nil, nil, nil, proxyRequestObservability{})
+}
+
+func directTransportPoolTestTarget(t *testing.T, id int64, origin string, responseHeaderTimeout time.Duration) publicRouteTargetConfig {
+	t.Helper()
+	parsed, err := url.Parse(origin)
+	if err != nil {
+		t.Fatalf("parse origin: %v", err)
+	}
+	return publicRouteTargetConfig{
+		ID:                            id,
+		Name:                          "direct-transport-test",
+		Enabled:                       true,
+		TargetType:                    publicRouteTargetTypeProxy,
+		Transport:                     publicRouteTargetTransportDirect,
+		URL:                           origin,
+		ParsedURL:                     parsed,
+		UpstreamResponseHeaderTimeout: responseHeaderTimeout,
+	}
+}

--- a/internal/server/proxy_lifecycle.go
+++ b/internal/server/proxy_lifecycle.go
@@ -136,6 +136,9 @@ func (a *App) stopProxy(ctx context.Context) (*p2pstreamv1.ProxyStatus, error) {
 	if a.TargetHealth != nil {
 		a.TargetHealth.reconcile(a, nil, false)
 	}
+	if a.DirectTransports != nil {
+		a.DirectTransports.closeAll()
+	}
 	if shutdownErr != nil {
 		return status, connect.NewError(connect.CodeInternal, shutdownErr)
 	}

--- a/internal/server/public_config_loader.go
+++ b/internal/server/public_config_loader.go
@@ -50,11 +50,13 @@ func (a *App) refreshPublicProxySnapshot(ctx context.Context) error {
 
 func (a *App) applyPublicProxySnapshot(snap *publicProxySnapshot) {
 	a.proxyMu.Lock()
+	previous := a.publicSnapshot
 	a.publicSnapshot = snap
 	a.ensureListenerStatesLocked(snap)
 	a.proxyStatusLocked()
 	active := a.proxyServiceActive
 	a.proxyMu.Unlock()
+	a.reconcileRouteTargetTransports(previous, snap)
 	a.LoadBalancers.reconcile(snap)
 	if a.TargetHealth != nil {
 		a.TargetHealth.reconcile(a, snap, active)
@@ -70,6 +72,41 @@ func (a *App) applyPublicProxySnapshot(snap *publicProxySnapshot) {
 	}
 	if a.PublicCache != nil {
 		a.PublicCache.reconcile(snap.CacheSettings)
+	}
+}
+
+type routeTargetTransportSignature struct {
+	Transport                   string
+	TargetOrigin                string
+	TLSSkipVerify               bool
+	ResponseHeaderTimeoutMillis int64
+}
+
+func (a *App) reconcileRouteTargetTransports(previous *publicProxySnapshot, current *publicProxySnapshot) {
+	if previous == nil {
+		return
+	}
+	for targetID, previousTarget := range previous.RouteTargets {
+		currentTarget, ok := current.RouteTargets[targetID]
+		if ok && routeTargetTransportSignatureFor(previousTarget) == routeTargetTransportSignatureFor(currentTarget) {
+			continue
+		}
+		if a.DirectTransports != nil {
+			a.DirectTransports.closeRouteTarget(targetID)
+		}
+		if a.AgentTransports != nil {
+			a.AgentTransports.closeRouteTarget(targetID)
+		}
+	}
+}
+
+func routeTargetTransportSignatureFor(target publicRouteTargetConfig) routeTargetTransportSignature {
+	timeout := normalizeUpstreamResponseHeaderTimeout(target.UpstreamResponseHeaderTimeout)
+	return routeTargetTransportSignature{
+		Transport:                   target.Transport,
+		TargetOrigin:                routeTargetTransportOrigin(target),
+		TLSSkipVerify:               target.TLSSkipVerify,
+		ResponseHeaderTimeoutMillis: int64(timeout / time.Millisecond),
 	}
 }
 

--- a/internal/server/public_routing.go
+++ b/internal/server/public_routing.go
@@ -501,10 +501,12 @@ func (a *App) proxyRouteTargetRequest(w http.ResponseWriter, r *http.Request, re
 		)
 	}
 
-	transport := directProxyTransport(resolution.Target.TLSSkipVerify, resolution.Target.UpstreamResponseHeaderTimeout)
+	var transport http.RoundTripper
 	if agent != nil {
 		transport = a.agentTargetTransport(agent, resolution.Target)
 		r = r.WithContext(withAgentDialRequestID(r.Context(), id.String()))
+	} else {
+		transport = a.directTargetTransport(resolution.Target)
 	}
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(proxyReq *httputil.ProxyRequest) {
@@ -627,6 +629,13 @@ func (a *App) agentTargetTransport(agent *AgentConn, target publicRouteTargetCon
 		return newAgentTransportPool().publicRouteTargetTransport(a, agent, target)
 	}
 	return a.AgentTransports.publicRouteTargetTransport(a, agent, target)
+}
+
+func (a *App) directTargetTransport(target publicRouteTargetConfig) http.RoundTripper {
+	if a.DirectTransports == nil {
+		return newDirectTransportPool().publicRouteTargetTransport(target)
+	}
+	return a.DirectTransports.publicRouteTargetTransport(target)
 }
 
 func (a *App) dialViaAgent(ctx context.Context, agent *AgentConn, network string, address string, requestID string) (net.Conn, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -58,6 +58,7 @@ type App struct {
 	observabilityRecorder *observabilityRecorder
 	auth                  *authService
 	AgentTransports       *agentTransportPool
+	DirectTransports      *directTransportPool
 	DashboardCache        *dashboardResponseCache
 	LoginThrottle         *loginThrottle
 	agentAuthLocks        *agentAuthLockMap


### PR DESCRIPTION
## Summary
- add a direct route-target transport pool so direct upstreams reuse TCP/TLS connections
- evict stale direct and agent route-target transports when target connection config changes or targets disappear
- keep direct health checks out of this hot-path pool

Closes #111

## Tests
- go test ./internal/server -run 'TestDirectTransportPool|TestRouteTargetTransportReconcile|TestAgentTransportPool|TestDirectProxyResponseHeaderTimeout'\n- go test ./tests/integration -run 'TestDirectPublicRouteTarget|TestPublicRouteTargetUpstreamResponseHeaderTimeoutAPI'\n- go test ./internal/server ./tests/integration\n- go test ./...\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pooled handling for direct route-target connections, improving reuse of outbound connections across requests.
  * Route-target connections now respect target origin, TLS verification settings, and response timeout when deciding reuse.

* **Bug Fixes**
  * Fixed transport reuse during snapshot updates so changed route-target settings now get refreshed correctly.
  * Cleaned up active direct connections during shutdown to avoid lingering idle connections.

* **Tests**
  * Added coverage for connection reuse, timeout handling, TLS differences, invalidation, and target reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->