### PR TITLE
Keep agent session open when stream open is cancelled

### DIFF
--- a/internal/server/public_routing.go
+++ b/internal/server/public_routing.go
@@ -649,7 +649,6 @@ func (a *App) dialViaAgent(ctx context.Context, agent *AgentConn, network string
 	go func() {
 		select {
 		case <-ctx.Done():
-			_ = session.Close()
 		case <-agent.Done:
 			_ = session.Close()
 		case <-openDone:
@@ -691,7 +690,6 @@ func (a *App) dialViaAgent(ctx context.Context, agent *AgentConn, network string
 		}
 		conn = result.conn
 	case <-ctx.Done():
-		_ = agent.Session.Close()
 		stopOpenWatch()
 		if agent != nil {
 			log.Debug().

--- a/internal/server/public_routing.go
+++ b/internal/server/public_routing.go
@@ -615,6 +615,11 @@ type agentDialError struct {
 	Err  string
 }
 
+type agentStreamOpenResult struct {
+	conn net.Conn
+	err  error
+}
+
 func (e agentDialError) Error() string {
 	if e.Err == "" {
 		return e.Kind
@@ -629,14 +634,37 @@ func (a *App) agentTargetTransport(agent *AgentConn, target publicRouteTargetCon
 	return a.AgentTransports.publicRouteTargetTransport(a, agent, target)
 }
 
+func startAgentStreamOpen(
+	ctx context.Context,
+	agentDone <-chan struct{},
+	open func() (net.Conn, error),
+) <-chan agentStreamOpenResult {
+	// Keep this channel unbuffered so ownership cannot be transferred after the
+	// caller has stopped receiving. A buffered result channel can accept a
+	// delayed successful Open even when ctx is already done, leaking that stream.
+	results := make(chan agentStreamOpenResult)
+	go func() {
+		conn, err := open()
+		result := agentStreamOpenResult{conn: conn, err: err}
+		select {
+		case results <- result:
+		case <-ctx.Done():
+			if conn != nil {
+				_ = conn.Close()
+			}
+		case <-agentDone:
+			if conn != nil {
+				_ = conn.Close()
+			}
+		}
+	}()
+	return results
+}
+
 func (a *App) dialViaAgent(ctx context.Context, agent *AgentConn, network string, address string, requestID string) (net.Conn, error) {
 	if agent == nil || agent.Session == nil || agent.Session.IsClosed() {
 		return nil, errAgentDisconnected
 	}
-	openCh := make(chan struct {
-		conn net.Conn
-		err  error
-	}, 1)
 	openDone := make(chan struct{})
 	stopOpenWatch := func() {
 		select {
@@ -654,24 +682,7 @@ func (a *App) dialViaAgent(ctx context.Context, agent *AgentConn, network string
 		case <-openDone:
 		}
 	}()
-	go func() {
-		conn, err := session.Open()
-		result := struct {
-			conn net.Conn
-			err  error
-		}{conn: conn, err: err}
-		select {
-		case openCh <- result:
-		case <-ctx.Done():
-			if conn != nil {
-				_ = conn.Close()
-			}
-		case <-agent.Done:
-			if conn != nil {
-				_ = conn.Close()
-			}
-		}
-	}()
+	openCh := startAgentStreamOpen(ctx, agent.Done, session.Open)
 
 	var conn net.Conn
 	select {

--- a/internal/server/public_routing.go
+++ b/internal/server/public_routing.go
@@ -641,15 +641,27 @@ func (a *App) agentTargetTransport(agent *AgentConn, target publicRouteTargetCon
 
 func startAgentStreamOpen(
 	ctx context.Context,
-	agentDone <-chan struct{},
+	agent *AgentConn,
 	open func() (net.Conn, error),
 ) <-chan agentStreamOpenResult {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	release, admitted := agent.acquireStreamOpenAdmission(ctx)
+	if !admitted {
+		return nil
+	}
 	// Keep this channel unbuffered so ownership cannot be transferred after the
 	// caller has stopped receiving. A buffered result channel can accept a
 	// delayed successful Open even when ctx is already done, leaking that stream.
 	results := make(chan agentStreamOpenResult)
 	go func() {
+		// Cancellation only abandons this caller. The permit remains held until
+		// Yamux Open itself returns so blocked opens cannot accumulate unbounded
+		// goroutines behind the session's finite AcceptBacklog.
+		defer release()
 		conn, err := open()
+		release()
 		result := agentStreamOpenResult{conn: conn, err: err}
 		select {
 		case results <- result:
@@ -657,7 +669,7 @@ func startAgentStreamOpen(
 			if conn != nil {
 				_ = conn.Close()
 			}
-		case <-agentDone:
+		case <-agent.Done:
 			if conn != nil {
 				_ = conn.Close()
 			}
@@ -677,29 +689,12 @@ func (a *App) dialViaAgent(ctx context.Context, agent *AgentConn, network string
 	if agent == nil || agent.Session == nil || agent.Session.IsClosed() {
 		return nil, errAgentDisconnected
 	}
-	openDone := make(chan struct{})
-	stopOpenWatch := func() {
-		select {
-		case <-openDone:
-		default:
-			close(openDone)
-		}
-	}
 	session := agent.Session
-	go func() {
-		select {
-		case <-ctx.Done():
-		case <-agent.Done:
-			_ = session.Close()
-		case <-openDone:
-		}
-	}()
-	openCh := startAgentStreamOpen(ctx, agent.Done, session.Open)
+	openCh := startAgentStreamOpen(ctx, agent, session.Open)
 
 	var conn net.Conn
 	select {
 	case result := <-openCh:
-		stopOpenWatch()
 		if result.err != nil {
 			if agent != nil {
 				log.Debug().
@@ -713,7 +708,6 @@ func (a *App) dialViaAgent(ctx context.Context, agent *AgentConn, network string
 		}
 		conn = result.conn
 	case <-ctx.Done():
-		stopOpenWatch()
 		if agent != nil {
 			log.Debug().
 				Err(ctx.Err()).
@@ -725,7 +719,6 @@ func (a *App) dialViaAgent(ctx context.Context, agent *AgentConn, network string
 		return nil, ctx.Err()
 	case <-agent.Done:
 		_ = agent.Session.Close()
-		stopOpenWatch()
 		log.Debug().
 			Str("request_id", requestID).
 			Str("agent", agent.PublicID).

--- a/internal/server/public_routing_timeout_test.go
+++ b/internal/server/public_routing_timeout_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -175,13 +176,14 @@ func TestAgentDialCancelWhileOpeningStreamDoesNotCloseSession(t *testing.T) {
 
 func TestAgentStreamOpenDelayedSuccessAfterCancelClosesStream(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
+	agent := &AgentConn{Done: make(chan struct{})}
 	openStarted := make(chan struct{})
 	releaseOpen := make(chan struct{})
 	stream, peer := net.Pipe()
 	defer stream.Close()
 	defer peer.Close()
 
-	results := startAgentStreamOpen(ctx, make(chan struct{}), func() (net.Conn, error) {
+	results := startAgentStreamOpen(ctx, agent, func() (net.Conn, error) {
 		close(openStarted)
 		<-releaseOpen
 		return stream, nil
@@ -205,6 +207,137 @@ func TestAgentStreamOpenDelayedSuccessAfterCancelClosesStream(t *testing.T) {
 		}
 		t.Fatal("delayed open transferred stream ownership after cancellation")
 	default:
+	}
+}
+
+func TestAgentStreamOpenAdmissionCanceledWaitersSpawnNoOpen(t *testing.T) {
+	agent := &AgentConn{
+		Done:                     make(chan struct{}),
+		streamOpenAdmissionLimit: 1,
+	}
+	releaseOpen := make(chan struct{})
+	openStarted := make(chan struct{})
+	var openCalls atomic.Int64
+	firstResults := startAgentStreamOpen(context.Background(), agent, func() (net.Conn, error) {
+		openCalls.Add(1)
+		close(openStarted)
+		<-releaseOpen
+		return nil, errors.New("first open finished")
+	})
+	<-openStarted
+
+	gate := agent.streamOpenAdmissionGate()
+	if cap(gate) != 1 || len(gate) != 1 {
+		t.Fatalf("open admission gate = len %d/cap %d, want 1/1", len(gate), cap(gate))
+	}
+	if max := tunnel.DefaultYamuxConfig(nil).AcceptBacklog; cap(gate) > max {
+		t.Fatalf("open admission capacity = %d, exceeds Yamux AcceptBacklog %d", cap(gate), max)
+	}
+
+	const canceledWaiters = 512
+	for i := 0; i < canceledWaiters; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		results := startAgentStreamOpen(ctx, agent, func() (net.Conn, error) {
+			openCalls.Add(1)
+			return nil, errors.New("canceled waiter unexpectedly opened")
+		})
+		if results != nil {
+			t.Fatalf("canceled waiter %d received a result channel", i)
+		}
+	}
+	if got := openCalls.Load(); got != 1 {
+		t.Fatalf("Open callbacks after canceled waiters = %d, want only the admitted callback", got)
+	}
+
+	close(releaseOpen)
+	select {
+	case result := <-firstResults:
+		if result.err == nil {
+			t.Fatal("first Open result unexpectedly succeeded")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for admitted Open to return")
+	}
+}
+
+func TestAgentStreamOpenAdmissionHeldUntilOpenReturnsAndReusable(t *testing.T) {
+	agent := &AgentConn{
+		Done:                     make(chan struct{}),
+		streamOpenAdmissionLimit: 1,
+	}
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	_ = startAgentStreamOpen(firstCtx, agent, func() (net.Conn, error) {
+		close(firstStarted)
+		<-releaseFirst
+		return nil, errors.New("first open finished")
+	})
+	<-firstStarted
+	cancelFirst()
+	if got := len(agent.streamOpenAdmissionGate()); got != 1 {
+		t.Fatalf("gate permits after caller cancellation = %d, want 1 held by blocked Open", got)
+	}
+
+	secondCalling := make(chan struct{})
+	secondStarted := make(chan struct{})
+	secondReturned := make(chan (<-chan agentStreamOpenResult), 1)
+	go func() {
+		close(secondCalling)
+		secondReturned <- startAgentStreamOpen(context.Background(), agent, func() (net.Conn, error) {
+			close(secondStarted)
+			return nil, errors.New("second open finished")
+		})
+	}()
+	<-secondCalling
+	select {
+	case <-secondStarted:
+		t.Fatal("caller cancellation released the permit before the underlying Open returned")
+	case <-secondReturned:
+		t.Fatal("waiting admission returned before the underlying Open released its permit")
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	close(releaseFirst)
+
+	var secondResults <-chan agentStreamOpenResult
+	select {
+	case secondResults = <-secondReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second admission")
+	}
+	select {
+	case <-secondStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second Open callback")
+	}
+
+	thirdStarted := make(chan struct{})
+	thirdResults := startAgentStreamOpen(context.Background(), agent, func() (net.Conn, error) {
+		close(thirdStarted)
+		return nil, errors.New("third open finished")
+	})
+	if thirdResults == nil {
+		t.Fatal("permit was not reusable after second Open returned")
+	}
+	select {
+	case <-thirdStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for third Open callback")
+	}
+	for name, results := range map[string]<-chan agentStreamOpenResult{
+		"second": secondResults,
+		"third":  thirdResults,
+	} {
+		select {
+		case result := <-results:
+			if result.err == nil {
+				t.Fatalf("%s Open result unexpectedly succeeded", name)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out receiving %s Open result", name)
+		}
 	}
 }
 

--- a/internal/server/public_routing_timeout_test.go
+++ b/internal/server/public_routing_timeout_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -124,6 +125,51 @@ func TestAgentProxyClientCancelBeforeFirstResponseDoesNotMarkPassiveFailure(t *t
 	traces, _ := app.TargetHealth.listHealthTraces(target.ID, agent.AgentID, 10, false)
 	if len(traces) != 0 {
 		t.Fatalf("unexpected health traces after client cancellation: %+v", traces)
+	}
+}
+
+func TestAgentDialCancelWhileOpeningStreamDoesNotCloseSession(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	session, err := yamux.Server(serverConn, tunnel.DefaultYamuxConfig(nil))
+	if err != nil {
+		t.Fatalf("yamux server: %v", err)
+	}
+	defer session.Close()
+
+	app := NewApp(nil, nil)
+	agent := &AgentConn{
+		AgentID:     7,
+		PublicID:    "agent-cancel-open",
+		Name:        "agent-cancel-open",
+		ConnectedAt: time.Now(),
+		Done:        make(chan struct{}),
+		Session:     session,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := app.dialViaAgent(ctx, agent, "tcp", "127.0.0.1:80", "cancel-open")
+		if conn != nil {
+			_ = conn.Close()
+		}
+		errCh <- err
+	}()
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("dial error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for cancelled dial")
+	}
+	select {
+	case <-session.CloseChan():
+		t.Fatal("request cancellation closed shared agent session")
+	default:
 	}
 }
 

--- a/internal/server/public_routing_timeout_test.go
+++ b/internal/server/public_routing_timeout_test.go
@@ -173,6 +173,41 @@ func TestAgentDialCancelWhileOpeningStreamDoesNotCloseSession(t *testing.T) {
 	}
 }
 
+func TestAgentStreamOpenDelayedSuccessAfterCancelClosesStream(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	openStarted := make(chan struct{})
+	releaseOpen := make(chan struct{})
+	stream, peer := net.Pipe()
+	defer stream.Close()
+	defer peer.Close()
+
+	results := startAgentStreamOpen(ctx, make(chan struct{}), func() (net.Conn, error) {
+		close(openStarted)
+		<-releaseOpen
+		return stream, nil
+	})
+
+	<-openStarted
+	cancel()
+	close(releaseOpen)
+
+	if err := peer.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set peer deadline: %v", err)
+	}
+	buf := make([]byte, 1)
+	if _, err := peer.Read(buf); !errors.Is(err, io.EOF) {
+		t.Fatalf("read after delayed open = %v, want EOF from closed abandoned stream", err)
+	}
+	select {
+	case result := <-results:
+		if result.conn != nil {
+			_ = result.conn.Close()
+		}
+		t.Fatal("delayed open transferred stream ownership after cancellation")
+	default:
+	}
+}
+
 func TestAgentProxyClientCancelDuringUploadClosesUpstream(t *testing.T) {
 	reached := make(chan struct{})
 	upstreamClosed := make(chan struct{})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -25,15 +25,18 @@ import (
 )
 
 type AgentConn struct {
-	AgentID        int64
-	PublicID       string
-	Name           string
-	Session        *yamux.Session
-	Done           chan struct{}
-	doneOnce       sync.Once
-	ActiveRequests atomic.Int64
-	ConnectedAt    time.Time
-	ConnectionDBID int64
+	AgentID                  int64
+	PublicID                 string
+	Name                     string
+	Session                  *yamux.Session
+	Done                     chan struct{}
+	doneOnce                 sync.Once
+	streamOpenMu             sync.Mutex
+	streamOpenGate           chan struct{}
+	streamOpenAdmissionLimit int
+	ActiveRequests           atomic.Int64
+	ConnectedAt              time.Time
+	ConnectionDBID           int64
 }
 
 func (c *AgentConn) signalDone() {
@@ -49,6 +52,64 @@ func (c *AgentConn) signalDone() {
 			close(c.Done)
 		}
 	})
+}
+
+func (c *AgentConn) streamOpenAdmissionGate() chan struct{} {
+	if c == nil {
+		return nil
+	}
+	c.streamOpenMu.Lock()
+	defer c.streamOpenMu.Unlock()
+	if c.streamOpenGate != nil {
+		return c.streamOpenGate
+	}
+	maxAdmissions := tunnel.DefaultYamuxConfig(nil).AcceptBacklog
+	if maxAdmissions < 1 {
+		maxAdmissions = 1
+	}
+	limit := c.streamOpenAdmissionLimit
+	if limit < 1 || limit > maxAdmissions {
+		limit = maxAdmissions
+	}
+	c.streamOpenGate = make(chan struct{}, limit)
+	return c.streamOpenGate
+}
+
+func (c *AgentConn) acquireStreamOpenAdmission(ctx context.Context) (func(), bool) {
+	if c == nil {
+		return nil, false
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	gate := c.streamOpenAdmissionGate()
+	select {
+	case gate <- struct{}{}:
+	case <-ctx.Done():
+		return nil, false
+	case <-c.Done:
+		return nil, false
+	}
+
+	// A ready gate and cancellation can race in the select above. Check again
+	// before the caller is allowed to create an Open goroutine.
+	select {
+	case <-ctx.Done():
+		<-gate
+		return nil, false
+	default:
+	}
+	select {
+	case <-c.Done:
+		<-gate
+		return nil, false
+	default:
+	}
+
+	var releaseOnce sync.Once
+	return func() {
+		releaseOnce.Do(func() { <-gate })
+	}, true
 }
 
 type App struct {


### PR DESCRIPTION
## Summary
- stop closing the shared yamux agent session when a request context is cancelled during stream open
- keep session closure behavior for actual agent disconnects
- add a regression test for cancellation while `session.Open()` is blocked

Closes #112

## Tests
- go test ./internal/server -run 'TestAgentDialCancelWhileOpeningStreamDoesNotCloseSession|TestAgentProxyClientCancel|TestAgentProxyAgentDisconnect|TestAgentTransportPool'\n- go test ./internal/server ./tests/integration\n- go test ./...\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when canceling agent tunnel connections while a stream is opening.
  * Prevented delayed stream openings from transferring or leaving connections active after cancellation.
  * Preserved shared agent sessions during canceled connection attempts.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->