### PR TITLE
Batch proxy observability writes

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -18,6 +18,11 @@ import (
 	"p2pstream/internal/server"
 )
 
+const (
+	serverShutdownTimeout             = 5 * time.Second
+	observabilityRecorderCloseTimeout = 5 * time.Second
+)
+
 var serverCmd = &cobra.Command{
 	Use:   "server",
 	Short: "Start the p2pstream proxy server",
@@ -109,8 +114,7 @@ var serverCmd = &cobra.Command{
 		<-ctx.Done()
 		log.Info().Msg("Shutting down servers gracefully...")
 
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
+		shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), serverShutdownTimeout)
 
 		var shutdownErrs []error
 		if _, err := app.StopProxyListener(shutdownCtx); err != nil {
@@ -119,9 +123,15 @@ var serverCmd = &cobra.Command{
 		if err := mgmtSrv.Shutdown(shutdownCtx); err != nil {
 			shutdownErrs = append(shutdownErrs, err)
 		}
-		if err := app.CloseObservabilityRecorder(shutdownCtx); err != nil {
+		cancelShutdown()
+
+		// Listener shutdown can consume its entire shared deadline. Give the
+		// recorder an independent bounded chance to persist already-queued data.
+		recorderCloseCtx, cancelRecorderClose := context.WithTimeout(context.Background(), observabilityRecorderCloseTimeout)
+		if err := app.CloseObservabilityRecorder(recorderCloseCtx); err != nil {
 			shutdownErrs = append(shutdownErrs, err)
 		}
+		cancelRecorderClose()
 
 		if len(shutdownErrs) > 0 {
 			log.Error().Errs("errors", shutdownErrs).Msg("Errors during shutdown")

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -119,6 +119,9 @@ var serverCmd = &cobra.Command{
 		if err := mgmtSrv.Shutdown(shutdownCtx); err != nil {
 			shutdownErrs = append(shutdownErrs, err)
 		}
+		if err := app.CloseObservabilityRecorder(shutdownCtx); err != nil {
+			shutdownErrs = append(shutdownErrs, err)
+		}
 
 		if len(shutdownErrs) > 0 {
 			log.Error().Errs("errors", shutdownErrs).Msg("Errors during shutdown")

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -53,6 +53,7 @@ type Querier interface {
 	DeleteProxyRequestStatusRollupsBefore(ctx context.Context, bucketUnixMillis int64) error
 	DeleteProxyRequestTupleRollupsBefore(ctx context.Context, bucketUnixMillis int64) error
 	DeletePublicCacheEntry(ctx context.Context, keyDigest string) error
+	DeletePublicCacheEntryGeneration(ctx context.Context, arg DeletePublicCacheEntryGenerationParams) (int64, error)
 	DeletePublicCacheRule(ctx context.Context, id int64) error
 	DeletePublicListener(ctx context.Context, id int64) error
 	DeletePublicRateLimitRule(ctx context.Context, id int64) error

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -168,7 +168,7 @@ type Querier interface {
 	SetPublicListenerEnabled(ctx context.Context, arg SetPublicListenerEnabledParams) (PublicListener, error)
 	SumPublicCacheBytes(ctx context.Context) (SumPublicCacheBytesRow, error)
 	TouchManagementAccessToken(ctx context.Context, id int64) error
-	TouchPublicCacheEntry(ctx context.Context, keyDigest string) error
+	TouchPublicCacheEntry(ctx context.Context, arg TouchPublicCacheEntryParams) error
 	TouchSession(ctx context.Context, id int64) error
 	TrustEnvironmentCertificate(ctx context.Context, arg TrustEnvironmentCertificateParams) (Environment, error)
 	UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent, error)

--- a/internal/db/query.sql.go
+++ b/internal/db/query.sql.go
@@ -1616,6 +1616,32 @@ func (q *Queries) DeletePublicCacheEntry(ctx context.Context, keyDigest string) 
 	return err
 }
 
+const deletePublicCacheEntryGeneration = `-- name: DeletePublicCacheEntryGeneration :execrows
+DELETE FROM public_cache_entries
+WHERE key_digest = ?1
+  AND (
+      stored_at = ?2
+      OR (
+          length(stored_at) = 19
+          AND stored_at = CAST(?3 AS TEXT)
+      )
+  )
+`
+
+type DeletePublicCacheEntryGenerationParams struct {
+	KeyDigest      string    `json:"key_digest"`
+	StoredAt       time.Time `json:"stored_at"`
+	StoredAtLegacy string    `json:"stored_at_legacy"`
+}
+
+func (q *Queries) DeletePublicCacheEntryGeneration(ctx context.Context, arg DeletePublicCacheEntryGenerationParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deletePublicCacheEntryGeneration, arg.KeyDigest, arg.StoredAt, arg.StoredAtLegacy)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const deletePublicCacheRule = `-- name: DeletePublicCacheRule :exec
 DELETE FROM public_cache_rules
 WHERE id = ?

--- a/internal/db/query.sql.go
+++ b/internal/db/query.sql.go
@@ -6199,18 +6199,26 @@ func (q *Queries) TouchManagementAccessToken(ctx context.Context, id int64) erro
 
 const touchPublicCacheEntry = `-- name: TouchPublicCacheEntry :exec
 UPDATE public_cache_entries
-SET last_accessed_at = CURRENT_TIMESTAMP,
-    hit_count = hit_count + ?1
-WHERE key_digest = ?2
+SET last_accessed_at = ?1,
+    hit_count = hit_count + ?2
+WHERE key_digest = ?3
+  AND stored_at = ?4
 `
 
 type TouchPublicCacheEntryParams struct {
-	HitCount  int64  `json:"hit_count"`
-	KeyDigest string `json:"key_digest"`
+	LastAccessedAt time.Time `json:"last_accessed_at"`
+	HitCount       int64     `json:"hit_count"`
+	KeyDigest      string    `json:"key_digest"`
+	StoredAt       time.Time `json:"stored_at"`
 }
 
 func (q *Queries) TouchPublicCacheEntry(ctx context.Context, arg TouchPublicCacheEntryParams) error {
-	_, err := q.db.ExecContext(ctx, touchPublicCacheEntry, arg.HitCount, arg.KeyDigest)
+	_, err := q.db.ExecContext(ctx, touchPublicCacheEntry,
+		arg.LastAccessedAt,
+		arg.HitCount,
+		arg.KeyDigest,
+		arg.StoredAt,
+	)
 	return err
 }
 
@@ -7955,7 +7963,7 @@ INSERT INTO public_cache_entries (
     vary_headers_json, response_headers_json, status_code, body_path, size_bytes, stored_at, expires_at,
     last_accessed_at, hit_count
 ) VALUES (
-    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, CURRENT_TIMESTAMP, 0
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?16, ?17, ?16, 0
 )
 ON CONFLICT(key_digest) DO UPDATE SET
     rule_id = excluded.rule_id,
@@ -7972,9 +7980,9 @@ ON CONFLICT(key_digest) DO UPDATE SET
     status_code = excluded.status_code,
     body_path = excluded.body_path,
     size_bytes = excluded.size_bytes,
-    stored_at = CURRENT_TIMESTAMP,
+    stored_at = excluded.stored_at,
     expires_at = excluded.expires_at,
-    last_accessed_at = CURRENT_TIMESTAMP,
+    last_accessed_at = excluded.stored_at,
     hit_count = 0
 RETURNING key_digest, rule_id, scope, listener_protocol, host, path, query_key, route_id, route_target_id, method,
           vary_headers_json, response_headers_json, status_code, body_path, size_bytes, stored_at, expires_at,
@@ -7997,6 +8005,7 @@ type UpsertPublicCacheEntryParams struct {
 	StatusCode          int64         `json:"status_code"`
 	BodyPath            string        `json:"body_path"`
 	SizeBytes           int64         `json:"size_bytes"`
+	StoredAt            time.Time     `json:"stored_at"`
 	ExpiresAt           time.Time     `json:"expires_at"`
 }
 
@@ -8017,6 +8026,7 @@ func (q *Queries) UpsertPublicCacheEntry(ctx context.Context, arg UpsertPublicCa
 		arg.StatusCode,
 		arg.BodyPath,
 		arg.SizeBytes,
+		arg.StoredAt,
 		arg.ExpiresAt,
 	)
 	var i PublicCacheEntry

--- a/internal/db/query.sql.go
+++ b/internal/db/query.sql.go
@@ -6200,12 +6200,17 @@ func (q *Queries) TouchManagementAccessToken(ctx context.Context, id int64) erro
 const touchPublicCacheEntry = `-- name: TouchPublicCacheEntry :exec
 UPDATE public_cache_entries
 SET last_accessed_at = CURRENT_TIMESTAMP,
-    hit_count = hit_count + 1
-WHERE key_digest = ?
+    hit_count = hit_count + ?1
+WHERE key_digest = ?2
 `
 
-func (q *Queries) TouchPublicCacheEntry(ctx context.Context, keyDigest string) error {
-	_, err := q.db.ExecContext(ctx, touchPublicCacheEntry, keyDigest)
+type TouchPublicCacheEntryParams struct {
+	HitCount  int64  `json:"hit_count"`
+	KeyDigest string `json:"key_digest"`
+}
+
+func (q *Queries) TouchPublicCacheEntry(ctx context.Context, arg TouchPublicCacheEntryParams) error {
+	_, err := q.db.ExecContext(ctx, touchPublicCacheEntry, arg.HitCount, arg.KeyDigest)
 	return err
 }
 

--- a/internal/db/query.sql.go
+++ b/internal/db/query.sql.go
@@ -6199,10 +6199,19 @@ func (q *Queries) TouchManagementAccessToken(ctx context.Context, id int64) erro
 
 const touchPublicCacheEntry = `-- name: TouchPublicCacheEntry :exec
 UPDATE public_cache_entries
-SET last_accessed_at = ?1,
+SET last_accessed_at = CASE
+        WHEN ?1 > last_accessed_at THEN ?1
+        ELSE last_accessed_at
+    END,
     hit_count = hit_count + ?2
 WHERE key_digest = ?3
-  AND stored_at = ?4
+  AND (
+      stored_at = ?4
+      OR (
+          length(stored_at) = 19
+          AND stored_at = CAST(?5 AS TEXT)
+      )
+  )
 `
 
 type TouchPublicCacheEntryParams struct {
@@ -6210,6 +6219,7 @@ type TouchPublicCacheEntryParams struct {
 	HitCount       int64     `json:"hit_count"`
 	KeyDigest      string    `json:"key_digest"`
 	StoredAt       time.Time `json:"stored_at"`
+	StoredAtLegacy string    `json:"stored_at_legacy"`
 }
 
 func (q *Queries) TouchPublicCacheEntry(ctx context.Context, arg TouchPublicCacheEntryParams) error {
@@ -6218,6 +6228,7 @@ func (q *Queries) TouchPublicCacheEntry(ctx context.Context, arg TouchPublicCach
 		arg.HitCount,
 		arg.KeyDigest,
 		arg.StoredAt,
+		arg.StoredAtLegacy,
 	)
 	return err
 }

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -355,8 +355,109 @@ func TestObservabilityRecorderCoalescesPublicCacheTouches(t *testing.T) {
 	if err := app.DB.QueryRowContext(ctx, `SELECT hit_count FROM public_cache_entries WHERE key_digest = ?`, keyDigest).Scan(&hitCount); err != nil {
 		t.Fatalf("read cache hit count: %v", err)
 	}
-	if hitCount != 1 {
-		t.Fatalf("cache hit count = %d, want 1 coalesced touch", hitCount)
+	if hitCount != 3 {
+		t.Fatalf("cache hit count = %d, want all 3 coalesced hits", hitCount)
+	}
+}
+
+func TestObservabilityRecorderBoundsPendingEventsWhenDatabaseFails(t *testing.T) {
+	database := newServerTestDB(t)
+	app := NewApp(nil, database)
+	recorder := app.observabilityRecorderService()
+	if err := database.Close(); err != nil {
+		t.Fatalf("close database: %v", err)
+	}
+
+	for i := 0; i < observabilityRecorderMaxBatch; i++ {
+		recorder.recordProxyRequestEvent(context.Background(), proxyRequestEvent{StatusCode: http.StatusOK})
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for recorder.pendingEvents.Load() < observabilityRecorderMaxBatch && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	for i := 0; i < observabilityRecorderQueueSize+2048; i++ {
+		recorder.recordProxyRequestEvent(context.Background(), proxyRequestEvent{StatusCode: http.StatusOK})
+	}
+
+	pending := recorder.pendingEvents.Load()
+	queued := len(recorder.events)
+	if pending != observabilityRecorderMaxBatch {
+		t.Fatalf("pending event batch = %d, want hard cap %d", pending, observabilityRecorderMaxBatch)
+	}
+	if queued != observabilityRecorderQueueSize {
+		t.Fatalf("queued events = %d, want bounded queue filled to %d", queued, observabilityRecorderQueueSize)
+	}
+	if got := pending + int64(queued); got != observabilityRecorderMaxBatch+observabilityRecorderQueueSize {
+		t.Fatalf("retained events = %d, want %d", got, observabilityRecorderMaxBatch+observabilityRecorderQueueSize)
+	}
+	if recorder.droppedEvents.Load() == 0 {
+		t.Fatal("expected excess events to be dropped")
+	}
+
+	time.Sleep(2 * observabilityRecorderFlushInterval)
+	if got := recorder.pendingEvents.Load(); got != pending {
+		t.Fatalf("pending batch grew across failed retries: got %d, want %d", got, pending)
+	}
+	if got := len(recorder.events); got != queued {
+		t.Fatalf("bounded queue changed across failed retries: got %d, want %d", got, queued)
+	}
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := recorder.close(closeCtx); err == nil {
+		t.Fatal("close with failed database unexpectedly succeeded")
+	}
+}
+
+func TestObservabilityRecorderRateLimitsDropLogs(t *testing.T) {
+	recorder := newObservabilityRecorder(nil)
+	recorder.dropEvent()
+	nextLog := recorder.nextDropLog.Load()
+	if nextLog <= time.Now().UnixNano() {
+		t.Fatalf("next drop log deadline = %d, want a future deadline", nextLog)
+	}
+	for i := 0; i < 100; i++ {
+		recorder.dropEvent()
+		recorder.dropTouch()
+	}
+	if got := recorder.nextDropLog.Load(); got != nextLog {
+		t.Fatalf("drop log deadline changed under amplification: got %d, want %d", got, nextLog)
+	}
+	if got := recorder.droppedEvents.Load(); got != 101 {
+		t.Fatalf("dropped events = %d, want 101", got)
+	}
+	if got := recorder.droppedTouches.Load(); got != 100 {
+		t.Fatalf("dropped touches = %d, want 100", got)
+	}
+}
+
+func TestObservabilityRecorderBoundsAndPrunesCacheTouchState(t *testing.T) {
+	recorder := newObservabilityRecorder(nil)
+	recorder.nextDropLog.Store(time.Now().Add(time.Hour).UnixNano())
+	touches := make(map[string]*publicCacheTouchState)
+	for i := 0; i < observabilityRecorderMaxTouchKeys; i++ {
+		recorder.queuePublicCacheTouch(touches, fmt.Sprintf("key-%d", i))
+	}
+	recorder.queuePublicCacheTouch(touches, "key-0")
+	if got := touches["key-0"].hitCount; got != 2 {
+		t.Fatalf("existing cache key hit count = %d, want 2", got)
+	}
+	recorder.queuePublicCacheTouch(touches, "overflow")
+	if got := len(touches); got != observabilityRecorderMaxTouchKeys {
+		t.Fatalf("cache touch state cardinality = %d, want cap %d", got, observabilityRecorderMaxTouchKeys)
+	}
+	if got := recorder.droppedTouches.Load(); got != 1 {
+		t.Fatalf("dropped cache touches = %d, want 1", got)
+	}
+
+	now := time.Now().UTC()
+	for _, touch := range touches {
+		touch.hitCount = 0
+		touch.lastFlushedAt = now.Add(-publicCacheTouchCoalesceInterval)
+	}
+	recorder.prunePublicCacheTouches(touches, now)
+	if len(touches) != 0 || recorder.pendingTouches.Load() != 0 {
+		t.Fatalf("expired cache touch state was not pruned: len=%d pending=%d", len(touches), recorder.pendingTouches.Load())
 	}
 }
 

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -654,23 +654,83 @@ func TestCloseObservabilityRecorderFlushesQueuedEvents(t *testing.T) {
 	}
 }
 
-func TestObservabilityRecorderCanceledFlushCanRetryWithFreshCloseContext(t *testing.T) {
+func TestCloseObservabilityRecorderCancelsActiveFlushAndDrains(t *testing.T) {
 	app := NewApp(nil, newServerTestDB(t))
 	recorder := newObservabilityRecorder(app)
-	// Suppress the worker until after the first flush so its unbuffered control
+	flushStarted := make(chan struct{})
+	flushCanceled := make(chan struct{})
+	flushCalls := 0
+	recorder.insertBatch = func(ctx context.Context, events []db.InsertProxyRequestEventAtParams, touches []db.TouchPublicCacheEntryParams) error {
+		flushCalls++
+		if flushCalls == 1 {
+			close(flushStarted)
+			<-ctx.Done()
+			close(flushCanceled)
+			return ctx.Err()
+		}
+		return app.insertProxyRequestEventsWithRollupsAndCacheTouches(ctx, events, touches)
+	}
+
+	for i := 0; i < observabilityRecorderMaxBatch; i++ {
+		recorder.recordProxyRequestEvent(context.Background(), proxyRequestEvent{StatusCode: http.StatusOK})
+	}
+	select {
+	case <-flushStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for background observability flush to start")
+	}
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := recorder.close(closeCtx); err != nil {
+		t.Fatalf("close recorder after canceling active flush: %v", err)
+	}
+	select {
+	case <-flushCanceled:
+	default:
+		t.Fatal("active background flush did not observe close cancellation")
+	}
+	if flushCalls != 2 {
+		t.Fatalf("flush calls = %d, want canceled background flush plus stop drain", flushCalls)
+	}
+	if recorder.pendingEvents.Load() != 0 || len(recorder.events) != 0 {
+		t.Fatalf("events remained after close drain: pending=%d queued=%d", recorder.pendingEvents.Load(), len(recorder.events))
+	}
+
+	var rawEvents int64
+	if err := app.DB.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM proxy_request_events`).Scan(&rawEvents); err != nil {
+		t.Fatalf("count drained proxy events: %v", err)
+	}
+	if rawEvents != observabilityRecorderMaxBatch {
+		t.Fatalf("drained proxy events = %d, want %d", rawEvents, observabilityRecorderMaxBatch)
+	}
+}
+
+func TestObservabilityRecorderCanceledCloseCanRetryWithFreshContext(t *testing.T) {
+	app := NewApp(nil, newServerTestDB(t))
+	recorder := newObservabilityRecorder(app)
+	// Suppress the worker until after the first close so its unbuffered control
 	// send deterministically observes the canceled context.
 	recorder.startOnce.Do(func() {})
 	recorder.recordProxyRequestEvent(context.Background(), proxyRequestEvent{StatusCode: http.StatusOK})
 
 	canceledCtx, cancel := context.WithCancel(context.Background())
 	cancel()
-	if err := recorder.flush(canceledCtx); !errors.Is(err, context.Canceled) {
-		t.Fatalf("flush error = %v, want context.Canceled", err)
+	if err := recorder.close(canceledCtx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("close error = %v, want context.Canceled", err)
+	}
+	if recorder.stopped || recorder.closing.Load() {
+		t.Fatalf("recorder remained stopped after failed pre-send close: stopped=%t closing=%t", recorder.stopped, recorder.closing.Load())
 	}
 
 	recorder.mu.Lock()
 	recorder.startOnce = sync.Once{}
 	recorder.mu.Unlock()
+	flushCtx, flushCancel := context.WithTimeout(context.Background(), time.Second)
+	defer flushCancel()
+	if err := recorder.flush(flushCtx); err != nil {
+		t.Fatalf("flush recorder with fresh context: %v", err)
+	}
 	closeCtx, closeCancel := context.WithTimeout(context.Background(), time.Second)
 	defer closeCancel()
 	if err := recorder.close(closeCtx); err != nil {
@@ -682,7 +742,7 @@ func TestObservabilityRecorderCanceledFlushCanRetryWithFreshCloseContext(t *test
 		t.Fatalf("count raw proxy events: %v", err)
 	}
 	if rawEvents != 1 {
-		t.Fatalf("raw proxy events after canceled flush and fresh close = %d, want 1", rawEvents)
+		t.Fatalf("raw proxy events after canceled close and fresh flush = %d, want 1", rawEvents)
 	}
 }
 

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -224,6 +224,9 @@ func TestProxyRequestEventRollupsAreWrittenWithRawEvent(t *testing.T) {
 		40,
 		400,
 	)
+	if err := app.flushObservabilityRecorder(ctx); err != nil {
+		t.Fatalf("flush observability recorder: %v", err)
+	}
 
 	var rawEvents int64
 	if err := app.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM proxy_request_events`).Scan(&rawEvents); err != nil {
@@ -265,6 +268,127 @@ func TestProxyRequestEventRollupsAreWrittenWithRawEvent(t *testing.T) {
 	}
 	if statusCode != http.StatusGatewayTimeout || requests != 1 || serverError != 1 || internalError != 1 {
 		t.Fatalf("unexpected status rollup: status=%d requests=%d server=%d internal=%d", statusCode, requests, serverError, internalError)
+	}
+}
+
+func TestObservabilityRecorderFlushesQueuedEventsAsAggregatedRollups(t *testing.T) {
+	ctx := context.Background()
+	app := NewApp(nil, newServerTestDB(t))
+	seedDashboardRollupDimensionFixtures(t, app.DB)
+
+	for _, statusCode := range []int{http.StatusOK, http.StatusCreated, http.StatusBadGateway} {
+		app.recordProxyRequestEventWithIDsAndContext(
+			ctx,
+			statusCode,
+			time.Duration(statusCode)*time.Millisecond,
+			"",
+			sqlNullInt64(1),
+			sqlNullInt64(1),
+			sqlNullInt64(1),
+			1,
+			2,
+			proxyRequestContext{Method: "GET", Host: "example.test", PathPrefix: "/api"},
+		)
+	}
+	if err := app.flushObservabilityRecorder(ctx); err != nil {
+		t.Fatalf("flush observability recorder: %v", err)
+	}
+
+	var rawEvents int64
+	if err := app.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM proxy_request_events`).Scan(&rawEvents); err != nil {
+		t.Fatalf("count raw proxy events: %v", err)
+	}
+	if rawEvents != 3 {
+		t.Fatalf("raw proxy events = %d, want 3", rawEvents)
+	}
+
+	var requests, success, serverError, durationMsSum, requestBytes, responseBytes int64
+	if err := app.DB.QueryRowContext(ctx, `
+		SELECT COALESCE(SUM(requests), 0), COALESCE(SUM(success), 0), COALESCE(SUM(server_error), 0),
+		       COALESCE(SUM(duration_ms_sum), 0), COALESCE(SUM(request_bytes), 0), COALESCE(SUM(response_bytes), 0)
+		FROM proxy_request_rollup_minutes
+	`).Scan(&requests, &success, &serverError, &durationMsSum, &requestBytes, &responseBytes); err != nil {
+		t.Fatalf("read proxy rollup totals: %v", err)
+	}
+	if requests != 3 || success != 2 || serverError != 1 || durationMsSum != 903 || requestBytes != 3 || responseBytes != 6 {
+		t.Fatalf("unexpected rollup totals: requests=%d success=%d server=%d duration=%d request_bytes=%d response_bytes=%d", requests, success, serverError, durationMsSum, requestBytes, responseBytes)
+	}
+
+	var tupleRows, tupleRequests int64
+	if err := app.DB.QueryRowContext(ctx, `
+		SELECT COUNT(*), COALESCE(SUM(requests), 0)
+		FROM proxy_request_tuple_rollup_minutes
+		WHERE listener_id = 1 AND route_id = 1 AND agent_id = 1 AND error_kind = '' AND status_class = 2
+	`).Scan(&tupleRows, &tupleRequests); err != nil {
+		t.Fatalf("read tuple rollups: %v", err)
+	}
+	if tupleRows != 1 || tupleRequests != 2 {
+		t.Fatalf("tuple rollup rows/requests = %d/%d, want 1/2", tupleRows, tupleRequests)
+	}
+}
+
+func TestObservabilityRecorderCoalescesPublicCacheTouches(t *testing.T) {
+	ctx := context.Background()
+	app := NewApp(nil, newServerTestDB(t))
+	keyDigest := "cache-touch-key"
+	if _, err := app.DB.ExecContext(ctx, `INSERT INTO public_cache_rules (id, name) VALUES (1, 'cache-touch-rule')`); err != nil {
+		t.Fatalf("insert cache rule: %v", err)
+	}
+	if _, err := app.DB.ExecContext(ctx, `
+		INSERT INTO public_cache_entries (
+			key_digest, rule_id, scope, listener_protocol, host, path, query_key, method,
+			vary_headers_json, response_headers_json, status_code, body_path, size_bytes, expires_at
+		) VALUES (?, 1, 'selected_backend', 'http', 'example.test', '/asset', '', 'GET', '[]', '{}', 200, '/tmp/body', 10, ?)
+	`, keyDigest, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("insert cache entry: %v", err)
+	}
+
+	recorder := app.observabilityRecorderService()
+	recorder.touchPublicCacheEntry(keyDigest)
+	recorder.touchPublicCacheEntry(keyDigest)
+	recorder.touchPublicCacheEntry(keyDigest)
+	if err := app.flushObservabilityRecorder(ctx); err != nil {
+		t.Fatalf("flush observability recorder: %v", err)
+	}
+
+	var hitCount int64
+	if err := app.DB.QueryRowContext(ctx, `SELECT hit_count FROM public_cache_entries WHERE key_digest = ?`, keyDigest).Scan(&hitCount); err != nil {
+		t.Fatalf("read cache hit count: %v", err)
+	}
+	if hitCount != 1 {
+		t.Fatalf("cache hit count = %d, want 1 coalesced touch", hitCount)
+	}
+}
+
+func TestCloseObservabilityRecorderFlushesQueuedEvents(t *testing.T) {
+	ctx := context.Background()
+	app := NewApp(nil, newServerTestDB(t))
+
+	app.recordProxyRequestEventWithIDsAndContext(
+		ctx,
+		http.StatusOK,
+		25*time.Millisecond,
+		"",
+		sql.NullInt64{},
+		sql.NullInt64{},
+		sql.NullInt64{},
+		3,
+		7,
+		proxyRequestContext{Method: "GET", Host: "example.test", PathPrefix: "/close"},
+	)
+	if err := app.CloseObservabilityRecorder(ctx); err != nil {
+		t.Fatalf("close observability recorder: %v", err)
+	}
+	if err := app.CloseObservabilityRecorder(ctx); err != nil {
+		t.Fatalf("close observability recorder twice: %v", err)
+	}
+
+	var rawEvents int64
+	if err := app.DB.QueryRowContext(ctx, `SELECT COUNT(*) FROM proxy_request_events`).Scan(&rawEvents); err != nil {
+		t.Fatalf("count raw proxy events: %v", err)
+	}
+	if rawEvents != 1 {
+		t.Fatalf("raw proxy events = %d, want 1", rawEvents)
 	}
 }
 

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -368,6 +368,116 @@ func TestObservabilityRecorderCoalescesPublicCacheTouches(t *testing.T) {
 	}
 }
 
+func TestObservabilityRecorderPreservesLatestCacheAccessAcrossPrunedState(t *testing.T) {
+	ctx := context.Background()
+	app := NewApp(nil, newServerTestDB(t))
+	keyDigest := "out-of-order-cache-touch"
+	storedAt := time.Unix(1_700_000_000, 123_456_789).UTC()
+	olderAccess := storedAt.Add(time.Second)
+	newerAccess := storedAt.Add(2 * time.Second)
+	if _, err := app.DB.ExecContext(ctx, `INSERT INTO public_cache_rules (id, name) VALUES (1, 'out-of-order-cache-rule')`); err != nil {
+		t.Fatalf("insert cache rule: %v", err)
+	}
+	if _, err := app.DB.ExecContext(ctx, `
+		INSERT INTO public_cache_entries (
+			key_digest, rule_id, scope, listener_protocol, host, path, query_key, method,
+			vary_headers_json, response_headers_json, status_code, body_path, size_bytes,
+			stored_at, expires_at, last_accessed_at
+		) VALUES (?, 1, 'selected_backend', 'http', 'example.test', '/asset', '', 'GET',
+			'[]', '{}', 200, '/tmp/body', 10, ?, ?, ?)
+	`, keyDigest, storedAt, storedAt.Add(time.Hour), storedAt); err != nil {
+		t.Fatalf("insert cache entry: %v", err)
+	}
+
+	recorder := newObservabilityRecorder(app)
+	touches := make(map[publicCacheTouchKey]*publicCacheTouchState)
+	batch := make([]db.InsertProxyRequestEventAtParams, 0)
+	recorder.queuePublicCacheTouch(touches, newPublicCacheTouch(keyDigest, storedAt, newerAccess))
+	firstFlushAt := newerAccess.Add(time.Second)
+	if err := recorder.flushBatch(ctx, &batch, touches, firstFlushAt, true); err != nil {
+		t.Fatalf("flush newer cache touch: %v", err)
+	}
+
+	assertEntry := func(wantHits int64, wantAccess time.Time) {
+		t.Helper()
+		var hitCount int64
+		var lastAccessedAt time.Time
+		if err := app.DB.QueryRowContext(ctx, `
+			SELECT hit_count, last_accessed_at
+			FROM public_cache_entries
+			WHERE key_digest = ?
+		`, keyDigest).Scan(&hitCount, &lastAccessedAt); err != nil {
+			t.Fatalf("read cache touch state: %v", err)
+		}
+		if hitCount != wantHits || !lastAccessedAt.Equal(wantAccess) {
+			t.Fatalf("cache touch state = hits %d/access %s, want %d/%s", hitCount, lastAccessedAt, wantHits, wantAccess)
+		}
+	}
+	assertEntry(1, newerAccess)
+
+	recorder.prunePublicCacheTouches(touches, firstFlushAt.Add(publicCacheTouchCoalesceInterval))
+	if len(touches) != 0 || recorder.pendingTouches.Load() != 0 {
+		t.Fatalf("flushed cache touch state was not pruned: len=%d pending=%d", len(touches), recorder.pendingTouches.Load())
+	}
+
+	recorder.queuePublicCacheTouch(touches, newPublicCacheTouch(keyDigest, storedAt, olderAccess))
+	if err := recorder.flushBatch(ctx, &batch, touches, firstFlushAt.Add(publicCacheTouchCoalesceInterval), true); err != nil {
+		t.Fatalf("flush older cache touch: %v", err)
+	}
+	assertEntry(2, newerAccess)
+}
+
+func TestObservabilityRecorderTouchesLegacySQLiteTimestampGeneration(t *testing.T) {
+	ctx := context.Background()
+	app := NewApp(nil, newServerTestDB(t))
+	keyDigest := "legacy-sqlite-cache-touch"
+	if _, err := app.DB.ExecContext(ctx, `INSERT INTO public_cache_rules (id, name) VALUES (1, 'legacy-cache-rule')`); err != nil {
+		t.Fatalf("insert cache rule: %v", err)
+	}
+	if _, err := app.DB.ExecContext(ctx, `
+		INSERT INTO public_cache_entries (
+			key_digest, rule_id, scope, listener_protocol, host, path, query_key, method,
+			vary_headers_json, response_headers_json, status_code, body_path, size_bytes, expires_at
+		) VALUES (?, 1, 'selected_backend', 'http', 'example.test', '/legacy', '', 'GET',
+			'[]', '{}', 200, '/tmp/legacy-body', 10, datetime('now', '+1 hour'))
+	`, keyDigest); err != nil {
+		t.Fatalf("insert legacy cache entry: %v", err)
+	}
+
+	var storedText string
+	var storedLength int
+	if err := app.DB.QueryRowContext(ctx, `
+		SELECT CAST(stored_at AS TEXT), length(stored_at)
+		FROM public_cache_entries
+		WHERE key_digest = ?
+	`, keyDigest).Scan(&storedText, &storedLength); err != nil {
+		t.Fatalf("read raw legacy stored_at: %v", err)
+	}
+	if storedLength != len("2006-01-02 15:04:05") {
+		t.Fatalf("legacy stored_at = %q (length %d), want SQLite CURRENT_TIMESTAMP format", storedText, storedLength)
+	}
+	entry, err := app.DB.GetPublicCacheEntry(ctx, keyDigest)
+	if err != nil {
+		t.Fatalf("load legacy cache entry: %v", err)
+	}
+	accessedAt := entry.StoredAt.Add(time.Second)
+	recorder := newObservabilityRecorder(app)
+	touches := make(map[publicCacheTouchKey]*publicCacheTouchState)
+	recorder.queuePublicCacheTouch(touches, newPublicCacheTouch(keyDigest, entry.StoredAt, accessedAt))
+	batch := make([]db.InsertProxyRequestEventAtParams, 0)
+	if err := recorder.flushBatch(ctx, &batch, touches, accessedAt, true); err != nil {
+		t.Fatalf("flush legacy cache touch: %v", err)
+	}
+
+	updated, err := app.DB.GetPublicCacheEntry(ctx, keyDigest)
+	if err != nil {
+		t.Fatalf("reload legacy cache entry: %v", err)
+	}
+	if updated.HitCount != 1 || !updated.LastAccessedAt.Equal(accessedAt) {
+		t.Fatalf("legacy cache touch = hits %d/access %s, want 1/%s", updated.HitCount, updated.LastAccessedAt, accessedAt)
+	}
+}
+
 func TestObservabilityRecorderBoundsPendingEventsWhenDatabaseFails(t *testing.T) {
 	database := newServerTestDB(t)
 	app := NewApp(nil, database)

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -333,32 +333,38 @@ func TestObservabilityRecorderCoalescesPublicCacheTouches(t *testing.T) {
 	ctx := context.Background()
 	app := NewApp(nil, newServerTestDB(t))
 	keyDigest := "cache-touch-key"
+	storedAt := time.Now().UTC().Round(0)
 	if _, err := app.DB.ExecContext(ctx, `INSERT INTO public_cache_rules (id, name) VALUES (1, 'cache-touch-rule')`); err != nil {
 		t.Fatalf("insert cache rule: %v", err)
 	}
 	if _, err := app.DB.ExecContext(ctx, `
 		INSERT INTO public_cache_entries (
 			key_digest, rule_id, scope, listener_protocol, host, path, query_key, method,
-			vary_headers_json, response_headers_json, status_code, body_path, size_bytes, expires_at
-		) VALUES (?, 1, 'selected_backend', 'http', 'example.test', '/asset', '', 'GET', '[]', '{}', 200, '/tmp/body', 10, ?)
-	`, keyDigest, time.Now().Add(time.Hour)); err != nil {
+			vary_headers_json, response_headers_json, status_code, body_path, size_bytes, stored_at, expires_at
+		) VALUES (?, 1, 'selected_backend', 'http', 'example.test', '/asset', '', 'GET', '[]', '{}', 200, '/tmp/body', 10, ?, ?)
+	`, keyDigest, storedAt, time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("insert cache entry: %v", err)
 	}
 
 	recorder := app.observabilityRecorderService()
-	recorder.touchPublicCacheEntry(keyDigest)
-	recorder.touchPublicCacheEntry(keyDigest)
-	recorder.touchPublicCacheEntry(keyDigest)
+	firstAccess := storedAt.Add(time.Second)
+	recorder.touchPublicCacheEntry(keyDigest, storedAt, firstAccess)
+	recorder.touchPublicCacheEntry(keyDigest, storedAt, firstAccess.Add(time.Second))
+	recorder.touchPublicCacheEntry(keyDigest, storedAt, firstAccess.Add(2*time.Second))
 	if err := app.flushObservabilityRecorder(ctx); err != nil {
 		t.Fatalf("flush observability recorder: %v", err)
 	}
 
 	var hitCount int64
-	if err := app.DB.QueryRowContext(ctx, `SELECT hit_count FROM public_cache_entries WHERE key_digest = ?`, keyDigest).Scan(&hitCount); err != nil {
+	var lastAccessedAt time.Time
+	if err := app.DB.QueryRowContext(ctx, `SELECT hit_count, last_accessed_at FROM public_cache_entries WHERE key_digest = ?`, keyDigest).Scan(&hitCount, &lastAccessedAt); err != nil {
 		t.Fatalf("read cache hit count: %v", err)
 	}
 	if hitCount != 3 {
 		t.Fatalf("cache hit count = %d, want all 3 coalesced hits", hitCount)
+	}
+	if want := firstAccess.Add(2 * time.Second); !lastAccessedAt.Equal(want) {
+		t.Fatalf("cache last access = %s, want latest hit %s", lastAccessedAt, want)
 	}
 }
 
@@ -436,15 +442,17 @@ func TestObservabilityRecorderRateLimitsDropLogs(t *testing.T) {
 func TestObservabilityRecorderBoundsAndPrunesCacheTouchState(t *testing.T) {
 	recorder := newObservabilityRecorder(nil)
 	recorder.nextDropLog.Store(time.Now().Add(time.Hour).UnixNano())
-	touches := make(map[string]*publicCacheTouchState)
+	touches := make(map[publicCacheTouchKey]*publicCacheTouchState)
+	storedAt := time.Unix(1_700_000_000, 0).UTC()
 	for i := 0; i < observabilityRecorderMaxTouchKeys; i++ {
-		recorder.queuePublicCacheTouch(touches, fmt.Sprintf("key-%d", i))
+		recorder.queuePublicCacheTouch(touches, newPublicCacheTouch(fmt.Sprintf("key-%d", i), storedAt, storedAt.Add(time.Second)))
 	}
-	recorder.queuePublicCacheTouch(touches, "key-0")
-	if got := touches["key-0"].hitCount; got != 2 {
+	keyZero := newPublicCacheTouch("key-0", storedAt, storedAt.Add(2*time.Second))
+	recorder.queuePublicCacheTouch(touches, keyZero)
+	if got := touches[keyZero.key].hitCount; got != 2 {
 		t.Fatalf("existing cache key hit count = %d, want 2", got)
 	}
-	recorder.queuePublicCacheTouch(touches, "overflow")
+	recorder.queuePublicCacheTouch(touches, newPublicCacheTouch("overflow", storedAt, storedAt.Add(time.Second)))
 	if got := len(touches); got != observabilityRecorderMaxTouchKeys {
 		t.Fatalf("cache touch state cardinality = %d, want cap %d", got, observabilityRecorderMaxTouchKeys)
 	}
@@ -460,6 +468,47 @@ func TestObservabilityRecorderBoundsAndPrunesCacheTouchState(t *testing.T) {
 	recorder.prunePublicCacheTouches(touches, now)
 	if len(touches) != 0 || recorder.pendingTouches.Load() != 0 {
 		t.Fatalf("expired cache touch state was not pruned: len=%d pending=%d", len(touches), recorder.pendingTouches.Load())
+	}
+}
+
+func TestObservabilityRecorderCoalescesCacheTouchesPerGeneration(t *testing.T) {
+	recorder := newObservabilityRecorder(nil)
+	touches := make(map[publicCacheTouchKey]*publicCacheTouchState)
+	storedAtA := time.Unix(1_700_000_000, 1).UTC()
+	storedAtB := storedAtA.Add(time.Nanosecond)
+	keyA := newPublicCacheTouch("same-digest", storedAtA, storedAtA.Add(time.Second))
+	keyB := newPublicCacheTouch("same-digest", storedAtB, storedAtB.Add(time.Second))
+
+	recorder.queuePublicCacheTouch(touches, keyA)
+	recorder.queuePublicCacheTouch(touches, newPublicCacheTouch("same-digest", storedAtA, storedAtA.Add(2*time.Second)))
+	recorder.queuePublicCacheTouch(touches, keyB)
+	recorder.queuePublicCacheTouch(touches, newPublicCacheTouch("same-digest", storedAtB, storedAtB.Add(2*time.Second)))
+	recorder.queuePublicCacheTouch(touches, newPublicCacheTouch("same-digest", storedAtB, storedAtB.Add(3*time.Second)))
+	if len(touches) != 2 || touches[keyA.key].hitCount != 2 || touches[keyB.key].hitCount != 3 {
+		t.Fatalf("generation touch state = len %d/A %d/B %d, want 2/2/3", len(touches), touches[keyA.key].hitCount, touches[keyB.key].hitCount)
+	}
+	if got := touches[keyA.key].lastAccessedAt; !got.Equal(storedAtA.Add(2 * time.Second)) {
+		t.Fatalf("generation A latest access = %s, want %s", got, storedAtA.Add(2*time.Second))
+	}
+	if got := touches[keyB.key].lastAccessedAt; !got.Equal(storedAtB.Add(3 * time.Second)) {
+		t.Fatalf("generation B latest access = %s, want %s", got, storedAtB.Add(3*time.Second))
+	}
+
+	batch := publicCacheTouchesToFlush(touches, time.Now().UTC(), true)
+	counts := make(map[time.Time]int64)
+	accesses := make(map[time.Time]time.Time)
+	for _, touch := range batch {
+		if touch.KeyDigest != "same-digest" {
+			t.Fatalf("touch digest = %q, want same-digest", touch.KeyDigest)
+		}
+		counts[touch.StoredAt] = touch.HitCount
+		accesses[touch.StoredAt] = touch.LastAccessedAt
+	}
+	if counts[storedAtA] != 2 || counts[storedAtB] != 3 {
+		t.Fatalf("generation flush counts = A %d/B %d, want 2/3", counts[storedAtA], counts[storedAtB])
+	}
+	if !accesses[storedAtA].Equal(storedAtA.Add(2*time.Second)) || !accesses[storedAtB].Equal(storedAtB.Add(3*time.Second)) {
+		t.Fatalf("generation flush access times = A %s/B %s", accesses[storedAtA], accesses[storedAtB])
 	}
 }
 

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -3,8 +3,10 @@ package server
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -490,6 +492,38 @@ func TestCloseObservabilityRecorderFlushesQueuedEvents(t *testing.T) {
 	}
 	if rawEvents != 1 {
 		t.Fatalf("raw proxy events = %d, want 1", rawEvents)
+	}
+}
+
+func TestObservabilityRecorderCanceledFlushCanRetryWithFreshCloseContext(t *testing.T) {
+	app := NewApp(nil, newServerTestDB(t))
+	recorder := newObservabilityRecorder(app)
+	// Suppress the worker until after the first flush so its unbuffered control
+	// send deterministically observes the canceled context.
+	recorder.startOnce.Do(func() {})
+	recorder.recordProxyRequestEvent(context.Background(), proxyRequestEvent{StatusCode: http.StatusOK})
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := recorder.flush(canceledCtx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("flush error = %v, want context.Canceled", err)
+	}
+
+	recorder.mu.Lock()
+	recorder.startOnce = sync.Once{}
+	recorder.mu.Unlock()
+	closeCtx, closeCancel := context.WithTimeout(context.Background(), time.Second)
+	defer closeCancel()
+	if err := recorder.close(closeCtx); err != nil {
+		t.Fatalf("close recorder with fresh context: %v", err)
+	}
+
+	var rawEvents int64
+	if err := app.DB.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM proxy_request_events`).Scan(&rawEvents); err != nil {
+		t.Fatalf("count raw proxy events: %v", err)
+	}
+	if rawEvents != 1 {
+		t.Fatalf("raw proxy events after canceled flush and fresh close = %d, want 1", rawEvents)
 	}
 }
 

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -482,8 +482,14 @@ func TestObservabilityRecorderBoundsPendingEventsWhenDatabaseFails(t *testing.T)
 	database := newServerTestDB(t)
 	app := NewApp(nil, database)
 	recorder := app.observabilityRecorderService()
-	if err := database.Close(); err != nil {
-		t.Fatalf("close database: %v", err)
+	flushFailure := errors.New("injected observability flush failure")
+	failFlush := true
+	insertBatch := recorder.insertBatch
+	recorder.insertBatch = func(ctx context.Context, events []db.InsertProxyRequestEventAtParams, touches []db.TouchPublicCacheEntryParams) error {
+		if failFlush {
+			return flushFailure
+		}
+		return insertBatch(ctx, events, touches)
 	}
 
 	for i := 0; i < observabilityRecorderMaxBatch; i++ {
@@ -521,9 +527,15 @@ func TestObservabilityRecorderBoundsPendingEventsWhenDatabaseFails(t *testing.T)
 	}
 
 	closeCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	if err := recorder.close(closeCtx); err == nil {
-		t.Fatal("close with failed database unexpectedly succeeded")
+	if err := recorder.close(closeCtx); !errors.Is(err, flushFailure) {
+		t.Fatalf("close error = %v, want injected flush failure", err)
+	}
+	cancel()
+	failFlush = false
+	retryCtx, retryCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer retryCancel()
+	if err := recorder.close(retryCtx); err != nil {
+		t.Fatalf("retry close after database recovery: %v", err)
 	}
 }
 
@@ -703,6 +715,79 @@ func TestCloseObservabilityRecorderCancelsActiveFlushAndDrains(t *testing.T) {
 	}
 	if rawEvents != observabilityRecorderMaxBatch {
 		t.Fatalf("drained proxy events = %d, want %d", rawEvents, observabilityRecorderMaxBatch)
+	}
+}
+
+func TestObservabilityRecorderFailedDeliveredCloseWakesConcurrentRetry(t *testing.T) {
+	app := NewApp(nil, newServerTestDB(t))
+	recorder := newObservabilityRecorder(app)
+	flushStarted := make(chan struct{})
+	secondCloseWaiting := make(chan struct{})
+	var waitOnce sync.Once
+	recorder.closeWaitHook = func() {
+		waitOnce.Do(func() { close(secondCloseWaiting) })
+	}
+	flushCalls := 0
+	var firstEvents, firstTouches, retryEvents, retryTouches int
+	recorder.insertBatch = func(ctx context.Context, events []db.InsertProxyRequestEventAtParams, touches []db.TouchPublicCacheEntryParams) error {
+		flushCalls++
+		if flushCalls == 1 {
+			firstEvents, firstTouches = len(events), len(touches)
+			close(flushStarted)
+			<-ctx.Done()
+			return ctx.Err()
+		}
+		retryEvents, retryTouches = len(events), len(touches)
+		return app.insertProxyRequestEventsWithRollupsAndCacheTouches(ctx, events, touches)
+	}
+
+	recorder.startOnce.Do(func() {})
+	storedAt := time.Now().Add(-time.Minute).UTC()
+	recorder.recordProxyRequestEvent(context.Background(), proxyRequestEvent{StatusCode: http.StatusOK})
+	recorder.touchPublicCacheEntry("retry-touch", storedAt, storedAt.Add(time.Second))
+	recorder.mu.Lock()
+	recorder.startOnce = sync.Once{}
+	recorder.mu.Unlock()
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- recorder.close(firstCtx) }()
+	select {
+	case <-flushStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for delivered stop flush")
+	}
+
+	secondCtx, cancelSecond := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelSecond()
+	secondDone := make(chan error, 1)
+	go func() { secondDone <- recorder.close(secondCtx) }()
+	select {
+	case <-secondCloseWaiting:
+	case <-time.After(2 * time.Second):
+		t.Fatal("concurrent close did not wait on the active close attempt")
+	}
+	cancelFirst()
+	if err := <-firstDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("first close error = %v, want context.Canceled", err)
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatalf("concurrent retry close: %v", err)
+	}
+	if flushCalls != 2 {
+		t.Fatalf("flush calls = %d, want failed stop plus retry", flushCalls)
+	}
+	if firstEvents != 1 || firstTouches != 1 || retryEvents != 1 || retryTouches != 1 {
+		t.Fatalf("retained batches = first events/touches %d/%d retry %d/%d, want 1/1 then 1/1", firstEvents, firstTouches, retryEvents, retryTouches)
+	}
+	if recorder.pendingEvents.Load() != 0 || recorder.pendingTouches.Load() != 0 || len(recorder.events) != 0 || len(recorder.touches) != 0 {
+		t.Fatalf("records remained after retry close: pending=%d/%d queued=%d/%d", recorder.pendingEvents.Load(), recorder.pendingTouches.Load(), len(recorder.events), len(recorder.touches))
+	}
+	var rawEvents int64
+	if err := app.DB.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM proxy_request_events`).Scan(&rawEvents); err != nil {
+		t.Fatalf("count retry-drained proxy events: %v", err)
+	}
+	if rawEvents != 1 {
+		t.Fatalf("retry-drained proxy events = %d, want 1", rawEvents)
 	}
 }
 

--- a/internal/server/observability_recorder.go
+++ b/internal/server/observability_recorder.go
@@ -46,6 +46,7 @@ type proxyRequestEvent struct {
 type observabilityRecorder struct {
 	app            *App
 	insertBatch    observabilityRecorderInsertFunc
+	closeWaitHook  func()
 	events         chan db.InsertProxyRequestEventAtParams
 	touches        chan publicCacheTouch
 	control        chan observabilityRecorderRequest
@@ -55,6 +56,7 @@ type observabilityRecorder struct {
 	activeFlush    *observabilityRecorderFlushOperation
 	startOnce      sync.Once
 	stopped        bool
+	closeAttempt   chan struct{}
 	closing        atomic.Bool
 	droppedEvents  atomic.Int64
 	droppedTouches atomic.Int64
@@ -71,9 +73,10 @@ type observabilityRecorderFlushOperation struct {
 type observabilityRecorderInsertFunc func(context.Context, []db.InsertProxyRequestEventAtParams, []db.TouchPublicCacheEntryParams) error
 
 type observabilityRecorderRequest struct {
-	ctx  context.Context
-	done chan error
-	stop bool
+	ctx          context.Context
+	done         chan error
+	closeAttempt chan struct{}
+	stop         bool
 }
 
 type publicCacheTouchState struct {
@@ -255,32 +258,37 @@ func (r *observabilityRecorder) flush(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	r.mu.Lock()
-	if r.stopped {
-		done := r.done
-		r.mu.Unlock()
+	for {
+		r.mu.Lock()
+		if r.stopped {
+			done := r.done
+			attempt := r.closeAttempt
+			r.mu.Unlock()
+			select {
+			case <-done:
+				return nil
+			case <-attempt:
+				continue
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		r.startLocked()
+		done := make(chan error, 1)
+		req := observabilityRecorderRequest{ctx: ctx, done: done}
 		select {
-		case <-done:
-			return nil
+		case r.control <- req:
+			r.mu.Unlock()
+		case <-ctx.Done():
+			r.mu.Unlock()
+			return ctx.Err()
+		}
+		select {
+		case err := <-done:
+			return err
 		case <-ctx.Done():
 			return ctx.Err()
 		}
-	}
-	r.startLocked()
-	done := make(chan error, 1)
-	req := observabilityRecorderRequest{ctx: ctx, done: done}
-	select {
-	case r.control <- req:
-		r.mu.Unlock()
-	case <-ctx.Done():
-		r.mu.Unlock()
-		return ctx.Err()
-	}
-	select {
-	case err := <-done:
-		return err
-	case <-ctx.Done():
-		return ctx.Err()
 	}
 }
 
@@ -291,43 +299,57 @@ func (r *observabilityRecorder) close(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	r.mu.Lock()
-	if r.stopped {
-		done := r.done
-		r.mu.Unlock()
+	for {
+		r.mu.Lock()
+		if r.stopped {
+			done := r.done
+			attempt := r.closeAttempt
+			if r.closeWaitHook != nil {
+				r.closeWaitHook()
+			}
+			r.mu.Unlock()
+			select {
+			case <-done:
+				return nil
+			case <-attempt:
+				continue
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		r.stopped = true
+		r.closing.Store(true)
+		attempt := make(chan struct{})
+		r.closeAttempt = attempt
+		r.startLocked()
+		r.cancelActiveFlush()
+		done := make(chan error, 1)
+		req := observabilityRecorderRequest{ctx: ctx, done: done, closeAttempt: attempt, stop: true}
 		select {
-		case <-done:
-			return nil
+		case r.control <- req:
+			r.mu.Unlock()
 		case <-ctx.Done():
+			r.restoreCloseAttemptLocked(attempt)
+			r.mu.Unlock()
 			return ctx.Err()
 		}
-	}
-	r.stopped = true
-	r.closing.Store(true)
-	r.startLocked()
-	r.cancelActiveFlush()
-	done := make(chan error, 1)
-	req := observabilityRecorderRequest{ctx: ctx, done: done, stop: true}
-	select {
-	case r.control <- req:
-		r.mu.Unlock()
-	case <-ctx.Done():
-		r.stopped = false
-		r.closing.Store(false)
-		r.mu.Unlock()
-		return ctx.Err()
-	}
-	select {
-	case err := <-done:
 		select {
-		case <-r.done:
+		case err := <-done:
 			return err
 		case <-ctx.Done():
 			return ctx.Err()
 		}
-	case <-ctx.Done():
-		return ctx.Err()
 	}
+}
+
+func (r *observabilityRecorder) restoreCloseAttemptLocked(attempt chan struct{}) {
+	if attempt == nil || r.closeAttempt != attempt {
+		return
+	}
+	r.stopped = false
+	r.closing.Store(false)
+	r.closeAttempt = nil
+	close(attempt)
 }
 
 func (r *observabilityRecorder) startLocked() {
@@ -406,11 +428,28 @@ func (r *observabilityRecorder) run() {
 			err := r.runFlushOperation(req.ctx, req.stop, func(ctx context.Context) error {
 				return r.flushQueued(ctx, &batch, touches, eventCount, touchCount)
 			})
-			req.done <- err
-			if req.stop {
-				close(r.done)
-				return
+			if !req.stop {
+				req.done <- err
+				continue
 			}
+			if err != nil {
+				r.mu.Lock()
+				r.restoreCloseAttemptLocked(req.closeAttempt)
+				r.mu.Unlock()
+				req.done <- err
+				continue
+			}
+			r.pendingEvents.Store(0)
+			r.pendingTouches.Store(0)
+			r.mu.Lock()
+			if r.closeAttempt == req.closeAttempt {
+				r.closeAttempt = nil
+				close(r.done)
+				close(req.closeAttempt)
+			}
+			r.mu.Unlock()
+			req.done <- nil
+			return
 		case <-ticker.C:
 			now := time.Now().UTC()
 			r.prunePublicCacheTouches(touches, now)

--- a/internal/server/observability_recorder.go
+++ b/internal/server/observability_recorder.go
@@ -21,6 +21,7 @@ const (
 	observabilityRecorderMaxTouchKeys  = 8192
 	observabilityRecorderLogInterval   = time.Minute
 	publicCacheTouchCoalesceInterval   = time.Minute
+	sqliteLegacyTimestampLayout        = "2006-01-02 15:04:05"
 )
 
 type proxyRequestEvent struct {
@@ -432,6 +433,7 @@ func publicCacheTouchesToFlush(touches map[publicCacheTouchKey]*publicCacheTouch
 			HitCount:       touch.hitCount,
 			KeyDigest:      key.keyDigest,
 			StoredAt:       key.storedAt,
+			StoredAtLegacy: key.storedAt.UTC().Format(sqliteLegacyTimestampLayout),
 			LastAccessedAt: touch.lastAccessedAt,
 		})
 	}

--- a/internal/server/observability_recorder.go
+++ b/internal/server/observability_recorder.go
@@ -44,7 +44,7 @@ type proxyRequestEvent struct {
 type observabilityRecorder struct {
 	app            *App
 	events         chan db.InsertProxyRequestEventAtParams
-	touches        chan string
+	touches        chan publicCacheTouch
 	control        chan observabilityRecorderRequest
 	done           chan struct{}
 	mu             sync.Mutex
@@ -65,15 +65,41 @@ type observabilityRecorderRequest struct {
 }
 
 type publicCacheTouchState struct {
-	hitCount      int64
-	lastFlushedAt time.Time
+	hitCount       int64
+	lastAccessedAt time.Time
+	lastFlushedAt  time.Time
+}
+
+type publicCacheTouchKey struct {
+	keyDigest string
+	storedAt  time.Time
+}
+
+type publicCacheTouch struct {
+	key        publicCacheTouchKey
+	accessedAt time.Time
+}
+
+func newPublicCacheTouch(keyDigest string, storedAt time.Time, accessedAt time.Time) publicCacheTouch {
+	storedAt = storedAt.UTC().Round(0)
+	accessedAt = accessedAt.UTC().Round(0)
+	if accessedAt.Before(storedAt) {
+		accessedAt = storedAt
+	}
+	return publicCacheTouch{
+		key: publicCacheTouchKey{
+			keyDigest: keyDigest,
+			storedAt:  storedAt,
+		},
+		accessedAt: accessedAt,
+	}
 }
 
 func newObservabilityRecorder(app *App) *observabilityRecorder {
 	return &observabilityRecorder{
 		app:     app,
 		events:  make(chan db.InsertProxyRequestEventAtParams, observabilityRecorderQueueSize),
-		touches: make(chan string, observabilityRecorderQueueSize),
+		touches: make(chan publicCacheTouch, observabilityRecorderQueueSize),
 		control: make(chan observabilityRecorderRequest),
 		done:    make(chan struct{}),
 	}
@@ -148,8 +174,8 @@ func (r *observabilityRecorder) recordProxyRequestEvent(ctx context.Context, eve
 	_ = ctx
 }
 
-func (r *observabilityRecorder) touchPublicCacheEntry(keyDigest string) {
-	if r == nil || r.app == nil || r.app.DB == nil || keyDigest == "" {
+func (r *observabilityRecorder) touchPublicCacheEntry(keyDigest string, storedAt time.Time, accessedAt time.Time) {
+	if r == nil || r.app == nil || r.app.DB == nil || keyDigest == "" || storedAt.IsZero() || accessedAt.IsZero() {
 		return
 	}
 	r.mu.Lock()
@@ -159,7 +185,7 @@ func (r *observabilityRecorder) touchPublicCacheEntry(keyDigest string) {
 	}
 	r.startLocked()
 	select {
-	case r.touches <- keyDigest:
+	case r.touches <- newPublicCacheTouch(keyDigest, storedAt, accessedAt):
 	default:
 		r.dropTouch()
 	}
@@ -295,7 +321,7 @@ func (r *observabilityRecorder) run() {
 	ticker := time.NewTicker(observabilityRecorderFlushInterval)
 	defer ticker.Stop()
 	batch := make([]db.InsertProxyRequestEventAtParams, 0, observabilityRecorderMaxBatch)
-	touches := make(map[string]*publicCacheTouchState)
+	touches := make(map[publicCacheTouchKey]*publicCacheTouchState)
 	for {
 		events := r.events
 		if len(batch) >= observabilityRecorderMaxBatch {
@@ -311,8 +337,8 @@ func (r *observabilityRecorder) run() {
 			if len(batch) >= observabilityRecorderMaxBatch {
 				r.flushBatch(context.Background(), &batch, touches, time.Now().UTC(), false)
 			}
-		case keyDigest := <-r.touches:
-			r.queuePublicCacheTouch(touches, keyDigest)
+		case touch := <-r.touches:
+			r.queuePublicCacheTouch(touches, touch)
 		case req := <-r.control:
 			eventCount := len(r.events)
 			touchCount := len(r.touches)
@@ -332,7 +358,7 @@ func (r *observabilityRecorder) run() {
 func (r *observabilityRecorder) flushQueued(
 	ctx context.Context,
 	batch *[]db.InsertProxyRequestEventAtParams,
-	touches map[string]*publicCacheTouchState,
+	touches map[publicCacheTouchKey]*publicCacheTouchState,
 	eventCount int,
 	touchCount int,
 ) error {
@@ -359,39 +385,43 @@ func (r *observabilityRecorder) flushQueued(
 	return r.flushBatch(ctx, batch, touches, time.Now().UTC(), true)
 }
 
-func (r *observabilityRecorder) queuePublicCacheTouch(touches map[string]*publicCacheTouchState, keyDigest string) {
-	if keyDigest == "" {
+func (r *observabilityRecorder) queuePublicCacheTouch(touches map[publicCacheTouchKey]*publicCacheTouchState, queued publicCacheTouch) {
+	if queued.key.keyDigest == "" || queued.key.storedAt.IsZero() || queued.accessedAt.IsZero() {
 		return
 	}
-	if touch := touches[keyDigest]; touch != nil {
+	queued = newPublicCacheTouch(queued.key.keyDigest, queued.key.storedAt, queued.accessedAt)
+	if touch := touches[queued.key]; touch != nil {
 		if touch.hitCount == math.MaxInt64 {
 			r.dropTouch()
 			return
 		}
 		touch.hitCount++
+		if queued.accessedAt.After(touch.lastAccessedAt) {
+			touch.lastAccessedAt = queued.accessedAt
+		}
 		return
 	}
 	if len(touches) >= observabilityRecorderMaxTouchKeys {
 		r.dropTouch()
 		return
 	}
-	touches[keyDigest] = &publicCacheTouchState{hitCount: 1}
+	touches[queued.key] = &publicCacheTouchState{hitCount: 1, lastAccessedAt: queued.accessedAt}
 	r.pendingTouches.Store(int64(len(touches)))
 }
 
-func (r *observabilityRecorder) prunePublicCacheTouches(touches map[string]*publicCacheTouchState, now time.Time) {
-	for keyDigest, touch := range touches {
+func (r *observabilityRecorder) prunePublicCacheTouches(touches map[publicCacheTouchKey]*publicCacheTouchState, now time.Time) {
+	for key, touch := range touches {
 		if touch.hitCount != 0 || touch.lastFlushedAt.IsZero() || now.Sub(touch.lastFlushedAt) < publicCacheTouchCoalesceInterval {
 			continue
 		}
-		delete(touches, keyDigest)
+		delete(touches, key)
 	}
 	r.pendingTouches.Store(int64(len(touches)))
 }
 
-func publicCacheTouchesToFlush(touches map[string]*publicCacheTouchState, now time.Time, force bool) []db.TouchPublicCacheEntryParams {
+func publicCacheTouchesToFlush(touches map[publicCacheTouchKey]*publicCacheTouchState, now time.Time, force bool) []db.TouchPublicCacheEntryParams {
 	var ready []db.TouchPublicCacheEntryParams
-	for keyDigest, touch := range touches {
+	for key, touch := range touches {
 		if touch.hitCount <= 0 {
 			continue
 		}
@@ -399,8 +429,10 @@ func publicCacheTouchesToFlush(touches map[string]*publicCacheTouchState, now ti
 			continue
 		}
 		ready = append(ready, db.TouchPublicCacheEntryParams{
-			HitCount:  touch.hitCount,
-			KeyDigest: keyDigest,
+			HitCount:       touch.hitCount,
+			KeyDigest:      key.keyDigest,
+			StoredAt:       key.storedAt,
+			LastAccessedAt: touch.lastAccessedAt,
 		})
 	}
 	return ready
@@ -409,7 +441,7 @@ func publicCacheTouchesToFlush(touches map[string]*publicCacheTouchState, now ti
 func (r *observabilityRecorder) flushBatch(
 	ctx context.Context,
 	batch *[]db.InsertProxyRequestEventAtParams,
-	touches map[string]*publicCacheTouchState,
+	touches map[publicCacheTouchKey]*publicCacheTouchState,
 	now time.Time,
 	forceTouches bool,
 ) error {
@@ -424,7 +456,8 @@ func (r *observabilityRecorder) flushBatch(
 	*batch = (*batch)[:0]
 	r.pendingEvents.Store(0)
 	for _, flushed := range touchBatch {
-		touch := touches[flushed.KeyDigest]
+		key := newPublicCacheTouch(flushed.KeyDigest, flushed.StoredAt, flushed.LastAccessedAt).key
+		touch := touches[key]
 		if touch == nil {
 			continue
 		}

--- a/internal/server/observability_recorder.go
+++ b/internal/server/observability_recorder.go
@@ -17,6 +17,7 @@ import (
 const (
 	observabilityRecorderQueueSize     = 8192
 	observabilityRecorderFlushInterval = 250 * time.Millisecond
+	observabilityRecorderFlushTimeout  = 5 * time.Second
 	observabilityRecorderMaxBatch      = 512
 	observabilityRecorderMaxTouchKeys  = 8192
 	observabilityRecorderLogInterval   = time.Minute
@@ -44,13 +45,17 @@ type proxyRequestEvent struct {
 
 type observabilityRecorder struct {
 	app            *App
+	insertBatch    observabilityRecorderInsertFunc
 	events         chan db.InsertProxyRequestEventAtParams
 	touches        chan publicCacheTouch
 	control        chan observabilityRecorderRequest
 	done           chan struct{}
 	mu             sync.Mutex
+	flushMu        sync.Mutex
+	activeFlush    *observabilityRecorderFlushOperation
 	startOnce      sync.Once
 	stopped        bool
+	closing        atomic.Bool
 	droppedEvents  atomic.Int64
 	droppedTouches atomic.Int64
 	pendingEvents  atomic.Int64
@@ -58,6 +63,12 @@ type observabilityRecorder struct {
 	nextDropLog    atomic.Int64
 	nextErrorLog   atomic.Int64
 }
+
+type observabilityRecorderFlushOperation struct {
+	cancel context.CancelFunc
+}
+
+type observabilityRecorderInsertFunc func(context.Context, []db.InsertProxyRequestEventAtParams, []db.TouchPublicCacheEntryParams) error
 
 type observabilityRecorderRequest struct {
 	ctx  context.Context
@@ -97,13 +108,17 @@ func newPublicCacheTouch(keyDigest string, storedAt time.Time, accessedAt time.T
 }
 
 func newObservabilityRecorder(app *App) *observabilityRecorder {
-	return &observabilityRecorder{
+	recorder := &observabilityRecorder{
 		app:     app,
 		events:  make(chan db.InsertProxyRequestEventAtParams, observabilityRecorderQueueSize),
 		touches: make(chan publicCacheTouch, observabilityRecorderQueueSize),
 		control: make(chan observabilityRecorderRequest),
 		done:    make(chan struct{}),
 	}
+	if app != nil {
+		recorder.insertBatch = app.insertProxyRequestEventsWithRollupsAndCacheTouches
+	}
+	return recorder
 }
 
 func (a *App) observabilityRecorderService() *observabilityRecorder {
@@ -288,7 +303,9 @@ func (r *observabilityRecorder) close(ctx context.Context) error {
 		}
 	}
 	r.stopped = true
+	r.closing.Store(true)
 	r.startLocked()
+	r.cancelActiveFlush()
 	done := make(chan error, 1)
 	req := observabilityRecorderRequest{ctx: ctx, done: done, stop: true}
 	select {
@@ -296,6 +313,7 @@ func (r *observabilityRecorder) close(ctx context.Context) error {
 		r.mu.Unlock()
 	case <-ctx.Done():
 		r.stopped = false
+		r.closing.Store(false)
 		r.mu.Unlock()
 		return ctx.Err()
 	}
@@ -318,6 +336,46 @@ func (r *observabilityRecorder) startLocked() {
 	})
 }
 
+func (r *observabilityRecorder) cancelActiveFlush() {
+	r.flushMu.Lock()
+	defer r.flushMu.Unlock()
+	if r.activeFlush != nil {
+		r.activeFlush.cancel()
+	}
+}
+
+func (r *observabilityRecorder) runFlushOperation(ctx context.Context, allowClosing bool, flush func(context.Context) error) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	flushCtx, cancel := context.WithCancel(ctx)
+	operation := &observabilityRecorderFlushOperation{cancel: cancel}
+
+	r.flushMu.Lock()
+	if !allowClosing && r.closing.Load() {
+		r.flushMu.Unlock()
+		cancel()
+		return context.Canceled
+	}
+	r.activeFlush = operation
+	r.flushMu.Unlock()
+
+	err := flush(flushCtx)
+	cancel()
+	r.flushMu.Lock()
+	if r.activeFlush == operation {
+		r.activeFlush = nil
+	}
+	r.flushMu.Unlock()
+	return err
+}
+
+func (r *observabilityRecorder) runBackgroundFlush(flush func(context.Context) error) error {
+	ctx, cancel := context.WithTimeout(context.Background(), observabilityRecorderFlushTimeout)
+	defer cancel()
+	return r.runFlushOperation(ctx, false, flush)
+}
+
 func (r *observabilityRecorder) run() {
 	ticker := time.NewTicker(observabilityRecorderFlushInterval)
 	defer ticker.Stop()
@@ -336,14 +394,19 @@ func (r *observabilityRecorder) run() {
 			batch = append(batch, event)
 			r.pendingEvents.Store(int64(len(batch)))
 			if len(batch) >= observabilityRecorderMaxBatch {
-				r.flushBatch(context.Background(), &batch, touches, time.Now().UTC(), false)
+				_ = r.runBackgroundFlush(func(ctx context.Context) error {
+					return r.flushBatch(ctx, &batch, touches, time.Now().UTC(), false)
+				})
 			}
 		case touch := <-r.touches:
 			r.queuePublicCacheTouch(touches, touch)
 		case req := <-r.control:
 			eventCount := len(r.events)
 			touchCount := len(r.touches)
-			req.done <- r.flushQueued(req.ctx, &batch, touches, eventCount, touchCount)
+			err := r.runFlushOperation(req.ctx, req.stop, func(ctx context.Context) error {
+				return r.flushQueued(ctx, &batch, touches, eventCount, touchCount)
+			})
+			req.done <- err
 			if req.stop {
 				close(r.done)
 				return
@@ -351,7 +414,9 @@ func (r *observabilityRecorder) run() {
 		case <-ticker.C:
 			now := time.Now().UTC()
 			r.prunePublicCacheTouches(touches, now)
-			r.flushBatch(context.Background(), &batch, touches, now, false)
+			_ = r.runBackgroundFlush(func(ctx context.Context) error {
+				return r.flushBatch(ctx, &batch, touches, now, false)
+			})
 		}
 	}
 }
@@ -451,8 +516,13 @@ func (r *observabilityRecorder) flushBatch(
 	if len(*batch) == 0 && len(touchBatch) == 0 {
 		return nil
 	}
-	if err := r.app.insertProxyRequestEventsWithRollupsAndCacheTouches(ctx, *batch, touchBatch); err != nil {
-		r.logFlushError(err)
+	if r.insertBatch == nil {
+		return nil
+	}
+	if err := r.insertBatch(ctx, *batch, touchBatch); err != nil {
+		if !r.closing.Load() || ctx.Err() != context.Canceled {
+			r.logFlushError(err)
+		}
 		return err
 	}
 	*batch = (*batch)[:0]

--- a/internal/server/observability_recorder.go
+++ b/internal/server/observability_recorder.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"database/sql"
+	"math"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -17,6 +18,8 @@ const (
 	observabilityRecorderQueueSize     = 8192
 	observabilityRecorderFlushInterval = 250 * time.Millisecond
 	observabilityRecorderMaxBatch      = 512
+	observabilityRecorderMaxTouchKeys  = 8192
+	observabilityRecorderLogInterval   = time.Minute
 	publicCacheTouchCoalesceInterval   = time.Minute
 )
 
@@ -49,12 +52,21 @@ type observabilityRecorder struct {
 	stopped        bool
 	droppedEvents  atomic.Int64
 	droppedTouches atomic.Int64
+	pendingEvents  atomic.Int64
+	pendingTouches atomic.Int64
+	nextDropLog    atomic.Int64
+	nextErrorLog   atomic.Int64
 }
 
 type observabilityRecorderRequest struct {
 	ctx  context.Context
 	done chan error
 	stop bool
+}
+
+type publicCacheTouchState struct {
+	hitCount      int64
+	lastFlushedAt time.Time
 }
 
 func newObservabilityRecorder(app *App) *observabilityRecorder {
@@ -131,8 +143,7 @@ func (r *observabilityRecorder) recordProxyRequestEvent(ctx context.Context, eve
 		CacheBytes:    int64FromUint64(event.CacheBytes),
 	}:
 	default:
-		r.droppedEvents.Add(1)
-		log.Warn().Msg("Dropping proxy request event because observability recorder queue is full")
+		r.dropEvent()
 	}
 	_ = ctx
 }
@@ -150,8 +161,48 @@ func (r *observabilityRecorder) touchPublicCacheEntry(keyDigest string) {
 	select {
 	case r.touches <- keyDigest:
 	default:
-		r.droppedTouches.Add(1)
-		log.Warn().Msg("Dropping public cache touch because observability recorder queue is full")
+		r.dropTouch()
+	}
+}
+
+func (r *observabilityRecorder) dropEvent() {
+	r.droppedEvents.Add(1)
+	r.logDrops()
+}
+
+func (r *observabilityRecorder) dropTouch() {
+	r.droppedTouches.Add(1)
+	r.logDrops()
+}
+
+func (r *observabilityRecorder) logDrops() {
+	now := time.Now().UnixNano()
+	for {
+		next := r.nextDropLog.Load()
+		if now < next {
+			return
+		}
+		if r.nextDropLog.CompareAndSwap(next, now+int64(observabilityRecorderLogInterval)) {
+			log.Warn().
+				Int64("dropped_events", r.droppedEvents.Load()).
+				Int64("dropped_cache_touches", r.droppedTouches.Load()).
+				Msg("Dropping observability records because recorder capacity is exhausted")
+			return
+		}
+	}
+}
+
+func (r *observabilityRecorder) logFlushError(err error) {
+	now := time.Now().UnixNano()
+	for {
+		next := r.nextErrorLog.Load()
+		if now < next {
+			return
+		}
+		if r.nextErrorLog.CompareAndSwap(next, now+int64(observabilityRecorderLogInterval)) {
+			log.Warn().Err(err).Msg("Failed to flush observability recorder; pending records will be retried")
+			return
+		}
 	}
 }
 
@@ -243,78 +294,145 @@ func (r *observabilityRecorder) startLocked() {
 func (r *observabilityRecorder) run() {
 	ticker := time.NewTicker(observabilityRecorderFlushInterval)
 	defer ticker.Stop()
-	var batch []db.InsertProxyRequestEventAtParams
-	touches := make(map[string]struct{})
-	lastTouch := make(map[string]time.Time)
+	batch := make([]db.InsertProxyRequestEventAtParams, 0, observabilityRecorderMaxBatch)
+	touches := make(map[string]*publicCacheTouchState)
 	for {
+		events := r.events
+		if len(batch) >= observabilityRecorderMaxBatch {
+			// A failed batch must stay fixed-size while it is retried. Leaving
+			// additional events in the bounded channel prevents an outage from
+			// turning the batch into unbounded heap growth.
+			events = nil
+		}
 		select {
-		case event := <-r.events:
+		case event := <-events:
 			batch = append(batch, event)
+			r.pendingEvents.Store(int64(len(batch)))
 			if len(batch) >= observabilityRecorderMaxBatch {
-				r.flushBatch(context.Background(), &batch, touches, lastTouch)
+				r.flushBatch(context.Background(), &batch, touches, time.Now().UTC(), false)
 			}
 		case keyDigest := <-r.touches:
-			if shouldQueuePublicCacheTouch(keyDigest, lastTouch, time.Now().UTC()) {
-				touches[keyDigest] = struct{}{}
-			}
+			r.queuePublicCacheTouch(touches, keyDigest)
 		case req := <-r.control:
-			r.drainAvailable(&batch, touches, lastTouch)
-			req.done <- r.flushBatch(req.ctx, &batch, touches, lastTouch)
+			eventCount := len(r.events)
+			touchCount := len(r.touches)
+			req.done <- r.flushQueued(req.ctx, &batch, touches, eventCount, touchCount)
 			if req.stop {
 				close(r.done)
 				return
 			}
 		case <-ticker.C:
-			r.drainAvailable(&batch, touches, lastTouch)
-			r.flushBatch(context.Background(), &batch, touches, lastTouch)
+			now := time.Now().UTC()
+			r.prunePublicCacheTouches(touches, now)
+			r.flushBatch(context.Background(), &batch, touches, now, false)
 		}
 	}
 }
 
-func (r *observabilityRecorder) drainAvailable(batch *[]db.InsertProxyRequestEventAtParams, touches map[string]struct{}, lastTouch map[string]time.Time) {
-	for {
-		select {
-		case event := <-r.events:
-			*batch = append(*batch, event)
-		case keyDigest := <-r.touches:
-			if shouldQueuePublicCacheTouch(keyDigest, lastTouch, time.Now().UTC()) {
-				touches[keyDigest] = struct{}{}
+func (r *observabilityRecorder) flushQueued(
+	ctx context.Context,
+	batch *[]db.InsertProxyRequestEventAtParams,
+	touches map[string]*publicCacheTouchState,
+	eventCount int,
+	touchCount int,
+) error {
+	for eventCount > 0 {
+		if len(*batch) >= observabilityRecorderMaxBatch {
+			if err := r.flushBatch(ctx, batch, touches, time.Now().UTC(), true); err != nil {
+				return err
 			}
-		default:
+		}
+		remaining := observabilityRecorderMaxBatch - len(*batch)
+		if remaining > eventCount {
+			remaining = eventCount
+		}
+		for i := 0; i < remaining; i++ {
+			*batch = append(*batch, <-r.events)
+		}
+		eventCount -= remaining
+		r.pendingEvents.Store(int64(len(*batch)))
+	}
+	r.prunePublicCacheTouches(touches, time.Now().UTC())
+	for i := 0; i < touchCount; i++ {
+		r.queuePublicCacheTouch(touches, <-r.touches)
+	}
+	return r.flushBatch(ctx, batch, touches, time.Now().UTC(), true)
+}
+
+func (r *observabilityRecorder) queuePublicCacheTouch(touches map[string]*publicCacheTouchState, keyDigest string) {
+	if keyDigest == "" {
+		return
+	}
+	if touch := touches[keyDigest]; touch != nil {
+		if touch.hitCount == math.MaxInt64 {
+			r.dropTouch()
 			return
 		}
+		touch.hitCount++
+		return
 	}
+	if len(touches) >= observabilityRecorderMaxTouchKeys {
+		r.dropTouch()
+		return
+	}
+	touches[keyDigest] = &publicCacheTouchState{hitCount: 1}
+	r.pendingTouches.Store(int64(len(touches)))
 }
 
-func (r *observabilityRecorder) flushBatch(ctx context.Context, batch *[]db.InsertProxyRequestEventAtParams, touches map[string]struct{}, lastTouch map[string]time.Time) error {
-	if len(*batch) == 0 && len(touches) == 0 {
+func (r *observabilityRecorder) prunePublicCacheTouches(touches map[string]*publicCacheTouchState, now time.Time) {
+	for keyDigest, touch := range touches {
+		if touch.hitCount != 0 || touch.lastFlushedAt.IsZero() || now.Sub(touch.lastFlushedAt) < publicCacheTouchCoalesceInterval {
+			continue
+		}
+		delete(touches, keyDigest)
+	}
+	r.pendingTouches.Store(int64(len(touches)))
+}
+
+func publicCacheTouchesToFlush(touches map[string]*publicCacheTouchState, now time.Time, force bool) []db.TouchPublicCacheEntryParams {
+	var ready []db.TouchPublicCacheEntryParams
+	for keyDigest, touch := range touches {
+		if touch.hitCount <= 0 {
+			continue
+		}
+		if !force && !touch.lastFlushedAt.IsZero() && now.Sub(touch.lastFlushedAt) < publicCacheTouchCoalesceInterval {
+			continue
+		}
+		ready = append(ready, db.TouchPublicCacheEntryParams{
+			HitCount:  touch.hitCount,
+			KeyDigest: keyDigest,
+		})
+	}
+	return ready
+}
+
+func (r *observabilityRecorder) flushBatch(
+	ctx context.Context,
+	batch *[]db.InsertProxyRequestEventAtParams,
+	touches map[string]*publicCacheTouchState,
+	now time.Time,
+	forceTouches bool,
+) error {
+	touchBatch := publicCacheTouchesToFlush(touches, now, forceTouches)
+	if len(*batch) == 0 && len(touchBatch) == 0 {
 		return nil
 	}
-	events := append([]db.InsertProxyRequestEventAtParams(nil), (*batch)...)
-	touchKeys := make([]string, 0, len(touches))
-	for keyDigest := range touches {
-		touchKeys = append(touchKeys, keyDigest)
-	}
-	if err := r.app.insertProxyRequestEventsWithRollupsAndCacheTouches(ctx, events, touchKeys); err != nil {
-		log.Warn().Err(err).Msg("Failed to flush observability recorder")
+	if err := r.app.insertProxyRequestEventsWithRollupsAndCacheTouches(ctx, *batch, touchBatch); err != nil {
+		r.logFlushError(err)
 		return err
 	}
 	*batch = (*batch)[:0]
-	for keyDigest := range touches {
-		delete(touches, keyDigest)
+	r.pendingEvents.Store(0)
+	for _, flushed := range touchBatch {
+		touch := touches[flushed.KeyDigest]
+		if touch == nil {
+			continue
+		}
+		touch.hitCount -= flushed.HitCount
+		touch.lastFlushedAt = now
 	}
+	r.prunePublicCacheTouches(touches, now)
 	return nil
-}
-
-func shouldQueuePublicCacheTouch(keyDigest string, lastTouch map[string]time.Time, now time.Time) bool {
-	if keyDigest == "" {
-		return false
-	}
-	if previous, ok := lastTouch[keyDigest]; ok && now.Sub(previous) < publicCacheTouchCoalesceInterval {
-		return false
-	}
-	lastTouch[keyDigest] = now
-	return true
 }
 
 func (r *observabilityRecorder) cleanup(ctx context.Context, now time.Time) {

--- a/internal/server/observability_recorder.go
+++ b/internal/server/observability_recorder.go
@@ -4,11 +4,20 @@ import (
 	"context"
 	"database/sql"
 	"net/http"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog/log"
 
 	"p2pstream/internal/db"
+)
+
+const (
+	observabilityRecorderQueueSize     = 8192
+	observabilityRecorderFlushInterval = 250 * time.Millisecond
+	observabilityRecorderMaxBatch      = 512
+	publicCacheTouchCoalesceInterval   = time.Minute
 )
 
 type proxyRequestEvent struct {
@@ -30,11 +39,32 @@ type proxyRequestEvent struct {
 }
 
 type observabilityRecorder struct {
-	app *App
+	app            *App
+	events         chan db.InsertProxyRequestEventAtParams
+	touches        chan string
+	control        chan observabilityRecorderRequest
+	done           chan struct{}
+	mu             sync.Mutex
+	startOnce      sync.Once
+	stopped        bool
+	droppedEvents  atomic.Int64
+	droppedTouches atomic.Int64
+}
+
+type observabilityRecorderRequest struct {
+	ctx  context.Context
+	done chan error
+	stop bool
 }
 
 func newObservabilityRecorder(app *App) *observabilityRecorder {
-	return &observabilityRecorder{app: app}
+	return &observabilityRecorder{
+		app:     app,
+		events:  make(chan db.InsertProxyRequestEventAtParams, observabilityRecorderQueueSize),
+		touches: make(chan string, observabilityRecorderQueueSize),
+		control: make(chan observabilityRecorderRequest),
+		done:    make(chan struct{}),
+	}
 }
 
 func (a *App) observabilityRecorderService() *observabilityRecorder {
@@ -46,6 +76,18 @@ func (a *App) observabilityRecorderService() *observabilityRecorder {
 	}
 	a.observabilityRecorder = newObservabilityRecorder(a)
 	return a.observabilityRecorder
+}
+
+func (a *App) flushObservabilityRecorder(ctx context.Context) error {
+	return a.FlushObservabilityRecorder(ctx)
+}
+
+func (a *App) FlushObservabilityRecorder(ctx context.Context) error {
+	return a.observabilityRecorderService().flush(ctx)
+}
+
+func (a *App) CloseObservabilityRecorder(ctx context.Context) error {
+	return a.observabilityRecorderService().close(ctx)
 }
 
 func (r *observabilityRecorder) recordProxyRequestEvent(ctx context.Context, event proxyRequestEvent) {
@@ -61,7 +103,14 @@ func (r *observabilityRecorder) recordProxyRequestEvent(ctx context.Context, eve
 	}
 
 	occurredAt := time.Now().UTC()
-	if err := a.insertProxyRequestEventWithRollups(ctx, db.InsertProxyRequestEventAtParams{
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.stopped {
+		return
+	}
+	r.startLocked()
+	select {
+	case r.events <- db.InsertProxyRequestEventAtParams{
 		OccurredAt:    occurredAt,
 		StatusCode:    int64(event.StatusCode),
 		DurationMs:    event.Duration.Milliseconds(),
@@ -80,9 +129,192 @@ func (r *observabilityRecorder) recordProxyRequestEvent(ctx context.Context, eve
 		CacheRuleID:   event.CacheRuleID,
 		CacheStatus:   event.CacheStatus,
 		CacheBytes:    int64FromUint64(event.CacheBytes),
-	}); err != nil {
-		log.Warn().Err(err).Msg("Failed to record proxy request event")
+	}:
+	default:
+		r.droppedEvents.Add(1)
+		log.Warn().Msg("Dropping proxy request event because observability recorder queue is full")
 	}
+	_ = ctx
+}
+
+func (r *observabilityRecorder) touchPublicCacheEntry(keyDigest string) {
+	if r == nil || r.app == nil || r.app.DB == nil || keyDigest == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.stopped {
+		return
+	}
+	r.startLocked()
+	select {
+	case r.touches <- keyDigest:
+	default:
+		r.droppedTouches.Add(1)
+		log.Warn().Msg("Dropping public cache touch because observability recorder queue is full")
+	}
+}
+
+func (r *observabilityRecorder) flush(ctx context.Context) error {
+	if r == nil || r.app == nil || r.app.DB == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	r.mu.Lock()
+	if r.stopped {
+		done := r.done
+		r.mu.Unlock()
+		select {
+		case <-done:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	r.startLocked()
+	done := make(chan error, 1)
+	req := observabilityRecorderRequest{ctx: ctx, done: done}
+	select {
+	case r.control <- req:
+		r.mu.Unlock()
+	case <-ctx.Done():
+		r.mu.Unlock()
+		return ctx.Err()
+	}
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (r *observabilityRecorder) close(ctx context.Context) error {
+	if r == nil || r.app == nil || r.app.DB == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	r.mu.Lock()
+	if r.stopped {
+		done := r.done
+		r.mu.Unlock()
+		select {
+		case <-done:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	r.stopped = true
+	r.startLocked()
+	done := make(chan error, 1)
+	req := observabilityRecorderRequest{ctx: ctx, done: done, stop: true}
+	select {
+	case r.control <- req:
+		r.mu.Unlock()
+	case <-ctx.Done():
+		r.stopped = false
+		r.mu.Unlock()
+		return ctx.Err()
+	}
+	select {
+	case err := <-done:
+		select {
+		case <-r.done:
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (r *observabilityRecorder) startLocked() {
+	r.startOnce.Do(func() {
+		go r.run()
+	})
+}
+
+func (r *observabilityRecorder) run() {
+	ticker := time.NewTicker(observabilityRecorderFlushInterval)
+	defer ticker.Stop()
+	var batch []db.InsertProxyRequestEventAtParams
+	touches := make(map[string]struct{})
+	lastTouch := make(map[string]time.Time)
+	for {
+		select {
+		case event := <-r.events:
+			batch = append(batch, event)
+			if len(batch) >= observabilityRecorderMaxBatch {
+				r.flushBatch(context.Background(), &batch, touches, lastTouch)
+			}
+		case keyDigest := <-r.touches:
+			if shouldQueuePublicCacheTouch(keyDigest, lastTouch, time.Now().UTC()) {
+				touches[keyDigest] = struct{}{}
+			}
+		case req := <-r.control:
+			r.drainAvailable(&batch, touches, lastTouch)
+			req.done <- r.flushBatch(req.ctx, &batch, touches, lastTouch)
+			if req.stop {
+				close(r.done)
+				return
+			}
+		case <-ticker.C:
+			r.drainAvailable(&batch, touches, lastTouch)
+			r.flushBatch(context.Background(), &batch, touches, lastTouch)
+		}
+	}
+}
+
+func (r *observabilityRecorder) drainAvailable(batch *[]db.InsertProxyRequestEventAtParams, touches map[string]struct{}, lastTouch map[string]time.Time) {
+	for {
+		select {
+		case event := <-r.events:
+			*batch = append(*batch, event)
+		case keyDigest := <-r.touches:
+			if shouldQueuePublicCacheTouch(keyDigest, lastTouch, time.Now().UTC()) {
+				touches[keyDigest] = struct{}{}
+			}
+		default:
+			return
+		}
+	}
+}
+
+func (r *observabilityRecorder) flushBatch(ctx context.Context, batch *[]db.InsertProxyRequestEventAtParams, touches map[string]struct{}, lastTouch map[string]time.Time) error {
+	if len(*batch) == 0 && len(touches) == 0 {
+		return nil
+	}
+	events := append([]db.InsertProxyRequestEventAtParams(nil), (*batch)...)
+	touchKeys := make([]string, 0, len(touches))
+	for keyDigest := range touches {
+		touchKeys = append(touchKeys, keyDigest)
+	}
+	if err := r.app.insertProxyRequestEventsWithRollupsAndCacheTouches(ctx, events, touchKeys); err != nil {
+		log.Warn().Err(err).Msg("Failed to flush observability recorder")
+		return err
+	}
+	*batch = (*batch)[:0]
+	for keyDigest := range touches {
+		delete(touches, keyDigest)
+	}
+	return nil
+}
+
+func shouldQueuePublicCacheTouch(keyDigest string, lastTouch map[string]time.Time, now time.Time) bool {
+	if keyDigest == "" {
+		return false
+	}
+	if previous, ok := lastTouch[keyDigest]; ok && now.Sub(previous) < publicCacheTouchCoalesceInterval {
+		return false
+	}
+	lastTouch[keyDigest] = now
+	return true
 }
 
 func (r *observabilityRecorder) cleanup(ctx context.Context, now time.Time) {

--- a/internal/server/observability_rollup.go
+++ b/internal/server/observability_rollup.go
@@ -22,7 +22,7 @@ func (a *App) insertProxyRequestEventWithRollups(ctx context.Context, event db.I
 	return a.insertProxyRequestEventsWithRollupsAndCacheTouches(ctx, []db.InsertProxyRequestEventAtParams{event}, nil)
 }
 
-func (a *App) insertProxyRequestEventsWithRollupsAndCacheTouches(ctx context.Context, events []db.InsertProxyRequestEventAtParams, cacheTouches []string) error {
+func (a *App) insertProxyRequestEventsWithRollupsAndCacheTouches(ctx context.Context, events []db.InsertProxyRequestEventAtParams, cacheTouches []db.TouchPublicCacheEntryParams) error {
 	if a.DB == nil {
 		return nil
 	}
@@ -64,11 +64,11 @@ func (a *App) insertProxyRequestEventsWithRollupsAndCacheTouches(ctx context.Con
 			return err
 		}
 	}
-	for _, keyDigest := range cacheTouches {
-		if keyDigest == "" {
+	for _, touch := range cacheTouches {
+		if touch.KeyDigest == "" || touch.HitCount <= 0 {
 			continue
 		}
-		if err := qtx.TouchPublicCacheEntry(ctx, keyDigest); err != nil {
+		if err := qtx.TouchPublicCacheEntry(ctx, touch); err != nil {
 			return err
 		}
 	}

--- a/internal/server/observability_rollup.go
+++ b/internal/server/observability_rollup.go
@@ -65,7 +65,7 @@ func (a *App) insertProxyRequestEventsWithRollupsAndCacheTouches(ctx context.Con
 		}
 	}
 	for _, touch := range cacheTouches {
-		if touch.KeyDigest == "" || touch.HitCount <= 0 {
+		if touch.KeyDigest == "" || touch.StoredAt.IsZero() || touch.LastAccessedAt.IsZero() || touch.HitCount <= 0 {
 			continue
 		}
 		if err := qtx.TouchPublicCacheEntry(ctx, touch); err != nil {

--- a/internal/server/observability_rollup.go
+++ b/internal/server/observability_rollup.go
@@ -19,7 +19,14 @@ const (
 )
 
 func (a *App) insertProxyRequestEventWithRollups(ctx context.Context, event db.InsertProxyRequestEventAtParams) error {
+	return a.insertProxyRequestEventsWithRollupsAndCacheTouches(ctx, []db.InsertProxyRequestEventAtParams{event}, nil)
+}
+
+func (a *App) insertProxyRequestEventsWithRollupsAndCacheTouches(ctx context.Context, events []db.InsertProxyRequestEventAtParams, cacheTouches []string) error {
 	if a.DB == nil {
+		return nil
+	}
+	if len(events) == 0 && len(cacheTouches) == 0 {
 		return nil
 	}
 
@@ -30,20 +37,132 @@ func (a *App) insertProxyRequestEventWithRollups(ctx context.Context, event db.I
 	defer tx.Rollback()
 
 	qtx := a.DB.WithTx(tx)
-	if _, err := qtx.InsertProxyRequestEventAt(ctx, event); err != nil {
-		return err
+	totals := make(map[int64]db.UpsertProxyRequestRollupMinuteParams)
+	tuples := make(map[proxyRequestTupleRollupKey]db.UpsertProxyRequestTupleRollupMinuteParams)
+	statuses := make(map[proxyRequestStatusRollupKey]db.UpsertProxyRequestStatusRollupMinuteParams)
+	for _, event := range events {
+		if _, err := qtx.InsertProxyRequestEventAt(ctx, event); err != nil {
+			return err
+		}
+		total, tuple, status := proxyRequestRollupParams(event)
+		mergeProxyRequestRollup(totals, total)
+		mergeProxyRequestTupleRollup(tuples, tuple)
+		mergeProxyRequestStatusRollup(statuses, status)
 	}
-	total, tuple, status := proxyRequestRollupParams(event)
-	if err := qtx.UpsertProxyRequestRollupMinute(ctx, total); err != nil {
-		return err
+	for _, total := range totals {
+		if err := qtx.UpsertProxyRequestRollupMinute(ctx, total); err != nil {
+			return err
+		}
 	}
-	if err := qtx.UpsertProxyRequestTupleRollupMinute(ctx, tuple); err != nil {
-		return err
+	for _, tuple := range tuples {
+		if err := qtx.UpsertProxyRequestTupleRollupMinute(ctx, tuple); err != nil {
+			return err
+		}
 	}
-	if err := qtx.UpsertProxyRequestStatusRollupMinute(ctx, status); err != nil {
-		return err
+	for _, status := range statuses {
+		if err := qtx.UpsertProxyRequestStatusRollupMinute(ctx, status); err != nil {
+			return err
+		}
+	}
+	for _, keyDigest := range cacheTouches {
+		if keyDigest == "" {
+			continue
+		}
+		if err := qtx.TouchPublicCacheEntry(ctx, keyDigest); err != nil {
+			return err
+		}
 	}
 	return tx.Commit()
+}
+
+type proxyRequestTupleRollupKey struct {
+	BucketUnixMillis int64
+	ListenerID       int64
+	RouteTargetID    int64
+	RouteID          int64
+	AgentID          int64
+	ErrorKind        string
+	StatusClass      int64
+}
+
+type proxyRequestStatusRollupKey struct {
+	BucketUnixMillis int64
+	StatusCode       int64
+}
+
+func mergeProxyRequestRollup(totals map[int64]db.UpsertProxyRequestRollupMinuteParams, next db.UpsertProxyRequestRollupMinuteParams) {
+	current, ok := totals[next.BucketUnixMillis]
+	if !ok {
+		totals[next.BucketUnixMillis] = next
+		return
+	}
+	current.Requests += next.Requests
+	current.Success += next.Success
+	current.ClientError += next.ClientError
+	current.ServerError += next.ServerError
+	current.InternalError += next.InternalError
+	current.DurationMsSum += next.DurationMsSum
+	if next.MaxDurationMs > current.MaxDurationMs {
+		current.MaxDurationMs = next.MaxDurationMs
+	}
+	current.SlowRequests += next.SlowRequests
+	current.RequestBytes += next.RequestBytes
+	current.ResponseBytes += next.ResponseBytes
+	current.CacheHits += next.CacheHits
+	current.CacheMisses += next.CacheMisses
+	current.CacheBypasses += next.CacheBypasses
+	current.CacheStored += next.CacheStored
+	current.CacheStoreFailed += next.CacheStoreFailed
+	current.CacheHitBytes += next.CacheHitBytes
+	current.CacheStoredBytes += next.CacheStoredBytes
+	totals[next.BucketUnixMillis] = current
+}
+
+func mergeProxyRequestTupleRollup(tuples map[proxyRequestTupleRollupKey]db.UpsertProxyRequestTupleRollupMinuteParams, next db.UpsertProxyRequestTupleRollupMinuteParams) {
+	key := proxyRequestTupleRollupKey{
+		BucketUnixMillis: next.BucketUnixMillis,
+		ListenerID:       next.ListenerID,
+		RouteTargetID:    next.RouteTargetID,
+		RouteID:          next.RouteID,
+		AgentID:          next.AgentID,
+		ErrorKind:        next.ErrorKind,
+		StatusClass:      next.StatusClass,
+	}
+	current, ok := tuples[key]
+	if !ok {
+		tuples[key] = next
+		return
+	}
+	current.Requests += next.Requests
+	current.Success += next.Success
+	current.ClientError += next.ClientError
+	current.ServerError += next.ServerError
+	current.InternalError += next.InternalError
+	current.DurationMsSum += next.DurationMsSum
+	current.RequestBytes += next.RequestBytes
+	current.ResponseBytes += next.ResponseBytes
+	tuples[key] = current
+}
+
+func mergeProxyRequestStatusRollup(statuses map[proxyRequestStatusRollupKey]db.UpsertProxyRequestStatusRollupMinuteParams, next db.UpsertProxyRequestStatusRollupMinuteParams) {
+	key := proxyRequestStatusRollupKey{
+		BucketUnixMillis: next.BucketUnixMillis,
+		StatusCode:       next.StatusCode,
+	}
+	current, ok := statuses[key]
+	if !ok {
+		statuses[key] = next
+		return
+	}
+	current.Requests += next.Requests
+	current.Success += next.Success
+	current.ClientError += next.ClientError
+	current.ServerError += next.ServerError
+	current.InternalError += next.InternalError
+	current.DurationMsSum += next.DurationMsSum
+	current.RequestBytes += next.RequestBytes
+	current.ResponseBytes += next.ResponseBytes
+	statuses[key] = current
 }
 
 func (a *App) insertAgentStatWithRollup(ctx context.Context, stat db.InsertAgentStatAtParams) error {

--- a/internal/server/proxy_lifecycle.go
+++ b/internal/server/proxy_lifecycle.go
@@ -136,6 +136,9 @@ func (a *App) stopProxy(ctx context.Context) (*p2pstreamv1.ProxyStatus, error) {
 	if a.TargetHealth != nil {
 		a.TargetHealth.reconcile(a, nil, false)
 	}
+	if err := a.FlushObservabilityRecorder(ctx); err != nil {
+		log.Warn().Err(err).Msg("Failed to flush observability recorder after stopping proxy")
+	}
 	if shutdownErr != nil {
 		return status, connect.NewError(connect.CodeInternal, shutdownErr)
 	}

--- a/internal/server/public_cache.go
+++ b/internal/server/public_cache.go
@@ -433,7 +433,7 @@ func (a *App) checkPublicCache(r *http.Request, resolution publicRouteResolution
 		entryCopy := entry
 		decision.Entry = &entryCopy
 		decision.LookupDuration = time.Since(startedAt)
-		_ = a.DB.TouchPublicCacheEntry(context.Background(), entry.KeyDigest)
+		a.observabilityRecorderService().touchPublicCacheEntry(entry.KeyDigest)
 		return decision
 	}
 	decision.Status = publicCacheStatusMiss

--- a/internal/server/public_cache.go
+++ b/internal/server/public_cache.go
@@ -612,10 +612,8 @@ func (c *publicProxyCache) lookupIndexedCandidates(lookupKey publicCacheLookupKe
 			delete(digests, key)
 			continue
 		}
-		if !indexEntry.entry.ExpiresAt.After(now) {
-			c.deleteEntryLocked(key)
-			continue
-		}
+		// Return expired entries to the caller as well. The caller owns the
+		// database and body-file cleanup, which must happen outside this mutex.
 		candidates = append(candidates, indexEntry.entry)
 	}
 	if len(digests) == 0 {
@@ -897,8 +895,7 @@ func (a *App) checkPublicCacheWithSnapshot(snap *publicProxySnapshot, r *http.Re
 			continue
 		}
 		if !entry.ExpiresAt.After(now) {
-			_ = a.DB.DeletePublicCacheEntry(context.Background(), entry.KeyDigest)
-			a.PublicCache.deleteEntry(entry.KeyDigest)
+			a.invalidatePublicCacheEntry(entry)
 			continue
 		}
 		decision.Status = publicCacheStatusHit
@@ -1115,17 +1112,24 @@ func (a *App) preparePublicCacheHitBody(r *http.Request, decision *publicCacheDe
 	if r.Method == http.MethodHead || decision.Entry.SizeBytes == 0 {
 		return true
 	}
-	if body := a.PublicCache.getMemory(decision.Entry.KeyDigest); len(body) > 0 {
-		decision.HitBody = io.NopCloser(bytes.NewReader(body))
-		return true
-	}
-	file, err := os.Open(decision.Entry.BodyPath)
+	body, err := a.openPublicCacheHitBody(*decision.Entry)
 	if err != nil {
-		a.invalidatePublicCacheEntry(*decision.Entry)
 		return false
 	}
-	decision.HitBody = file
+	decision.HitBody = body
 	return true
+}
+
+func (a *App) openPublicCacheHitBody(entry db.PublicCacheEntry) (io.ReadCloser, error) {
+	if body := a.PublicCache.getMemory(entry.KeyDigest); len(body) > 0 {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+	file, err := os.Open(entry.BodyPath)
+	if err != nil {
+		a.invalidatePublicCacheEntry(entry)
+		return nil, err
+	}
+	return file, nil
 }
 
 func (a *App) invalidatePublicCacheEntry(entry db.PublicCacheEntry) {
@@ -1182,18 +1186,15 @@ func (a *App) servePublicCacheHit(w http.ResponseWriter, r *http.Request, resolu
 	if r.Method != http.MethodHead && decision.Entry.SizeBytes > 0 {
 		if decision.HitBody != nil {
 			body = decision.HitBody
-		} else if memoryBody := a.PublicCache.getMemory(decision.Entry.KeyDigest); len(memoryBody) > 0 {
-			body = io.NopCloser(bytes.NewReader(memoryBody))
 		} else {
-			file, err := os.Open(decision.Entry.BodyPath)
+			var err error
+			body, err = a.openPublicCacheHitBody(*decision.Entry)
 			if err != nil {
-				a.invalidatePublicCacheEntry(*decision.Entry)
 				statusCode = http.StatusInternalServerError
 				errorKind = "cache_body_missing"
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 				return
 			}
-			body = file
 		}
 		if shaper != nil {
 			body = shaper.wrapDownloadBody(r.Context(), body)

--- a/internal/server/public_cache.go
+++ b/internal/server/public_cache.go
@@ -724,7 +724,9 @@ func (c *publicProxyCache) touchIndexedEntry(key string, storedAt time.Time, now
 	if !ok || !indexEntry.entry.StoredAt.Equal(storedAt) {
 		return
 	}
-	indexEntry.entry.LastAccessedAt = now
+	if now.After(indexEntry.entry.LastAccessedAt) {
+		indexEntry.entry.LastAccessedAt = now
+	}
 	indexEntry.entry.HitCount++
 	c.indexEntries[key] = indexEntry
 }

--- a/internal/server/public_cache.go
+++ b/internal/server/public_cache.go
@@ -161,6 +161,7 @@ type publicProxyCache struct {
 	negativeOrder   *list.List
 	memoryBytes     int64
 	lastFingerprint string
+	lastStoredAt    time.Time
 	generation      uint64
 }
 
@@ -369,6 +370,20 @@ func (c *publicProxyCache) memoryHotObjectMaxBytesSnapshot() int64 {
 		return 0
 	}
 	return c.settings.MemoryHotObjectMaxBytes
+}
+
+func (c *publicProxyCache) nextStoredAt() time.Time {
+	now := time.Now().UTC().Round(0)
+	if c == nil {
+		return now
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !now.After(c.lastStoredAt) {
+		now = c.lastStoredAt.Add(time.Nanosecond)
+	}
+	c.lastStoredAt = now
+	return now
 }
 
 func (c *publicProxyCache) cacheDir() string {
@@ -693,15 +708,20 @@ func (c *publicProxyCache) putIndexEntryLocked(entry db.PublicCacheEntry) bool {
 // touchIndexedEntry keeps the in-memory index consistent with hits queued for
 // the observability recorder. Database hit counts are updated only by that
 // recorder so coalescing cannot double-count a cache hit.
-func (c *publicProxyCache) touchIndexedEntry(key string, now time.Time) {
-	if c == nil || key == "" {
+func (c *publicProxyCache) touchIndexedEntry(key string, storedAt time.Time, now time.Time) {
+	if c == nil || key == "" || storedAt.IsZero() {
 		return
+	}
+	storedAt = storedAt.UTC().Round(0)
+	now = now.UTC().Round(0)
+	if now.Before(storedAt) {
+		now = storedAt
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.ensureIndexLocked()
 	indexEntry, ok := c.indexEntries[key]
-	if !ok {
+	if !ok || !indexEntry.entry.StoredAt.Equal(storedAt) {
 		return
 	}
 	indexEntry.entry.LastAccessedAt = now
@@ -884,8 +904,8 @@ func (a *App) checkPublicCacheWithSnapshot(snap *publicProxySnapshot, r *http.Re
 		entryCopy := entry
 		decision.Entry = &entryCopy
 		decision.LookupDuration = time.Since(startedAt)
-		a.PublicCache.touchIndexedEntry(entry.KeyDigest, now)
-		a.observabilityRecorderService().touchPublicCacheEntry(entry.KeyDigest)
+		a.PublicCache.touchIndexedEntry(entry.KeyDigest, entry.StoredAt, now)
+		a.observabilityRecorderService().touchPublicCacheEntry(entry.KeyDigest, entry.StoredAt, now)
 		return decision
 	}
 	decision.Status = publicCacheStatusMiss
@@ -1374,6 +1394,7 @@ func (r *publicCacheStoreReadCloser) commit() {
 			routeTargetID = sql.NullInt64{Int64: r.resolution.Target.ID, Valid: true}
 		}
 	}
+	storedAt := r.app.PublicCache.nextStoredAt()
 	entry, err := r.app.DB.UpsertPublicCacheEntry(context.Background(), db.UpsertPublicCacheEntryParams{
 		KeyDigest:           r.keyDigest,
 		RuleID:              r.rule.ID,
@@ -1390,6 +1411,7 @@ func (r *publicCacheStoreReadCloser) commit() {
 		StatusCode:          r.statusCode,
 		BodyPath:            r.finalPath,
 		SizeBytes:           r.bytesWritten,
+		StoredAt:            storedAt,
 		ExpiresAt:           r.expiresAt,
 	})
 	if err != nil {

--- a/internal/server/public_cache.go
+++ b/internal/server/public_cache.go
@@ -149,8 +149,10 @@ type publicProxyCache struct {
 	dir string
 
 	// storeGate lets cache writes run concurrently while making a configuration
-	// invalidation atomic with respect to the final database commit.
+	// invalidation atomic with respect to the final database commit. Stores for
+	// the same digest also share a stripe because they reuse one body path.
 	storeGate       sync.RWMutex
+	storeStripes    [64]sync.Mutex
 	mu              sync.Mutex
 	settings        publicCacheSettingsConfig
 	lastCleanup     time.Time
@@ -163,10 +165,13 @@ type publicProxyCache struct {
 	lastFingerprint string
 	lastStoredAt    time.Time
 	generation      uint64
+	invalidateHook  func()
+	upsertHook      func(context.Context, db.UpsertPublicCacheEntryParams) (db.PublicCacheEntry, error)
 }
 
 type publicCacheMemoryEntry struct {
 	body         []byte
+	storedAt     time.Time
 	lastAccessed time.Time
 }
 
@@ -267,11 +272,18 @@ func (c *publicProxyCache) invalidateEntries() {
 		return
 	}
 	c.storeGate.Lock()
+	defer c.storeGate.Unlock()
+	c.invalidateEntriesLocked()
+}
+
+func (c *publicProxyCache) invalidateEntriesLocked() {
+	if c == nil {
+		return
+	}
 	c.mu.Lock()
 	c.generation++
 	c.clearIndexLocked()
 	c.mu.Unlock()
-	c.storeGate.Unlock()
 }
 
 func (c *publicProxyCache) captureGeneration(fingerprint string) (uint64, bool) {
@@ -292,22 +304,36 @@ func (c *publicProxyCache) generationMatches(generation uint64, fingerprint stri
 	return c.settings.Enabled && c.generation == generation && c.lastFingerprint == fingerprint
 }
 
-func (c *publicProxyCache) acquireStoreGeneration(generation uint64, fingerprint string) bool {
-	if c == nil {
+func (c *publicProxyCache) storeStripe(key string) *sync.Mutex {
+	if c == nil || key == "" {
+		return nil
+	}
+	sum := sha256.Sum256([]byte(key))
+	return &c.storeStripes[int(sum[0])%len(c.storeStripes)]
+}
+
+func (c *publicProxyCache) acquireStoreGeneration(key string, generation uint64, fingerprint string) bool {
+	stripe := c.storeStripe(key)
+	if stripe == nil {
 		return false
 	}
+	stripe.Lock()
 	c.storeGate.RLock()
 	if c.generationMatches(generation, fingerprint) {
 		return true
 	}
 	c.storeGate.RUnlock()
+	stripe.Unlock()
 	return false
 }
 
-func (c *publicProxyCache) releaseStoreGeneration() {
-	if c != nil {
-		c.storeGate.RUnlock()
+func (c *publicProxyCache) releaseStoreGeneration(key string) {
+	stripe := c.storeStripe(key)
+	if stripe == nil {
+		return
 	}
+	c.storeGate.RUnlock()
+	stripe.Unlock()
 }
 
 func publicCacheRuntimeFingerprint(settings publicCacheSettingsConfig, rules []publicCacheRuleConfig) string {
@@ -407,24 +433,26 @@ func (c *publicProxyCache) tempDir() string {
 	return filepath.Join(c.cacheDir(), "tmp")
 }
 
-func (c *publicProxyCache) getMemory(key string) []byte {
-	if c == nil {
+func (c *publicProxyCache) getMemory(key string, storedAt time.Time) []byte {
+	if c == nil || storedAt.IsZero() {
 		return nil
 	}
+	storedAt = storedAt.UTC().Round(0)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	entry := c.memoryEntries[key]
-	if entry == nil {
+	if entry == nil || !entry.storedAt.Equal(storedAt) {
 		return nil
 	}
 	entry.lastAccessed = time.Now()
 	return append([]byte(nil), entry.body...)
 }
 
-func (c *publicProxyCache) putMemory(key string, body []byte) {
-	if c == nil || key == "" || len(body) == 0 {
+func (c *publicProxyCache) putMemory(key string, storedAt time.Time, body []byte) {
+	if c == nil || key == "" || storedAt.IsZero() || len(body) == 0 {
 		return
 	}
+	storedAt = storedAt.UTC().Round(0)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if !c.settings.Enabled || c.settings.MaxMemoryBytes <= 0 || int64(len(body)) > c.settings.MemoryHotObjectMaxBytes {
@@ -433,7 +461,7 @@ func (c *publicProxyCache) putMemory(key string, body []byte) {
 	if existing := c.memoryEntries[key]; existing != nil {
 		c.memoryBytes -= int64(len(existing.body))
 	}
-	c.memoryEntries[key] = &publicCacheMemoryEntry{body: append([]byte(nil), body...), lastAccessed: time.Now()}
+	c.memoryEntries[key] = &publicCacheMemoryEntry{body: append([]byte(nil), body...), storedAt: storedAt, lastAccessed: time.Now()}
 	c.memoryBytes += int64(len(body))
 	c.pruneMemoryLocked()
 }
@@ -461,6 +489,29 @@ func (c *publicProxyCache) deleteEntry(key string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.deleteEntryLocked(key)
+}
+
+func (c *publicProxyCache) deleteEntryGeneration(key string, storedAt time.Time) {
+	if c == nil || key == "" || storedAt.IsZero() {
+		return
+	}
+	storedAt = storedAt.UTC().Round(0)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if memoryEntry := c.memoryEntries[key]; memoryEntry != nil && memoryEntry.storedAt.Equal(storedAt) {
+		c.deleteMemoryLocked(key)
+	}
+	indexEntry, ok := c.indexEntries[key]
+	if !ok || !indexEntry.entry.StoredAt.Equal(storedAt) {
+		return
+	}
+	delete(c.indexEntries, key)
+	if digests := c.indexLookups[indexEntry.lookupKey]; digests != nil {
+		delete(digests, key)
+		if len(digests) == 0 {
+			delete(c.indexLookups, indexEntry.lookupKey)
+		}
+	}
 }
 
 func (c *publicProxyCache) deleteEntryLocked(key string) {
@@ -777,6 +828,8 @@ func (c *publicProxyCache) maybeCleanup(ctx context.Context, q *db.DB) {
 	c.lastCleanup = now
 	settings := c.settings
 	c.mu.Unlock()
+	c.storeGate.Lock()
+	defer c.storeGate.Unlock()
 
 	rows, err := q.DeleteExpiredPublicCacheEntries(ctx, now)
 	if err == nil {
@@ -1121,7 +1174,7 @@ func (a *App) preparePublicCacheHitBody(r *http.Request, decision *publicCacheDe
 }
 
 func (a *App) openPublicCacheHitBody(entry db.PublicCacheEntry) (io.ReadCloser, error) {
-	if body := a.PublicCache.getMemory(entry.KeyDigest); len(body) > 0 {
+	if body := a.PublicCache.getMemory(entry.KeyDigest, entry.StoredAt); len(body) > 0 {
 		return io.NopCloser(bytes.NewReader(body)), nil
 	}
 	file, err := os.Open(entry.BodyPath)
@@ -1133,14 +1186,26 @@ func (a *App) openPublicCacheHitBody(entry db.PublicCacheEntry) (io.ReadCloser, 
 }
 
 func (a *App) invalidatePublicCacheEntry(entry db.PublicCacheEntry) {
-	if a == nil {
+	if a == nil || a.DB == nil || entry.KeyDigest == "" || entry.StoredAt.IsZero() {
 		return
 	}
-	if a.DB != nil && entry.KeyDigest != "" {
-		_ = a.DB.DeletePublicCacheEntry(context.Background(), entry.KeyDigest)
+	if a.PublicCache != nil {
+		a.PublicCache.storeGate.Lock()
+		defer a.PublicCache.storeGate.Unlock()
+		if a.PublicCache.invalidateHook != nil {
+			a.PublicCache.invalidateHook()
+		}
+	}
+	deleted, err := a.DB.DeletePublicCacheEntryGeneration(context.Background(), db.DeletePublicCacheEntryGenerationParams{
+		KeyDigest:      entry.KeyDigest,
+		StoredAt:       entry.StoredAt,
+		StoredAtLegacy: entry.StoredAt.UTC().Format(sqliteLegacyTimestampLayout),
+	})
+	if err != nil || deleted == 0 {
+		return
 	}
 	if a.PublicCache != nil {
-		a.PublicCache.deleteEntry(entry.KeyDigest)
+		a.PublicCache.deleteEntryGeneration(entry.KeyDigest, entry.StoredAt)
 	}
 	if entry.BodyPath != "" {
 		_ = os.Remove(entry.BodyPath)
@@ -1371,17 +1436,33 @@ func (r *publicCacheStoreReadCloser) commit() {
 		r.discard()
 		return
 	}
-	if r.app == nil || r.app.PublicCache == nil || !r.app.PublicCache.acquireStoreGeneration(r.cacheGeneration, r.cacheFingerprint) {
+	if r.app == nil || r.app.PublicCache == nil || !r.app.PublicCache.acquireStoreGeneration(r.keyDigest, r.cacheGeneration, r.cacheFingerprint) {
 		r.discard()
 		return
 	}
-	defer r.app.PublicCache.releaseStoreGeneration()
+	defer r.app.PublicCache.releaseStoreGeneration(r.keyDigest)
 	if err := r.tmp.Close(); err != nil {
 		r.markStoreFailed()
 		r.discard()
 		return
 	}
+	backupPath := ""
+	if _, err := os.Stat(r.finalPath); err == nil {
+		backupPath = r.tmpPath + ".previous"
+		if err := os.Link(r.finalPath, backupPath); err != nil {
+			r.markStoreFailed()
+			r.discard()
+			return
+		}
+	} else if !os.IsNotExist(err) {
+		r.markStoreFailed()
+		r.discard()
+		return
+	}
 	if err := os.Rename(r.tmpPath, r.finalPath); err != nil {
+		if backupPath != "" {
+			_ = os.Remove(backupPath)
+		}
 		r.markStoreFailed()
 		r.discard()
 		return
@@ -1398,7 +1479,7 @@ func (r *publicCacheStoreReadCloser) commit() {
 		}
 	}
 	storedAt := r.app.PublicCache.nextStoredAt()
-	entry, err := r.app.DB.UpsertPublicCacheEntry(context.Background(), db.UpsertPublicCacheEntryParams{
+	params := db.UpsertPublicCacheEntryParams{
 		KeyDigest:           r.keyDigest,
 		RuleID:              r.rule.ID,
 		Scope:               r.rule.Scope,
@@ -1416,13 +1497,27 @@ func (r *publicCacheStoreReadCloser) commit() {
 		SizeBytes:           r.bytesWritten,
 		StoredAt:            storedAt,
 		ExpiresAt:           r.expiresAt,
-	})
+	}
+	upsert := r.app.DB.UpsertPublicCacheEntry
+	if r.app.PublicCache.upsertHook != nil {
+		upsert = r.app.PublicCache.upsertHook
+	}
+	entry, err := upsert(context.Background(), params)
 	if err != nil {
-		_ = os.Remove(r.finalPath)
-		r.app.PublicCache.deleteEntry(r.keyDigest)
+		if backupPath == "" {
+			_ = os.Remove(r.finalPath)
+		} else if restoreErr := os.Rename(backupPath, r.finalPath); restoreErr != nil {
+			_ = os.Remove(r.finalPath)
+			if retryErr := os.Rename(backupPath, r.finalPath); retryErr != nil {
+				log.Error().Err(retryErr).Str("cache_key", r.keyDigest).Msg("Failed to restore previous public cache body")
+			}
+		}
 		r.markStoreFailed()
 		log.Warn().Err(err).Str("cache_key", r.keyDigest).Msg("Failed to store public cache entry")
 		return
+	}
+	if backupPath != "" {
+		_ = os.Remove(backupPath)
 	}
 	r.app.PublicCache.putIndexEntry(entry)
 	if r.decision != nil {
@@ -1431,7 +1526,7 @@ func (r *publicCacheStoreReadCloser) commit() {
 		r.decision.StoredBytes = r.bytesWritten
 	}
 	if r.memoryBuffer != nil {
-		r.app.PublicCache.putMemory(r.keyDigest, r.memoryBuffer.Bytes())
+		r.app.PublicCache.putMemory(r.keyDigest, entry.StoredAt, r.memoryBuffer.Bytes())
 	}
 	if r.trace != nil {
 		resolution := r.resolution
@@ -2065,6 +2160,8 @@ func (a *App) purgePublicCacheEntriesByRuleID(ctx context.Context, ruleID int64)
 	if a == nil || a.DB == nil || a.PublicCache == nil || ruleID <= 0 {
 		return nil
 	}
+	a.PublicCache.storeGate.Lock()
+	defer a.PublicCache.storeGate.Unlock()
 	rows, err := a.DB.PurgePublicCacheEntriesByRule(ctx, ruleID)
 	if err != nil {
 		return err
@@ -2102,11 +2199,13 @@ func (a *App) PurgePublicCache(ctx context.Context, req *connect.Request[p2pstre
 	if a.PublicCache == nil {
 		return connect.NewResponse(&p2pstreamv1.PurgePublicCacheResponse{}), nil
 	}
+	a.PublicCache.storeGate.Lock()
+	defer a.PublicCache.storeGate.Unlock()
 	var rows []db.PurgeAllPublicCacheEntriesRow
 	var purgedEntries int64
 	var purgedBytes int64
 	if req.Msg.All {
-		a.PublicCache.invalidateEntries()
+		a.PublicCache.invalidateEntriesLocked()
 		var err error
 		rows, err = a.DB.PurgeAllPublicCacheEntries(ctx)
 		if err != nil {
@@ -2119,7 +2218,7 @@ func (a *App) PurgePublicCache(ctx context.Context, req *connect.Request[p2pstre
 			purgedBytes += row.SizeBytes
 		}
 	} else if req.Msg.RuleId > 0 {
-		a.PublicCache.invalidateEntries()
+		a.PublicCache.invalidateEntriesLocked()
 		ruleRows, err := a.DB.PurgePublicCacheEntriesByRule(ctx, req.Msg.RuleId)
 		if err != nil {
 			return nil, publicDBError(err)
@@ -2139,7 +2238,7 @@ func (a *App) PurgePublicCache(ctx context.Context, req *connect.Request[p2pstre
 		if pathPrefix != "" && !strings.HasPrefix(pathPrefix, "/") {
 			return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("cache purge path prefix must start with /"))
 		}
-		a.PublicCache.invalidateEntries()
+		a.PublicCache.invalidateEntriesLocked()
 		hostRows, err := a.DB.PurgePublicCacheEntriesByHostPath(ctx, db.PurgePublicCacheEntriesByHostPathParams{
 			Column1: host,
 			Host:    host,

--- a/internal/server/public_cache.go
+++ b/internal/server/public_cache.go
@@ -492,11 +492,16 @@ func publicCacheLookupKeyHash(lookupKey publicCacheLookupKey) publicCacheLookupD
 	return sha256.Sum256(data)
 }
 
-func (c *publicProxyCache) negativeLookupLimitLocked() int {
+func (c *publicProxyCache) maxIndexEntriesLocked() int64 {
 	maxEntries := c.settings.MaxEntries
 	if maxEntries <= 0 {
 		maxEntries = defaultPublicCacheMaxEntries
 	}
+	return maxEntries
+}
+
+func (c *publicProxyCache) negativeLookupLimitLocked() int {
+	maxEntries := c.maxIndexEntriesLocked()
 	remaining := maxEntries - int64(len(c.indexEntries))
 	if remaining <= 0 {
 		return 0
@@ -617,12 +622,25 @@ func (c *publicProxyCache) storeIndexedCandidates(lookupKey publicCacheLookupKey
 	}
 	stored := false
 	for _, entry := range candidates {
-		if !entry.ExpiresAt.After(now) {
-			c.deleteEntryLocked(entry.KeyDigest)
+		// Another cold lookup may have installed and touched this digest while the
+		// current database read was in flight. Never replace that newer in-memory
+		// state with the stale row returned by this read.
+		if existing, ok := c.indexEntries[entry.KeyDigest]; ok {
+			if existing.lookupKey == lookupKey && existing.entry.ExpiresAt.After(now) {
+				stored = true
+			}
 			continue
 		}
-		c.putIndexEntryLocked(entry)
+		if !entry.ExpiresAt.After(now) {
+			continue
+		}
+		if publicCacheLookupKeyFromEntry(entry) != lookupKey {
+			continue
+		}
+		// A valid database candidate satisfies this lookup even when the positive
+		// index is already at capacity and cannot retain the row.
 		stored = true
+		c.putIndexEntryLocked(entry)
 	}
 	if !stored {
 		c.rememberNegativeLookupLocked(lookupKey, now)
@@ -639,12 +657,20 @@ func (c *publicProxyCache) putIndexEntry(entry db.PublicCacheEntry) {
 	c.putIndexEntryLocked(entry)
 }
 
-func (c *publicProxyCache) putIndexEntryLocked(entry db.PublicCacheEntry) {
+func (c *publicProxyCache) putIndexEntryLocked(entry db.PublicCacheEntry) bool {
 	if entry.KeyDigest == "" {
-		return
+		return false
 	}
 	lookupKey := publicCacheLookupKeyFromEntry(entry)
-	if existing, ok := c.indexEntries[entry.KeyDigest]; ok && existing.lookupKey != lookupKey {
+	existing, exists := c.indexEntries[entry.KeyDigest]
+	if !exists && int64(len(c.indexEntries)) >= c.maxIndexEntriesLocked() {
+		// Do not retain a contradictory negative result for a positive row that
+		// was deliberately left uncached because the positive index is full.
+		c.removeNegativeLookupLocked(lookupKey)
+		c.pruneNegativeLookupsLocked(time.Now())
+		return false
+	}
+	if exists && existing.lookupKey != lookupKey {
 		if digests := c.indexLookups[existing.lookupKey]; digests != nil {
 			delete(digests, entry.KeyDigest)
 			if len(digests) == 0 {
@@ -661,6 +687,7 @@ func (c *publicProxyCache) putIndexEntryLocked(entry db.PublicCacheEntry) {
 	digests[entry.KeyDigest] = struct{}{}
 	c.removeNegativeLookupLocked(lookupKey)
 	c.pruneNegativeLookupsLocked(time.Now())
+	return true
 }
 
 // touchIndexedEntry keeps the in-memory index consistent with hits queued for

--- a/internal/server/public_cache.go
+++ b/internal/server/public_cache.go
@@ -71,6 +71,8 @@ const (
 var defaultPublicCacheStatusCodes = []int64{200, 203, 204, 301, 308}
 var defaultPublicCacheVaryHeaders = []string{"Accept-Encoding"}
 
+var errPublicCacheGenerationChanged = errors.New("public cache entry generation changed")
+
 type publicCacheSettingsConfig struct {
 	Enabled                 bool
 	MaxDiskBytes            int64
@@ -167,6 +169,7 @@ type publicProxyCache struct {
 	generation      uint64
 	invalidateHook  func()
 	upsertHook      func(context.Context, db.UpsertPublicCacheEntryParams) (db.PublicCacheEntry, error)
+	duplicateHook   func()
 }
 
 type publicCacheMemoryEntry struct {
@@ -312,28 +315,38 @@ func (c *publicProxyCache) storeStripe(key string) *sync.Mutex {
 	return &c.storeStripes[int(sum[0])%len(c.storeStripes)]
 }
 
-func (c *publicProxyCache) acquireStoreGeneration(key string, generation uint64, fingerprint string) bool {
+func (c *publicProxyCache) acquireKeyFence(key string) bool {
 	stripe := c.storeStripe(key)
 	if stripe == nil {
 		return false
 	}
 	stripe.Lock()
 	c.storeGate.RLock()
-	if c.generationMatches(generation, fingerprint) {
-		return true
-	}
-	c.storeGate.RUnlock()
-	stripe.Unlock()
-	return false
+	return true
 }
 
-func (c *publicProxyCache) releaseStoreGeneration(key string) {
+func (c *publicProxyCache) releaseKeyFence(key string) {
 	stripe := c.storeStripe(key)
 	if stripe == nil {
 		return
 	}
 	c.storeGate.RUnlock()
 	stripe.Unlock()
+}
+
+func (c *publicProxyCache) acquireStoreGeneration(key string, generation uint64, fingerprint string) bool {
+	if !c.acquireKeyFence(key) {
+		return false
+	}
+	if c.generationMatches(generation, fingerprint) {
+		return true
+	}
+	c.releaseKeyFence(key)
+	return false
+}
+
+func (c *publicProxyCache) releaseStoreGeneration(key string) {
+	c.releaseKeyFence(key)
 }
 
 func publicCacheRuntimeFingerprint(settings publicCacheSettingsConfig, rules []publicCacheRuleConfig) string {
@@ -1163,7 +1176,8 @@ func (a *App) preparePublicCacheHitBody(r *http.Request, decision *publicCacheDe
 		return false
 	}
 	if r.Method == http.MethodHead || decision.Entry.SizeBytes == 0 {
-		return true
+		_, err := a.openCurrentPublicCacheHit(*decision.Entry, false)
+		return err == nil
 	}
 	body, err := a.openPublicCacheHitBody(*decision.Entry)
 	if err != nil {
@@ -1174,10 +1188,34 @@ func (a *App) preparePublicCacheHitBody(r *http.Request, decision *publicCacheDe
 }
 
 func (a *App) openPublicCacheHitBody(entry db.PublicCacheEntry) (io.ReadCloser, error) {
+	return a.openCurrentPublicCacheHit(entry, true)
+}
+
+func (a *App) openCurrentPublicCacheHit(entry db.PublicCacheEntry, openBody bool) (io.ReadCloser, error) {
+	if a == nil || a.PublicCache == nil || a.DB == nil || !a.PublicCache.acquireKeyFence(entry.KeyDigest) {
+		return nil, errPublicCacheGenerationChanged
+	}
+	current, err := a.DB.GetPublicCacheEntry(context.Background(), entry.KeyDigest)
+	if err != nil || !current.StoredAt.Equal(entry.StoredAt) {
+		a.PublicCache.releaseKeyFence(entry.KeyDigest)
+		if err == nil || errors.Is(err, sql.ErrNoRows) {
+			a.invalidatePublicCacheEntry(entry)
+		}
+		if err == nil {
+			err = errPublicCacheGenerationChanged
+		}
+		return nil, err
+	}
+	if !openBody {
+		a.PublicCache.releaseKeyFence(entry.KeyDigest)
+		return nil, nil
+	}
 	if body := a.PublicCache.getMemory(entry.KeyDigest, entry.StoredAt); len(body) > 0 {
+		a.PublicCache.releaseKeyFence(entry.KeyDigest)
 		return io.NopCloser(bytes.NewReader(body)), nil
 	}
 	file, err := os.Open(entry.BodyPath)
+	a.PublicCache.releaseKeyFence(entry.KeyDigest)
 	if err != nil {
 		a.invalidatePublicCacheEntry(entry)
 		return nil, err
@@ -1201,11 +1239,14 @@ func (a *App) invalidatePublicCacheEntry(entry db.PublicCacheEntry) {
 		StoredAt:       entry.StoredAt,
 		StoredAtLegacy: entry.StoredAt.UTC().Format(sqliteLegacyTimestampLayout),
 	})
-	if err != nil || deleted == 0 {
+	if err != nil {
 		return
 	}
 	if a.PublicCache != nil {
 		a.PublicCache.deleteEntryGeneration(entry.KeyDigest, entry.StoredAt)
+	}
+	if deleted == 0 {
+		return
 	}
 	if entry.BodyPath != "" {
 		_ = os.Remove(entry.BodyPath)
@@ -1441,6 +1482,18 @@ func (r *publicCacheStoreReadCloser) commit() {
 		return
 	}
 	defer r.app.PublicCache.releaseStoreGeneration(r.keyDigest)
+	if existing, err := r.app.DB.GetPublicCacheEntry(context.Background(), r.keyDigest); err == nil && existing.ExpiresAt.After(time.Now()) {
+		if r.app.PublicCache.duplicateHook != nil {
+			r.app.PublicCache.duplicateHook()
+		}
+		r.discard()
+		return
+	} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		r.markStoreFailed()
+		r.discard()
+		log.Warn().Err(err).Str("cache_key", r.keyDigest).Msg("Failed to check for an existing public cache entry")
+		return
+	}
 	if err := r.tmp.Close(); err != nil {
 		r.markStoreFailed()
 		r.discard()

--- a/internal/server/public_cache_test.go
+++ b/internal/server/public_cache_test.go
@@ -689,6 +689,7 @@ func TestPublicCacheTouchTokenRejectsReplacedEntry(t *testing.T) {
 	defer closeDB()
 	ctx := context.Background()
 	keyDigest := "replacement-token-digest"
+	oldStoredAt := time.Unix(1_700_000_000, 123_456_789).UTC()
 	params := db.UpsertPublicCacheEntryParams{
 		KeyDigest:           keyDigest,
 		RuleID:              resolution.CacheRuleID,
@@ -705,10 +706,9 @@ func TestPublicCacheTouchTokenRejectsReplacedEntry(t *testing.T) {
 		StatusCode:          http.StatusOK,
 		BodyPath:            "/tmp/replacement-token.body",
 		SizeBytes:           10,
-		StoredAt:            app.PublicCache.nextStoredAt(),
+		StoredAt:            oldStoredAt,
 		ExpiresAt:           time.Now().Add(time.Hour),
 	}
-	oldStoredAt := params.StoredAt
 	oldEntry, err := app.DB.UpsertPublicCacheEntry(ctx, params)
 	if err != nil {
 		t.Fatalf("insert old cache entry: %v", err)
@@ -721,7 +721,7 @@ func TestPublicCacheTouchTokenRejectsReplacedEntry(t *testing.T) {
 	app.PublicCache.touchIndexedEntry(keyDigest, oldEntry.StoredAt, oldTouchAt)
 	app.observabilityRecorderService().touchPublicCacheEntry(keyDigest, oldEntry.StoredAt, oldTouchAt)
 
-	params.StoredAt = app.PublicCache.nextStoredAt()
+	params.StoredAt = oldStoredAt.Add(time.Nanosecond)
 	params.BodyPath = "/tmp/replacement-token-new.body"
 	replacement, err := app.DB.UpsertPublicCacheEntry(ctx, params)
 	if err != nil {
@@ -1068,9 +1068,10 @@ func TestPublicCacheStaleCandidateDoesNotOverwriteIndexedHits(t *testing.T) {
 	t.Run("deterministic interleaving", func(t *testing.T) {
 		cache, generation, fingerprint, staleEntry, lookup, now := newCache(t)
 		cache.storeIndexedCandidates(lookup, []db.PublicCacheEntry{staleEntry}, now, generation, fingerprint)
-		cache.touchIndexedEntry(staleEntry.KeyDigest, staleEntry.StoredAt, now.Add(time.Second))
+		newerTouch := now.Add(2 * time.Second)
+		cache.touchIndexedEntry(staleEntry.KeyDigest, staleEntry.StoredAt, newerTouch)
 		cache.storeIndexedCandidates(lookup, []db.PublicCacheEntry{staleEntry}, now, generation, fingerprint)
-		cache.touchIndexedEntry(staleEntry.KeyDigest, staleEntry.StoredAt, now.Add(2*time.Second))
+		cache.touchIndexedEntry(staleEntry.KeyDigest, staleEntry.StoredAt, now.Add(time.Second))
 
 		cache.mu.Lock()
 		indexed := cache.indexEntries[staleEntry.KeyDigest].entry
@@ -1078,8 +1079,8 @@ func TestPublicCacheStaleCandidateDoesNotOverwriteIndexedHits(t *testing.T) {
 		if indexed.HitCount != 2 {
 			t.Fatalf("indexed hit count = %d, want 2 after stale second store", indexed.HitCount)
 		}
-		if !indexed.LastAccessedAt.Equal(now.Add(2 * time.Second)) {
-			t.Fatalf("indexed last access = %s, want newest touch", indexed.LastAccessedAt)
+		if !indexed.LastAccessedAt.Equal(newerTouch) {
+			t.Fatalf("indexed last access = %s, want newer out-of-order touch %s", indexed.LastAccessedAt, newerTouch)
 		}
 	})
 

--- a/internal/server/public_cache_test.go
+++ b/internal/server/public_cache_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -652,6 +653,7 @@ func TestPublicCacheIndexedHitsUpdateMemoryAndDatabaseExactly(t *testing.T) {
 		StatusCode:          http.StatusOK,
 		BodyPath:            bodyPath,
 		SizeBytes:           int64(len("counted")),
+		StoredAt:            app.PublicCache.nextStoredAt(),
 		ExpiresAt:           time.Now().Add(time.Hour),
 	}); err != nil {
 		t.Fatalf("insert cache entry: %v", err)
@@ -679,6 +681,122 @@ func TestPublicCacheIndexedHitsUpdateMemoryAndDatabaseExactly(t *testing.T) {
 	app.PublicCache.mu.Unlock()
 	if indexedHits != 2 {
 		t.Fatalf("indexed cache hit count = %d, want 2", indexedHits)
+	}
+}
+
+func TestPublicCacheTouchTokenRejectsReplacedEntry(t *testing.T) {
+	app, resolution, closeDB := newTestPublicCacheApp(t)
+	defer closeDB()
+	ctx := context.Background()
+	keyDigest := "replacement-token-digest"
+	params := db.UpsertPublicCacheEntryParams{
+		KeyDigest:           keyDigest,
+		RuleID:              resolution.CacheRuleID,
+		Scope:               publicCacheScopeSelectedBackend,
+		ListenerProtocol:    resolution.Listener.Protocol,
+		Host:                "assets.example.test",
+		Path:                "/assets/replacement.txt",
+		QueryKey:            "",
+		RouteID:             sql.NullInt64{Int64: resolution.Route.ID, Valid: true},
+		RouteTargetID:       sql.NullInt64{Int64: resolution.Target.ID, Valid: true},
+		Method:              http.MethodGet,
+		VaryHeadersJson:     "[]",
+		ResponseHeadersJson: `{"Content-Type":["text/plain"]}`,
+		StatusCode:          http.StatusOK,
+		BodyPath:            "/tmp/replacement-token.body",
+		SizeBytes:           10,
+		StoredAt:            app.PublicCache.nextStoredAt(),
+		ExpiresAt:           time.Now().Add(time.Hour),
+	}
+	oldStoredAt := params.StoredAt
+	oldEntry, err := app.DB.UpsertPublicCacheEntry(ctx, params)
+	if err != nil {
+		t.Fatalf("insert old cache entry: %v", err)
+	}
+	if !oldEntry.StoredAt.Equal(oldStoredAt) || !oldEntry.LastAccessedAt.Equal(oldStoredAt) {
+		t.Fatalf("old stored_at round trip = stored %s/access %s, want %s", oldEntry.StoredAt, oldEntry.LastAccessedAt, oldStoredAt)
+	}
+	app.PublicCache.putIndexEntry(oldEntry)
+	oldTouchAt := time.Now().UTC()
+	app.PublicCache.touchIndexedEntry(keyDigest, oldEntry.StoredAt, oldTouchAt)
+	app.observabilityRecorderService().touchPublicCacheEntry(keyDigest, oldEntry.StoredAt, oldTouchAt)
+
+	params.StoredAt = app.PublicCache.nextStoredAt()
+	params.BodyPath = "/tmp/replacement-token-new.body"
+	replacement, err := app.DB.UpsertPublicCacheEntry(ctx, params)
+	if err != nil {
+		t.Fatalf("replace cache entry: %v", err)
+	}
+	if !replacement.StoredAt.Equal(params.StoredAt) || !replacement.LastAccessedAt.Equal(params.StoredAt) {
+		t.Fatalf("replacement stored_at round trip = stored %s/access %s, want %s", replacement.StoredAt, replacement.LastAccessedAt, params.StoredAt)
+	}
+	if !replacement.StoredAt.After(oldEntry.StoredAt) {
+		t.Fatalf("replacement token = %s, want after old token %s", replacement.StoredAt, oldEntry.StoredAt)
+	}
+	app.PublicCache.putIndexEntry(replacement)
+	app.PublicCache.touchIndexedEntry(keyDigest, oldEntry.StoredAt, oldTouchAt.Add(time.Second))
+	if err := app.flushObservabilityRecorder(ctx); err != nil {
+		t.Fatalf("flush old cache touch: %v", err)
+	}
+
+	assertCounts := func(want int64, wantLastAccess time.Time) db.PublicCacheEntry {
+		t.Helper()
+		databaseEntry, err := app.DB.GetPublicCacheEntry(ctx, keyDigest)
+		if err != nil {
+			t.Fatalf("load replacement cache entry: %v", err)
+		}
+		app.PublicCache.mu.Lock()
+		indexedEntry := app.PublicCache.indexEntries[keyDigest].entry
+		app.PublicCache.mu.Unlock()
+		if databaseEntry.HitCount != want || indexedEntry.HitCount != want {
+			t.Fatalf("replacement hit counts = database %d/index %d, want %d", databaseEntry.HitCount, indexedEntry.HitCount, want)
+		}
+		if !databaseEntry.StoredAt.Equal(replacement.StoredAt) || !indexedEntry.StoredAt.Equal(replacement.StoredAt) {
+			t.Fatalf("replacement tokens changed = database %s/index %s, want %s", databaseEntry.StoredAt, indexedEntry.StoredAt, replacement.StoredAt)
+		}
+		if !databaseEntry.LastAccessedAt.Equal(wantLastAccess) || !indexedEntry.LastAccessedAt.Equal(wantLastAccess) {
+			t.Fatalf("replacement last access = database %s/index %s, want %s", databaseEntry.LastAccessedAt, indexedEntry.LastAccessedAt, wantLastAccess)
+		}
+		if databaseEntry.LastAccessedAt.Before(databaseEntry.StoredAt) || indexedEntry.LastAccessedAt.Before(indexedEntry.StoredAt) {
+			t.Fatalf("replacement last access regressed before stored_at: database %s/%s index %s/%s", databaseEntry.LastAccessedAt, databaseEntry.StoredAt, indexedEntry.LastAccessedAt, indexedEntry.StoredAt)
+		}
+		return databaseEntry
+	}
+	assertCounts(0, replacement.StoredAt)
+
+	newTouchAt := oldTouchAt.Add(2 * time.Second)
+	app.PublicCache.touchIndexedEntry(keyDigest, replacement.StoredAt, newTouchAt)
+	app.observabilityRecorderService().touchPublicCacheEntry(keyDigest, replacement.StoredAt, newTouchAt)
+	if err := app.flushObservabilityRecorder(ctx); err != nil {
+		t.Fatalf("flush replacement cache touch: %v", err)
+	}
+	assertCounts(1, newTouchAt)
+}
+
+func TestPublicCacheStoredAtTokensAreStrictlyUnique(t *testing.T) {
+	cache := newPublicProxyCache(t.TempDir())
+	const count = 256
+	tokens := make(chan time.Time, count)
+	var group sync.WaitGroup
+	for i := 0; i < count; i++ {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			tokens <- cache.nextStoredAt()
+		}()
+	}
+	group.Wait()
+	close(tokens)
+
+	ordered := make([]time.Time, 0, count)
+	for token := range tokens {
+		ordered = append(ordered, token)
+	}
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Before(ordered[j]) })
+	for i := 1; i < len(ordered); i++ {
+		if !ordered[i].After(ordered[i-1]) {
+			t.Fatalf("stored_at token %d = %s, want after %s", i, ordered[i], ordered[i-1])
+		}
 	}
 }
 
@@ -714,6 +832,7 @@ func TestPublicCacheStaleIndexedBodyFallsBackToMiss(t *testing.T) {
 		StatusCode:          http.StatusOK,
 		BodyPath:            bodyPath,
 		SizeBytes:           int64(len("stale-body")),
+		StoredAt:            app.PublicCache.nextStoredAt(),
 		ExpiresAt:           time.Now().Add(time.Hour),
 	}); err != nil {
 		t.Fatalf("insert cache entry: %v", err)
@@ -775,6 +894,7 @@ func TestPublicCacheEmptyMissUsesWarmedIndex(t *testing.T) {
 		StatusCode:          http.StatusOK,
 		BodyPath:            bodyPath,
 		SizeBytes:           int64(len("later-body")),
+		StoredAt:            app.PublicCache.nextStoredAt(),
 		ExpiresAt:           time.Now().Add(time.Hour),
 	})
 	if err != nil {
@@ -939,6 +1059,7 @@ func TestPublicCacheStaleCandidateDoesNotOverwriteIndexedHits(t *testing.T) {
 			ListenerProtocol: publicListenerProtocolHTTP,
 			Host:             "assets.example",
 			Path:             "/asset",
+			StoredAt:         now.Add(-time.Minute),
 			ExpiresAt:        now.Add(time.Hour),
 		}
 		return cache, generation, fingerprint, entry, publicCacheLookupKeyFromEntry(entry), now
@@ -947,9 +1068,9 @@ func TestPublicCacheStaleCandidateDoesNotOverwriteIndexedHits(t *testing.T) {
 	t.Run("deterministic interleaving", func(t *testing.T) {
 		cache, generation, fingerprint, staleEntry, lookup, now := newCache(t)
 		cache.storeIndexedCandidates(lookup, []db.PublicCacheEntry{staleEntry}, now, generation, fingerprint)
-		cache.touchIndexedEntry(staleEntry.KeyDigest, now.Add(time.Second))
+		cache.touchIndexedEntry(staleEntry.KeyDigest, staleEntry.StoredAt, now.Add(time.Second))
 		cache.storeIndexedCandidates(lookup, []db.PublicCacheEntry{staleEntry}, now, generation, fingerprint)
-		cache.touchIndexedEntry(staleEntry.KeyDigest, now.Add(2*time.Second))
+		cache.touchIndexedEntry(staleEntry.KeyDigest, staleEntry.StoredAt, now.Add(2*time.Second))
 
 		cache.mu.Lock()
 		indexed := cache.indexEntries[staleEntry.KeyDigest].entry
@@ -973,7 +1094,7 @@ func TestPublicCacheStaleCandidateDoesNotOverwriteIndexedHits(t *testing.T) {
 				defer group.Done()
 				<-start
 				cache.storeIndexedCandidates(lookup, []db.PublicCacheEntry{staleEntry}, now, generation, fingerprint)
-				cache.touchIndexedEntry(staleEntry.KeyDigest, now.Add(time.Second))
+				cache.touchIndexedEntry(staleEntry.KeyDigest, staleEntry.StoredAt, now.Add(time.Second))
 			}()
 		}
 		close(start)
@@ -1367,6 +1488,7 @@ func TestPublicCacheHeadServedFromCachedGet(t *testing.T) {
 		StatusCode:          http.StatusOK,
 		BodyPath:            bodyPath,
 		SizeBytes:           int64(len("head-body")),
+		StoredAt:            app.PublicCache.nextStoredAt(),
 		ExpiresAt:           time.Now().Add(time.Hour),
 	}); err != nil {
 		t.Fatalf("insert cache entry: %v", err)

--- a/internal/server/public_cache_test.go
+++ b/internal/server/public_cache_test.go
@@ -565,6 +565,9 @@ func TestPublicCacheDirectBackendMissStoresThenHit(t *testing.T) {
 	if firstDecision.Status != publicCacheStatusStored || firstDecision.StoredBytes != int64(len("asset-v1")) {
 		t.Fatalf("stored decision = status %q bytes %d", firstDecision.Status, firstDecision.StoredBytes)
 	}
+	if err := app.flushObservabilityRecorder(context.Background()); err != nil {
+		t.Fatalf("flush observability recorder: %v", err)
+	}
 
 	var eventStatus string
 	var eventBytes int64
@@ -655,6 +658,9 @@ func TestPublicCacheAgentBackendMissStoresThenHit(t *testing.T) {
 	}
 	if firstDecision.Status != publicCacheStatusStored || firstDecision.StoredBytes != int64(len("agent-asset-v1")) {
 		t.Fatalf("stored decision = status %q bytes %d", firstDecision.Status, firstDecision.StoredBytes)
+	}
+	if err := app.flushObservabilityRecorder(context.Background()); err != nil {
+		t.Fatalf("flush observability recorder: %v", err)
 	}
 
 	var eventAgentID sql.NullInt64
@@ -890,7 +896,14 @@ func newTestPublicCacheApp(t *testing.T) (*App, publicRouteResolution, func()) {
 	app.proxyMu.Unlock()
 	app.PublicCache.reconcile(defaultPublicCacheSettings())
 
-	return app, resolution, func() { database.Close() }
+	return app, resolution, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := app.flushObservabilityRecorder(ctx); err != nil {
+			t.Fatalf("flush observability recorder: %v", err)
+		}
+		database.Close()
+	}
 }
 
 func setTestCacheRuleAllowCookieRequests(t *testing.T, app *App, allowed bool) {

--- a/internal/server/public_cache_test.go
+++ b/internal/server/public_cache_test.go
@@ -900,7 +900,7 @@ func TestPublicCacheExpiredIndexedEntryInvalidatesRowIndexMemoryAndBody(t *testi
 		t.Fatalf("insert expired cache entry: %v", err)
 	}
 	app.PublicCache.putIndexEntry(entry)
-	app.PublicCache.putMemory(keyDigest, body)
+	app.PublicCache.putMemory(keyDigest, entry.StoredAt, body)
 	app.PublicCache.mu.Lock()
 	app.PublicCache.lastCleanup = time.Now()
 	_, indexed := app.PublicCache.indexEntries[keyDigest]
@@ -926,6 +926,259 @@ func TestPublicCacheExpiredIndexedEntryInvalidatesRowIndexMemoryAndBody(t *testi
 	app.PublicCache.mu.Unlock()
 	if indexed || inMemory {
 		t.Fatalf("expired cache state remained after invalidation: index=%t memory=%t", indexed, inMemory)
+	}
+}
+
+func TestPublicCacheStaleInvalidationDoesNotDeleteReplacementGeneration(t *testing.T) {
+	app, resolution, closeDB := newTestPublicCacheApp(t)
+	defer closeDB()
+	req := httptest.NewRequest(http.MethodGet, "http://assets.example.test/assets/replaced.txt", nil)
+	snap := app.currentPublicSnapshot()
+	if snap == nil || len(snap.CacheRules) == 0 {
+		t.Fatal("test cache snapshot missing rule")
+	}
+	rule := snap.CacheRules[0]
+	v1, err := storeTestPublicCacheGeneration(app, resolution, req, rule, app.PublicCache.nextStoredAt(), []byte("generation-v1"))
+	if err != nil {
+		t.Fatalf("store cache generation v1: %v", err)
+	}
+	staleCopy := v1
+	v2, err := storeTestPublicCacheGeneration(app, resolution, req, rule, app.PublicCache.nextStoredAt(), []byte("generation-v2"))
+	if err != nil {
+		t.Fatalf("store cache generation v2: %v", err)
+	}
+
+	app.invalidatePublicCacheEntry(staleCopy)
+	assertTestPublicCacheGeneration(t, app, v2, []byte("generation-v2"))
+	if body := app.PublicCache.getMemory(v1.KeyDigest, v1.StoredAt); len(body) != 0 {
+		t.Fatalf("stale generation memory remained addressable: %q", body)
+	}
+}
+
+func TestPublicCacheFailedReplacementRestoresPreviousGeneration(t *testing.T) {
+	app, resolution, closeDB := newTestPublicCacheApp(t)
+	defer closeDB()
+	req := httptest.NewRequest(http.MethodGet, "http://assets.example.test/assets/failed-replacement.txt", nil)
+	snap := app.currentPublicSnapshot()
+	if snap == nil || len(snap.CacheRules) == 0 {
+		t.Fatal("test cache snapshot missing rule")
+	}
+	rule := snap.CacheRules[0]
+	v1, err := storeTestPublicCacheGeneration(app, resolution, req, rule, app.PublicCache.nextStoredAt(), []byte("failed-replacement-v1"))
+	if err != nil {
+		t.Fatalf("store failed-replacement generation v1: %v", err)
+	}
+	fingerprint := publicCacheSnapshotFingerprint(snap)
+	generation, current := app.PublicCache.captureGeneration(fingerprint)
+	if !current {
+		t.Fatal("cache generation was not current before failed replacement")
+	}
+	decision := publicCacheDecision{
+		Rule:             rule,
+		Status:           publicCacheStatusMiss,
+		QueryKey:         "",
+		Host:             normalizeRequestHost(req.Host),
+		Path:             req.URL.EscapedPath(),
+		Cacheable:        true,
+		cacheGeneration:  generation,
+		cacheFingerprint: fingerprint,
+		cacheCurrent:     true,
+	}
+	upsertFailure := errors.New("injected cache upsert failure")
+	app.PublicCache.upsertHook = func(context.Context, db.UpsertPublicCacheEntryParams) (db.PublicCacheEntry, error) {
+		return db.PublicCacheEntry{}, upsertFailure
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/plain"}},
+		Body:       io.NopCloser(strings.NewReader("failed-replacement-v2")),
+	}
+	captured := app.capturePublicCacheResponseBody(context.Background(), req, resolution, &decision, resp, nil)
+	if captured == nil {
+		t.Fatal("failed-replacement response body was not captured")
+	}
+	if _, err := io.Copy(io.Discard, captured); err != nil {
+		t.Fatalf("read failed-replacement response: %v", err)
+	}
+	if err := captured.Close(); err != nil {
+		t.Fatalf("close failed-replacement response: %v", err)
+	}
+	app.PublicCache.upsertHook = nil
+	if decision.Status != publicCacheStatusStoreFailed {
+		t.Fatalf("failed replacement cache status = %q, want %q", decision.Status, publicCacheStatusStoreFailed)
+	}
+	assertTestPublicCacheGeneration(t, app, v1, []byte("failed-replacement-v1"))
+	backups, err := filepath.Glob(filepath.Join(app.PublicCache.tempDir(), "*.previous"))
+	if err != nil {
+		t.Fatalf("glob failed-replacement backups: %v", err)
+	}
+	if len(backups) != 0 {
+		t.Fatalf("failed-replacement backup files remained: %v", backups)
+	}
+}
+
+func TestPublicCacheInvalidationSerializesReplacementCommit(t *testing.T) {
+	app, resolution, closeDB := newTestPublicCacheApp(t)
+	defer closeDB()
+	req := httptest.NewRequest(http.MethodGet, "http://assets.example.test/assets/interleaved.txt", nil)
+	snap := app.currentPublicSnapshot()
+	if snap == nil || len(snap.CacheRules) == 0 {
+		t.Fatal("test cache snapshot missing rule")
+	}
+	rule := snap.CacheRules[0]
+	v1, err := storeTestPublicCacheGeneration(app, resolution, req, rule, app.PublicCache.nextStoredAt(), []byte("interleaved-v1"))
+	if err != nil {
+		t.Fatalf("store interleaved generation v1: %v", err)
+	}
+	v2StoredAt := app.PublicCache.nextStoredAt()
+
+	invalidationLocked := make(chan struct{})
+	releaseInvalidation := make(chan struct{})
+	app.PublicCache.invalidateHook = func() {
+		close(invalidationLocked)
+		<-releaseInvalidation
+	}
+	invalidationDone := make(chan struct{})
+	go func() {
+		app.invalidatePublicCacheEntry(v1)
+		close(invalidationDone)
+	}()
+	select {
+	case <-invalidationLocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for invalidation store gate")
+	}
+
+	type replacementResult struct {
+		entry db.PublicCacheEntry
+		err   error
+	}
+	replacementAcquired := make(chan struct{})
+	replacementDone := make(chan replacementResult, 1)
+	go func() {
+		app.PublicCache.storeGate.RLock()
+		close(replacementAcquired)
+		entry, err := storeTestPublicCacheGeneration(app, resolution, req, rule, v2StoredAt, []byte("interleaved-v2"))
+		app.PublicCache.storeGate.RUnlock()
+		replacementDone <- replacementResult{entry: entry, err: err}
+	}()
+	select {
+	case <-replacementAcquired:
+		close(releaseInvalidation)
+		t.Fatal("replacement acquired the store gate before invalidation completed")
+	case <-time.After(50 * time.Millisecond):
+		close(releaseInvalidation)
+	}
+	select {
+	case <-invalidationDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for invalidation to finish")
+	}
+	app.PublicCache.invalidateHook = nil
+	select {
+	case <-replacementAcquired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("replacement did not acquire the store gate after invalidation")
+	}
+	var replacement replacementResult
+	select {
+	case replacement = <-replacementDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for replacement commit")
+	}
+	if replacement.err != nil {
+		t.Fatalf("store interleaved generation v2: %v", replacement.err)
+	}
+	assertTestPublicCacheGeneration(t, app, replacement.entry, []byte("interleaved-v2"))
+}
+
+func TestPublicCacheCleanupWaitsForActiveStoreGeneration(t *testing.T) {
+	app, resolution, closeDB := newTestPublicCacheApp(t)
+	defer closeDB()
+	req := httptest.NewRequest(http.MethodGet, "http://assets.example.test/assets/cleanup-gate.txt", nil)
+	snap := app.currentPublicSnapshot()
+	if snap == nil || len(snap.CacheRules) == 0 {
+		t.Fatal("test cache snapshot missing rule")
+	}
+	entry, err := storeTestPublicCacheGeneration(app, resolution, req, snap.CacheRules[0], app.PublicCache.nextStoredAt(), []byte("cleanup-gate"))
+	if err != nil {
+		t.Fatalf("store cleanup-gate entry: %v", err)
+	}
+	entry.ExpiresAt = time.Now().Add(-time.Minute)
+	if _, err := app.DB.ExecContext(context.Background(), `UPDATE public_cache_entries SET expires_at = ? WHERE key_digest = ?`, entry.ExpiresAt, entry.KeyDigest); err != nil {
+		t.Fatalf("expire cleanup-gate entry: %v", err)
+	}
+	app.PublicCache.putIndexEntry(entry)
+	app.PublicCache.mu.Lock()
+	app.PublicCache.lastCleanup = time.Time{}
+	app.PublicCache.mu.Unlock()
+
+	app.PublicCache.storeGate.RLock()
+	cleanupDone := make(chan struct{})
+	go func() {
+		app.PublicCache.maybeCleanup(context.Background(), app.DB)
+		close(cleanupDone)
+	}()
+	premature := false
+	select {
+	case <-cleanupDone:
+		premature = true
+	case <-time.After(50 * time.Millisecond):
+	}
+	app.PublicCache.storeGate.RUnlock()
+	if premature {
+		t.Fatal("cleanup completed while a store generation held the read gate")
+	}
+	select {
+	case <-cleanupDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanup did not continue after the store generation released its gate")
+	}
+	if _, err := app.DB.GetPublicCacheEntry(context.Background(), entry.KeyDigest); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("cleanup-gate database row error = %v, want sql.ErrNoRows", err)
+	}
+	if _, err := os.Stat(entry.BodyPath); !os.IsNotExist(err) {
+		t.Fatalf("cleanup-gate body stat error = %v, want not exist", err)
+	}
+}
+
+func TestPublicCacheGenerationInvalidationSupportsLegacyTimestamp(t *testing.T) {
+	app, resolution, closeDB := newTestPublicCacheApp(t)
+	defer closeDB()
+	req := httptest.NewRequest(http.MethodGet, "http://assets.example.test/assets/legacy-generation.txt", nil)
+	snap := app.currentPublicSnapshot()
+	if snap == nil || len(snap.CacheRules) == 0 {
+		t.Fatal("test cache snapshot missing rule")
+	}
+	entry, err := storeTestPublicCacheGeneration(app, resolution, req, snap.CacheRules[0], app.PublicCache.nextStoredAt(), []byte("legacy-generation"))
+	if err != nil {
+		t.Fatalf("store legacy-generation entry: %v", err)
+	}
+	legacyStoredAt := entry.StoredAt.UTC().Truncate(time.Second)
+	legacyText := legacyStoredAt.Format(sqliteLegacyTimestampLayout)
+	if _, err := app.DB.ExecContext(context.Background(), `
+		UPDATE public_cache_entries
+		SET stored_at = ?, last_accessed_at = ?
+		WHERE key_digest = ?
+	`, legacyText, legacyText, entry.KeyDigest); err != nil {
+		t.Fatalf("convert cache generation to legacy timestamp: %v", err)
+	}
+	entry, err = app.DB.GetPublicCacheEntry(context.Background(), entry.KeyDigest)
+	if err != nil {
+		t.Fatalf("load legacy cache generation: %v", err)
+	}
+	app.PublicCache.putIndexEntry(entry)
+	app.PublicCache.putMemory(entry.KeyDigest, entry.StoredAt, []byte("legacy-generation"))
+
+	app.invalidatePublicCacheEntry(entry)
+	if _, err := app.DB.GetPublicCacheEntry(context.Background(), entry.KeyDigest); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("legacy cache generation database row error = %v, want sql.ErrNoRows", err)
+	}
+	if _, err := os.Stat(entry.BodyPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy cache generation body stat error = %v, want not exist", err)
+	}
+	if body := app.PublicCache.getMemory(entry.KeyDigest, entry.StoredAt); len(body) != 0 {
+		t.Fatalf("legacy cache generation memory remained: %q", body)
 	}
 }
 
@@ -1577,6 +1830,70 @@ func TestPublicCacheHeadServedFromCachedGet(t *testing.T) {
 	}
 	if rec.Body.Len() != 0 {
 		t.Fatalf("HEAD body length = %d, want 0", rec.Body.Len())
+	}
+}
+
+func storeTestPublicCacheGeneration(app *App, resolution publicRouteResolution, req *http.Request, rule publicCacheRuleConfig, storedAt time.Time, body []byte) (db.PublicCacheEntry, error) {
+	keyDigest := publicCacheKeyDigest(req, resolution, rule, "", nil)
+	bodyPath := app.PublicCache.bodyPath(keyDigest)
+	if err := os.MkdirAll(filepath.Dir(bodyPath), 0700); err != nil {
+		return db.PublicCacheEntry{}, err
+	}
+	if err := os.WriteFile(bodyPath, body, 0600); err != nil {
+		return db.PublicCacheEntry{}, err
+	}
+	entry, err := app.DB.UpsertPublicCacheEntry(context.Background(), db.UpsertPublicCacheEntryParams{
+		KeyDigest:           keyDigest,
+		RuleID:              resolution.CacheRuleID,
+		Scope:               publicCacheScopeSelectedBackend,
+		ListenerProtocol:    resolution.Listener.Protocol,
+		Host:                normalizeRequestHost(req.Host),
+		Path:                req.URL.EscapedPath(),
+		QueryKey:            "",
+		RouteID:             sql.NullInt64{Int64: resolution.Route.ID, Valid: true},
+		RouteTargetID:       sql.NullInt64{Int64: resolution.Target.ID, Valid: true},
+		Method:              http.MethodGet,
+		VaryHeadersJson:     "[]",
+		ResponseHeadersJson: `{"Content-Type":["text/plain"]}`,
+		StatusCode:          http.StatusOK,
+		BodyPath:            bodyPath,
+		SizeBytes:           int64(len(body)),
+		StoredAt:            storedAt,
+		ExpiresAt:           time.Now().Add(time.Hour),
+	})
+	if err != nil {
+		return db.PublicCacheEntry{}, err
+	}
+	app.PublicCache.putIndexEntry(entry)
+	app.PublicCache.putMemory(keyDigest, entry.StoredAt, body)
+	return entry, nil
+}
+
+func assertTestPublicCacheGeneration(t *testing.T, app *App, want db.PublicCacheEntry, body []byte) {
+	t.Helper()
+	got, err := app.DB.GetPublicCacheEntry(context.Background(), want.KeyDigest)
+	if err != nil {
+		t.Fatalf("load cache generation: %v", err)
+	}
+	if !got.StoredAt.Equal(want.StoredAt) || got.BodyPath != want.BodyPath {
+		t.Fatalf("database cache generation = stored %s/body %q, want %s/%q", got.StoredAt, got.BodyPath, want.StoredAt, want.BodyPath)
+	}
+	diskBody, err := os.ReadFile(want.BodyPath)
+	if err != nil {
+		t.Fatalf("read cache generation body: %v", err)
+	}
+	if string(diskBody) != string(body) {
+		t.Fatalf("disk cache generation body = %q, want %q", diskBody, body)
+	}
+	app.PublicCache.mu.Lock()
+	indexed := app.PublicCache.indexEntries[want.KeyDigest]
+	memory := app.PublicCache.memoryEntries[want.KeyDigest]
+	app.PublicCache.mu.Unlock()
+	if !indexed.entry.StoredAt.Equal(want.StoredAt) {
+		t.Fatalf("indexed cache generation = %s, want %s", indexed.entry.StoredAt, want.StoredAt)
+	}
+	if memory == nil || !memory.storedAt.Equal(want.StoredAt) || string(memory.body) != string(body) {
+		t.Fatalf("memory cache generation = %#v, want stored %s/body %q", memory, want.StoredAt, body)
 	}
 }
 

--- a/internal/server/public_cache_test.go
+++ b/internal/server/public_cache_test.go
@@ -613,10 +613,15 @@ func TestPublicCacheDirectBackendMissStoresThenHit(t *testing.T) {
 	if thirdDecision.Status != publicCacheStatusHit {
 		t.Fatalf("third warmed cache status = %q, want hit", thirdDecision.Status)
 	}
-	thirdRec := httptest.NewRecorder()
-	app.servePublicCacheHit(thirdRec, thirdReq, resolution, nil, nil, thirdDecision, proxyRequestObservability{})
-	if thirdRec.Code != http.StatusOK || thirdRec.Body.String() != "asset-v1" {
-		t.Fatalf("third warmed response = status %d body %q, want cached asset", thirdRec.Code, thirdRec.Body.String())
+	if app.preparePublicCacheHitBody(thirdReq, &thirdDecision) {
+		if thirdDecision.HitBody != nil {
+			_ = thirdDecision.HitBody.Close()
+		}
+		t.Fatal("warmed cache generation without its authoritative database row was prepared")
+	}
+	fourthDecision := app.checkPublicCache(httptest.NewRequest(http.MethodGet, "http://assets.example.test/assets/app.txt?v=1", nil), resolution)
+	if fourthDecision.Status != publicCacheStatusMiss {
+		t.Fatalf("cache status after rejecting stale warmed generation = %q, want miss", fourthDecision.Status)
 	}
 }
 
@@ -955,7 +960,7 @@ func TestPublicCacheStaleInvalidationDoesNotDeleteReplacementGeneration(t *testi
 	}
 }
 
-func TestPublicCacheFailedReplacementRestoresPreviousGeneration(t *testing.T) {
+func TestPublicCacheFailedExpiredReplacementRestoresPreviousGeneration(t *testing.T) {
 	app, resolution, closeDB := newTestPublicCacheApp(t)
 	defer closeDB()
 	req := httptest.NewRequest(http.MethodGet, "http://assets.example.test/assets/failed-replacement.txt", nil)
@@ -968,6 +973,11 @@ func TestPublicCacheFailedReplacementRestoresPreviousGeneration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("store failed-replacement generation v1: %v", err)
 	}
+	v1.ExpiresAt = time.Now().Add(-time.Minute)
+	if _, err := app.DB.ExecContext(context.Background(), `UPDATE public_cache_entries SET expires_at = ? WHERE key_digest = ?`, v1.ExpiresAt, v1.KeyDigest); err != nil {
+		t.Fatalf("expire failed-replacement generation v1: %v", err)
+	}
+	app.PublicCache.putIndexEntry(v1)
 	fingerprint := publicCacheSnapshotFingerprint(snap)
 	generation, current := app.PublicCache.captureGeneration(fingerprint)
 	if !current {
@@ -985,7 +995,11 @@ func TestPublicCacheFailedReplacementRestoresPreviousGeneration(t *testing.T) {
 		cacheCurrent:     true,
 	}
 	upsertFailure := errors.New("injected cache upsert failure")
-	app.PublicCache.upsertHook = func(context.Context, db.UpsertPublicCacheEntryParams) (db.PublicCacheEntry, error) {
+	upsertCalls := 0
+	upsertKey := ""
+	app.PublicCache.upsertHook = func(_ context.Context, params db.UpsertPublicCacheEntryParams) (db.PublicCacheEntry, error) {
+		upsertCalls++
+		upsertKey = params.KeyDigest
 		return db.PublicCacheEntry{}, upsertFailure
 	}
 	resp := &http.Response{
@@ -1004,6 +1018,9 @@ func TestPublicCacheFailedReplacementRestoresPreviousGeneration(t *testing.T) {
 		t.Fatalf("close failed-replacement response: %v", err)
 	}
 	app.PublicCache.upsertHook = nil
+	if upsertCalls != 1 || upsertKey != v1.KeyDigest {
+		t.Fatalf("failed replacement upsert = calls %d/key %q, want 1/%q", upsertCalls, upsertKey, v1.KeyDigest)
+	}
 	if decision.Status != publicCacheStatusStoreFailed {
 		t.Fatalf("failed replacement cache status = %q, want %q", decision.Status, publicCacheStatusStoreFailed)
 	}
@@ -1014,6 +1031,235 @@ func TestPublicCacheFailedReplacementRestoresPreviousGeneration(t *testing.T) {
 	}
 	if len(backups) != 0 {
 		t.Fatalf("failed-replacement backup files remained: %v", backups)
+	}
+}
+
+func TestPublicCacheFirstWriterWinsWhileLateReaderWaits(t *testing.T) {
+	app, resolution, closeDB := newTestPublicCacheApp(t)
+	defer closeDB()
+	req := httptest.NewRequest(http.MethodGet, "http://assets.example.test/assets/first-writer.txt", nil)
+	firstDecision := app.checkPublicCache(req, resolution)
+	secondDecision := app.checkPublicCache(req, resolution)
+	if firstDecision.Status != publicCacheStatusMiss || secondDecision.Status != publicCacheStatusMiss {
+		t.Fatalf("initial cache statuses = %q/%q, want miss/miss", firstDecision.Status, secondDecision.Status)
+	}
+	capture := func(decision *publicCacheDecision, generation, body string) io.ReadCloser {
+		t.Helper()
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type":       []string{"text/plain"},
+				"X-Cache-Generation": []string{generation},
+			},
+			Body: io.NopCloser(strings.NewReader(body)),
+		}
+		captured := app.capturePublicCacheResponseBody(context.Background(), req, resolution, decision, resp, nil)
+		if captured == nil {
+			t.Fatalf("%s response body was not captured", generation)
+		}
+		return captured
+	}
+	firstBody := capture(&firstDecision, "v1", "first-writer-v1")
+	secondBody := capture(&secondDecision, "v2", "late-writer-v2")
+
+	firstUpsertStarted := make(chan struct{})
+	releaseFirstUpsert := make(chan struct{})
+	var releaseFirstOnce sync.Once
+	releaseFirst := func() { releaseFirstOnce.Do(func() { close(releaseFirstUpsert) }) }
+	defer releaseFirst()
+	var upsertCallsMu sync.Mutex
+	upsertCalls := 0
+	app.PublicCache.upsertHook = func(ctx context.Context, params db.UpsertPublicCacheEntryParams) (db.PublicCacheEntry, error) {
+		upsertCallsMu.Lock()
+		upsertCalls++
+		call := upsertCalls
+		upsertCallsMu.Unlock()
+		if call == 1 {
+			close(firstUpsertStarted)
+			<-releaseFirstUpsert
+		}
+		return app.DB.UpsertPublicCacheEntry(ctx, params)
+	}
+	lateWriterChecked := make(chan struct{})
+	releaseLateWriter := make(chan struct{})
+	var releaseLateOnce sync.Once
+	releaseLate := func() { releaseLateOnce.Do(func() { close(releaseLateWriter) }) }
+	defer releaseLate()
+	app.PublicCache.duplicateHook = func() {
+		close(lateWriterChecked)
+		<-releaseLateWriter
+	}
+
+	drain := func(body io.ReadCloser, done chan<- error) {
+		_, copyErr := io.Copy(io.Discard, body)
+		done <- errors.Join(copyErr, body.Close())
+	}
+	firstDone := make(chan error, 1)
+	go drain(firstBody, firstDone)
+	select {
+	case <-firstUpsertStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first writer to reach upsert")
+	}
+
+	secondDone := make(chan error, 1)
+	go drain(secondBody, secondDone)
+	select {
+	case err := <-secondDone:
+		releaseFirst()
+		t.Fatalf("late writer completed before first writer committed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	releaseFirst()
+	select {
+	case err := <-firstDone:
+		if err != nil {
+			t.Fatalf("first writer failed: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first writer")
+	}
+	select {
+	case <-lateWriterChecked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for late writer duplicate check")
+	}
+
+	hitDecision := app.checkPublicCache(req, resolution)
+	if hitDecision.Status != publicCacheStatusHit {
+		releaseLate()
+		t.Fatalf("cache status after first commit = %q, want hit", hitDecision.Status)
+	}
+	type preparedResult struct {
+		decision publicCacheDecision
+		ok       bool
+	}
+	prepared := make(chan preparedResult, 1)
+	go func() {
+		prepared <- preparedResult{decision: hitDecision, ok: app.preparePublicCacheHitBody(req, &hitDecision)}
+	}()
+	var early *preparedResult
+	select {
+	case result := <-prepared:
+		early = &result
+	case <-time.After(50 * time.Millisecond):
+	}
+	releaseLate()
+	if early != nil {
+		t.Fatal("cache reader passed the key fence while the late writer held it")
+	}
+	select {
+	case err := <-secondDone:
+		if err != nil {
+			t.Fatalf("late writer failed while being discarded: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for late writer")
+	}
+	var result preparedResult
+	select {
+	case result = <-prepared:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for cache reader")
+	}
+	if !result.ok {
+		t.Fatal("first generation cache hit was not prepared after the late writer was discarded")
+	}
+	rec := httptest.NewRecorder()
+	app.servePublicCacheHit(rec, req, resolution, nil, nil, result.decision, proxyRequestObservability{})
+	if rec.Code != http.StatusOK || rec.Header().Get("X-Cache-Generation") != "v1" || rec.Body.String() != "first-writer-v1" {
+		t.Fatalf("cache response = status %d/generation %q/body %q, want 200/v1/first-writer-v1", rec.Code, rec.Header().Get("X-Cache-Generation"), rec.Body.String())
+	}
+	upsertCallsMu.Lock()
+	gotUpsertCalls := upsertCalls
+	upsertCallsMu.Unlock()
+	if gotUpsertCalls != 1 {
+		t.Fatalf("cache upsert calls = %d, want 1", gotUpsertCalls)
+	}
+	if firstDecision.Status != publicCacheStatusStored || secondDecision.Status != publicCacheStatusMiss {
+		t.Fatalf("final cache statuses = %q/%q, want stored/miss", firstDecision.Status, secondDecision.Status)
+	}
+	app.PublicCache.upsertHook = nil
+	app.PublicCache.duplicateHook = nil
+}
+
+func TestPublicCacheStaleResolvedHitRejectsReplacementBody(t *testing.T) {
+	app, resolution, closeDB := newTestPublicCacheApp(t)
+	defer closeDB()
+	req := httptest.NewRequest(http.MethodGet, "http://assets.example.test/assets/stale-resolved.txt", nil)
+	snap := app.currentPublicSnapshot()
+	if snap == nil || len(snap.CacheRules) == 0 {
+		t.Fatal("test cache snapshot missing rule")
+	}
+	rule := snap.CacheRules[0]
+	v1, err := storeTestPublicCacheGeneration(app, resolution, req, rule, app.PublicCache.nextStoredAt(), []byte("stale-resolved-v1"))
+	if err != nil {
+		t.Fatalf("store stale-resolved generation v1: %v", err)
+	}
+	staleDecision := app.checkPublicCache(req, resolution)
+	if staleDecision.Status != publicCacheStatusHit || staleDecision.Entry == nil || !staleDecision.Entry.StoredAt.Equal(v1.StoredAt) {
+		t.Fatalf("resolved cache decision = %#v, want generation v1 hit", staleDecision)
+	}
+	app.invalidatePublicCacheEntry(v1)
+	v2, err := storeTestPublicCacheGeneration(app, resolution, req, rule, app.PublicCache.nextStoredAt(), []byte("stale-resolved-v2"))
+	if err != nil {
+		t.Fatalf("store stale-resolved generation v2: %v", err)
+	}
+	if app.preparePublicCacheHitBody(req, &staleDecision) {
+		if staleDecision.HitBody != nil {
+			_ = staleDecision.HitBody.Close()
+		}
+		t.Fatal("stale generation v1 decision opened the generation v2 body")
+	}
+	assertTestPublicCacheGeneration(t, app, v2, []byte("stale-resolved-v2"))
+}
+
+func TestPublicCachePreparedDiskHitDoesNotHoldGenerationFence(t *testing.T) {
+	app, resolution, closeDB := newTestPublicCacheApp(t)
+	defer closeDB()
+	req := httptest.NewRequest(http.MethodGet, "http://assets.example.test/assets/open-descriptor.txt", nil)
+	snap := app.currentPublicSnapshot()
+	if snap == nil || len(snap.CacheRules) == 0 {
+		t.Fatal("test cache snapshot missing rule")
+	}
+	v1Body := []byte("open-descriptor-v1")
+	v1, err := storeTestPublicCacheGeneration(app, resolution, req, snap.CacheRules[0], app.PublicCache.nextStoredAt(), v1Body)
+	if err != nil {
+		t.Fatalf("store open-descriptor generation v1: %v", err)
+	}
+	decision := app.checkPublicCache(req, resolution)
+	if decision.Status != publicCacheStatusHit {
+		t.Fatalf("open-descriptor cache status = %q, want hit", decision.Status)
+	}
+	app.PublicCache.deleteMemory(v1.KeyDigest)
+	if !app.preparePublicCacheHitBody(req, &decision) || decision.HitBody == nil {
+		t.Fatal("open-descriptor disk hit was not prepared")
+	}
+	defer decision.HitBody.Close()
+
+	invalidationDone := make(chan struct{})
+	go func() {
+		app.invalidatePublicCacheEntry(v1)
+		close(invalidationDone)
+	}()
+	select {
+	case <-invalidationDone:
+	case <-time.After(2 * time.Second):
+		_ = decision.HitBody.Close()
+		t.Fatal("cache invalidation waited for the prepared response body to close")
+	}
+	if _, err := app.DB.GetPublicCacheEntry(context.Background(), v1.KeyDigest); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("open-descriptor database row error = %v, want sql.ErrNoRows", err)
+	}
+	if _, err := os.Stat(v1.BodyPath); !os.IsNotExist(err) {
+		t.Fatalf("open-descriptor body path stat error = %v, want not exist", err)
+	}
+	gotBody, err := io.ReadAll(decision.HitBody)
+	if err != nil {
+		t.Fatalf("read prepared open-descriptor body after invalidation: %v", err)
+	}
+	if string(gotBody) != string(v1Body) {
+		t.Fatalf("prepared open-descriptor body = %q, want %q", gotBody, v1Body)
 	}
 }
 
@@ -1834,7 +2080,7 @@ func TestPublicCacheHeadServedFromCachedGet(t *testing.T) {
 }
 
 func storeTestPublicCacheGeneration(app *App, resolution publicRouteResolution, req *http.Request, rule publicCacheRuleConfig, storedAt time.Time, body []byte) (db.PublicCacheEntry, error) {
-	keyDigest := publicCacheKeyDigest(req, resolution, rule, "", nil)
+	keyDigest := publicCacheKeyDigest(req, resolution, rule, "", rule.VaryHeaders)
 	bodyPath := app.PublicCache.bodyPath(keyDigest)
 	if err := os.MkdirAll(filepath.Dir(bodyPath), 0700); err != nil {
 		return db.PublicCacheEntry{}, err
@@ -1853,7 +2099,7 @@ func storeTestPublicCacheGeneration(app *App, resolution publicRouteResolution, 
 		RouteID:             sql.NullInt64{Int64: resolution.Route.ID, Valid: true},
 		RouteTargetID:       sql.NullInt64{Int64: resolution.Target.ID, Valid: true},
 		Method:              http.MethodGet,
-		VaryHeadersJson:     "[]",
+		VaryHeadersJson:     publicCacheStringListJSON(rule.VaryHeaders),
 		ResponseHeadersJson: `{"Content-Type":["text/plain"]}`,
 		StatusCode:          http.StatusOK,
 		BodyPath:            bodyPath,

--- a/internal/server/public_cache_test.go
+++ b/internal/server/public_cache_test.go
@@ -920,6 +920,139 @@ func TestPublicCacheIndexMaintainsPositiveAndNegativeLookupConsistency(t *testin
 	}
 }
 
+func TestPublicCacheStaleCandidateDoesNotOverwriteIndexedHits(t *testing.T) {
+	newCache := func(t *testing.T) (*publicProxyCache, uint64, string, db.PublicCacheEntry, publicCacheLookupKey, time.Time) {
+		t.Helper()
+		cache := newPublicProxyCache(t.TempDir())
+		settings := defaultPublicCacheSettings()
+		rules := []publicCacheRuleConfig{{ID: 1, Enabled: true, Fingerprint: "rule-v1"}}
+		fingerprint := publicCacheRuntimeFingerprint(settings, rules)
+		cache.reconcile(settings, rules)
+		generation, ok := cache.captureGeneration(fingerprint)
+		if !ok {
+			t.Fatal("cache generation was not current after reconcile")
+		}
+		now := time.Unix(1_700_000_000, 0)
+		entry := db.PublicCacheEntry{
+			KeyDigest:        "shared-digest",
+			RuleID:           1,
+			ListenerProtocol: publicListenerProtocolHTTP,
+			Host:             "assets.example",
+			Path:             "/asset",
+			ExpiresAt:        now.Add(time.Hour),
+		}
+		return cache, generation, fingerprint, entry, publicCacheLookupKeyFromEntry(entry), now
+	}
+
+	t.Run("deterministic interleaving", func(t *testing.T) {
+		cache, generation, fingerprint, staleEntry, lookup, now := newCache(t)
+		cache.storeIndexedCandidates(lookup, []db.PublicCacheEntry{staleEntry}, now, generation, fingerprint)
+		cache.touchIndexedEntry(staleEntry.KeyDigest, now.Add(time.Second))
+		cache.storeIndexedCandidates(lookup, []db.PublicCacheEntry{staleEntry}, now, generation, fingerprint)
+		cache.touchIndexedEntry(staleEntry.KeyDigest, now.Add(2*time.Second))
+
+		cache.mu.Lock()
+		indexed := cache.indexEntries[staleEntry.KeyDigest].entry
+		cache.mu.Unlock()
+		if indexed.HitCount != 2 {
+			t.Fatalf("indexed hit count = %d, want 2 after stale second store", indexed.HitCount)
+		}
+		if !indexed.LastAccessedAt.Equal(now.Add(2 * time.Second)) {
+			t.Fatalf("indexed last access = %s, want newest touch", indexed.LastAccessedAt)
+		}
+	})
+
+	t.Run("parallel cold loads", func(t *testing.T) {
+		cache, generation, fingerprint, staleEntry, lookup, now := newCache(t)
+		const workers = 64
+		start := make(chan struct{})
+		var group sync.WaitGroup
+		for i := 0; i < workers; i++ {
+			group.Add(1)
+			go func() {
+				defer group.Done()
+				<-start
+				cache.storeIndexedCandidates(lookup, []db.PublicCacheEntry{staleEntry}, now, generation, fingerprint)
+				cache.touchIndexedEntry(staleEntry.KeyDigest, now.Add(time.Second))
+			}()
+		}
+		close(start)
+		group.Wait()
+
+		cache.mu.Lock()
+		hitCount := cache.indexEntries[staleEntry.KeyDigest].entry.HitCount
+		cache.mu.Unlock()
+		if hitCount != workers {
+			t.Fatalf("parallel indexed hit count = %d, want %d", hitCount, workers)
+		}
+	})
+}
+
+func TestPublicCachePositiveIndexAdmissionIsBounded(t *testing.T) {
+	cache := newPublicProxyCache(t.TempDir())
+	settings := defaultPublicCacheSettings()
+	settings.MaxEntries = 1
+	rules := []publicCacheRuleConfig{{ID: 1, Enabled: true, Fingerprint: "rule-v1"}}
+	fingerprint := publicCacheRuntimeFingerprint(settings, rules)
+	cache.reconcile(settings, rules)
+	generation, ok := cache.captureGeneration(fingerprint)
+	if !ok {
+		t.Fatal("cache generation was not current after reconcile")
+	}
+	now := time.Unix(1_700_000_000, 0)
+	entryA := db.PublicCacheEntry{
+		KeyDigest:        "digest-a",
+		RuleID:           1,
+		ListenerProtocol: publicListenerProtocolHTTP,
+		Host:             "a.example",
+		Path:             "/asset",
+		ExpiresAt:        now.Add(time.Hour),
+	}
+	entryB := db.PublicCacheEntry{
+		KeyDigest:        "digest-b",
+		RuleID:           1,
+		ListenerProtocol: publicListenerProtocolHTTP,
+		Host:             "b.example",
+		Path:             "/asset",
+		ExpiresAt:        now.Add(time.Hour),
+	}
+	lookupB := publicCacheLookupKeyFromEntry(entryB)
+
+	cache.putIndexEntry(entryA)
+	cache.storeIndexedCandidates(lookupB, []db.PublicCacheEntry{entryB}, now, generation, fingerprint)
+	cache.storeIndexedCandidates(publicCacheLookupKey{
+		RuleID:           1,
+		ListenerProtocol: publicListenerProtocolHTTP,
+		Host:             "miss.example",
+		Path:             "/asset",
+	}, nil, now, generation, fingerprint)
+
+	cache.mu.Lock()
+	entryCount := len(cache.indexEntries)
+	_, keptA := cache.indexEntries[entryA.KeyDigest]
+	_, admittedB := cache.indexEntries[entryB.KeyDigest]
+	_, negativeB := cache.negativeLookups[publicCacheLookupKeyHash(lookupB)]
+	negativeCount := len(cache.negativeLookups)
+	cache.mu.Unlock()
+	if entryCount != 1 || !keptA || admittedB {
+		t.Fatalf("bounded positive index = count %d/kept A %v/admitted B %v, want 1/true/false", entryCount, keptA, admittedB)
+	}
+	if negativeB || negativeCount != 0 {
+		t.Fatalf("negative budget at positive cap = contradictory B %v/count %d, want false/0", negativeB, negativeCount)
+	}
+
+	entryA.HitCount = 7
+	entryA.LastAccessedAt = now.Add(time.Minute)
+	cache.putIndexEntry(entryA)
+	cache.mu.Lock()
+	updated := cache.indexEntries[entryA.KeyDigest].entry
+	entryCount = len(cache.indexEntries)
+	cache.mu.Unlock()
+	if entryCount != 1 || updated.HitCount != 7 || !updated.LastAccessedAt.Equal(entryA.LastAccessedAt) {
+		t.Fatalf("existing entry update at cap = count %d/hits %d/last access %s", entryCount, updated.HitCount, updated.LastAccessedAt)
+	}
+}
+
 func TestPublicCacheStaleConcurrentLookupLoadsCannotRepopulateAfterReconcile(t *testing.T) {
 	cache := newPublicProxyCache(t.TempDir())
 	settings := defaultPublicCacheSettings()

--- a/internal/server/public_cache_test.go
+++ b/internal/server/public_cache_test.go
@@ -858,6 +858,77 @@ func TestPublicCacheStaleIndexedBodyFallsBackToMiss(t *testing.T) {
 	}
 }
 
+func TestPublicCacheExpiredIndexedEntryInvalidatesRowIndexMemoryAndBody(t *testing.T) {
+	app, resolution, closeDB := newTestPublicCacheApp(t)
+	defer closeDB()
+
+	req := httptest.NewRequest(http.MethodGet, "http://assets.example.test/assets/expired.txt", nil)
+	snap := app.currentPublicSnapshot()
+	if snap == nil || len(snap.CacheRules) == 0 {
+		t.Fatal("test cache snapshot missing rule")
+	}
+	rule := snap.CacheRules[0]
+	keyDigest := publicCacheKeyDigest(req, resolution, rule, "", nil)
+	body := []byte("expired-body")
+	bodyPath := app.PublicCache.bodyPath(keyDigest)
+	if err := os.MkdirAll(filepath.Dir(bodyPath), 0700); err != nil {
+		t.Fatalf("create cache body dir: %v", err)
+	}
+	if err := os.WriteFile(bodyPath, body, 0600); err != nil {
+		t.Fatalf("write expired cache body: %v", err)
+	}
+	entry, err := app.DB.UpsertPublicCacheEntry(context.Background(), db.UpsertPublicCacheEntryParams{
+		KeyDigest:           keyDigest,
+		RuleID:              resolution.CacheRuleID,
+		Scope:               publicCacheScopeSelectedBackend,
+		ListenerProtocol:    resolution.Listener.Protocol,
+		Host:                "assets.example.test",
+		Path:                "/assets/expired.txt",
+		QueryKey:            "",
+		RouteID:             sql.NullInt64{Int64: resolution.Route.ID, Valid: true},
+		RouteTargetID:       sql.NullInt64{Int64: resolution.Target.ID, Valid: true},
+		Method:              http.MethodGet,
+		VaryHeadersJson:     "[]",
+		ResponseHeadersJson: `{"Content-Type":["text/plain"]}`,
+		StatusCode:          http.StatusOK,
+		BodyPath:            bodyPath,
+		SizeBytes:           int64(len(body)),
+		StoredAt:            app.PublicCache.nextStoredAt(),
+		ExpiresAt:           time.Now().Add(-time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("insert expired cache entry: %v", err)
+	}
+	app.PublicCache.putIndexEntry(entry)
+	app.PublicCache.putMemory(keyDigest, body)
+	app.PublicCache.mu.Lock()
+	app.PublicCache.lastCleanup = time.Now()
+	_, indexed := app.PublicCache.indexEntries[keyDigest]
+	_, inMemory := app.PublicCache.memoryEntries[keyDigest]
+	app.PublicCache.mu.Unlock()
+	if !indexed || !inMemory {
+		t.Fatalf("expired cache fixture was not indexed and warmed: index=%t memory=%t", indexed, inMemory)
+	}
+
+	decision := app.checkPublicCache(req, resolution)
+	if decision.Status != publicCacheStatusMiss {
+		t.Fatalf("expired cache status = %q, want miss", decision.Status)
+	}
+	if _, err := app.DB.GetPublicCacheEntry(context.Background(), keyDigest); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expired cache database row error = %v, want sql.ErrNoRows", err)
+	}
+	if _, err := os.Stat(bodyPath); !os.IsNotExist(err) {
+		t.Fatalf("expired cache body stat error = %v, want not exist", err)
+	}
+	app.PublicCache.mu.Lock()
+	_, indexed = app.PublicCache.indexEntries[keyDigest]
+	_, inMemory = app.PublicCache.memoryEntries[keyDigest]
+	app.PublicCache.mu.Unlock()
+	if indexed || inMemory {
+		t.Fatalf("expired cache state remained after invalidation: index=%t memory=%t", indexed, inMemory)
+	}
+}
+
 func TestPublicCacheEmptyMissUsesWarmedIndex(t *testing.T) {
 	app, resolution, closeDB := newTestPublicCacheApp(t)
 	defer closeDB()

--- a/sql/query.sql
+++ b/sql/query.sql
@@ -2157,6 +2157,17 @@ WHERE key_digest = sqlc.arg(key_digest)
 DELETE FROM public_cache_entries
 WHERE key_digest = ?;
 
+-- name: DeletePublicCacheEntryGeneration :execrows
+DELETE FROM public_cache_entries
+WHERE key_digest = sqlc.arg(key_digest)
+  AND (
+      stored_at = sqlc.arg(stored_at)
+      OR (
+          length(stored_at) = 19
+          AND stored_at = CAST(sqlc.arg(stored_at_legacy) AS TEXT)
+      )
+  );
+
 -- name: DeleteExpiredPublicCacheEntries :many
 DELETE FROM public_cache_entries
 WHERE expires_at <= ?

--- a/sql/query.sql
+++ b/sql/query.sql
@@ -2140,8 +2140,8 @@ RETURNING key_digest, rule_id, scope, listener_protocol, host, path, query_key, 
 -- name: TouchPublicCacheEntry :exec
 UPDATE public_cache_entries
 SET last_accessed_at = CURRENT_TIMESTAMP,
-    hit_count = hit_count + 1
-WHERE key_digest = ?;
+    hit_count = hit_count + sqlc.arg(hit_count)
+WHERE key_digest = sqlc.arg(key_digest);
 
 -- name: DeletePublicCacheEntry :exec
 DELETE FROM public_cache_entries

--- a/sql/query.sql
+++ b/sql/query.sql
@@ -2139,10 +2139,19 @@ RETURNING key_digest, rule_id, scope, listener_protocol, host, path, query_key, 
 
 -- name: TouchPublicCacheEntry :exec
 UPDATE public_cache_entries
-SET last_accessed_at = sqlc.arg(last_accessed_at),
+SET last_accessed_at = CASE
+        WHEN sqlc.arg(last_accessed_at) > last_accessed_at THEN sqlc.arg(last_accessed_at)
+        ELSE last_accessed_at
+    END,
     hit_count = hit_count + sqlc.arg(hit_count)
 WHERE key_digest = sqlc.arg(key_digest)
-  AND stored_at = sqlc.arg(stored_at);
+  AND (
+      stored_at = sqlc.arg(stored_at)
+      OR (
+          length(stored_at) = 19
+          AND stored_at = CAST(sqlc.arg(stored_at_legacy) AS TEXT)
+      )
+  );
 
 -- name: DeletePublicCacheEntry :exec
 DELETE FROM public_cache_entries

--- a/sql/query.sql
+++ b/sql/query.sql
@@ -2112,7 +2112,7 @@ INSERT INTO public_cache_entries (
     vary_headers_json, response_headers_json, status_code, body_path, size_bytes, stored_at, expires_at,
     last_accessed_at, hit_count
 ) VALUES (
-    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, CURRENT_TIMESTAMP, 0
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, sqlc.arg(stored_at), sqlc.arg(expires_at), sqlc.arg(stored_at), 0
 )
 ON CONFLICT(key_digest) DO UPDATE SET
     rule_id = excluded.rule_id,
@@ -2129,9 +2129,9 @@ ON CONFLICT(key_digest) DO UPDATE SET
     status_code = excluded.status_code,
     body_path = excluded.body_path,
     size_bytes = excluded.size_bytes,
-    stored_at = CURRENT_TIMESTAMP,
+    stored_at = excluded.stored_at,
     expires_at = excluded.expires_at,
-    last_accessed_at = CURRENT_TIMESTAMP,
+    last_accessed_at = excluded.stored_at,
     hit_count = 0
 RETURNING key_digest, rule_id, scope, listener_protocol, host, path, query_key, route_id, route_target_id, method,
           vary_headers_json, response_headers_json, status_code, body_path, size_bytes, stored_at, expires_at,
@@ -2139,9 +2139,10 @@ RETURNING key_digest, rule_id, scope, listener_protocol, host, path, query_key, 
 
 -- name: TouchPublicCacheEntry :exec
 UPDATE public_cache_entries
-SET last_accessed_at = CURRENT_TIMESTAMP,
+SET last_accessed_at = sqlc.arg(last_accessed_at),
     hit_count = hit_count + sqlc.arg(hit_count)
-WHERE key_digest = sqlc.arg(key_digest);
+WHERE key_digest = sqlc.arg(key_digest)
+  AND stored_at = sqlc.arg(stored_at);
 
 -- name: DeletePublicCacheEntry :exec
 DELETE FROM public_cache_entries

--- a/tests/integration/multi_agent_routing_test.go
+++ b/tests/integration/multi_agent_routing_test.go
@@ -207,6 +207,9 @@ func TestAgentPoolBackendsRouteOnlyToAssignedAgents(t *testing.T) {
 	baseURL := "http://" + publicListenerBoundAddress(t, status, listener.ID)
 	assertAgentRequest(t, baseURL+"/a")
 	assertAgentRequest(t, baseURL+"/b")
+	if err := app.FlushObservabilityRecorder(context.Background()); err != nil {
+		t.Fatalf("flush observability recorder: %v", err)
+	}
 	assertSelectedAgents(t, database, []int64{agentA.GetId(), agentB.GetId()})
 
 	cancel()

--- a/tests/integration/observability_test.go
+++ b/tests/integration/observability_test.go
@@ -206,6 +206,9 @@ func TestProxyRequestEventRecordedCountsOnly(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", resp.StatusCode)
 	}
+	if err := app.FlushObservabilityRecorder(context.Background()); err != nil {
+		t.Fatalf("flush observability recorder: %v", err)
+	}
 
 	summary, err := database.GetProxyRequestSummarySince(context.Background(), time.Now().UTC().Add(-time.Minute))
 	if err != nil {

--- a/tests/integration/route_redirect_test.go
+++ b/tests/integration/route_redirect_test.go
@@ -164,6 +164,9 @@ func TestPublicRouteRedirectResponses(t *testing.T) {
 			if got := resp.Header.Get("Location"); got != tt.wantLoc {
 				t.Fatalf("Location = %q, want %q", got, tt.wantLoc)
 			}
+			if err := app.FlushObservabilityRecorder(context.Background()); err != nil {
+				t.Fatalf("flush observability recorder: %v", err)
+			}
 
 			var routeID sql.NullInt64
 			var routeTargetID sql.NullInt64


### PR DESCRIPTION
## Summary
- queue proxy request events onto a buffered background recorder instead of writing SQLite synchronously on the proxy path
- batch raw event inserts with in-memory minute rollup aggregation in one transaction
- coalesce public cache hit touches per key and flush observability data during proxy/server shutdown

Closes #113

## Tests
- go test ./internal/server -run 'TestProxyRequestEventRollupsAreWrittenWithRawEvent|TestObservabilityRecorder|TestCloseObservabilityRecorder|TestPublicCache' -count=1\n- go test ./tests/integration -run 'TestPublicRouteRedirectResponses|TestAgentPoolBackendsRouteOnlyToAssignedAgents|TestProxyRequestEventRecordedCountsOnly' -count=1\n- go test ./internal/server ./tests/integration -count=1\n- go test ./... -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asynchronous observability recording with batching, event rollups, cache-hit tracking, bounded queues, and explicit flush controls.
  * Added automatic refresh support for active HTTPS listener configuration.
* **Bug Fixes**
  * Improved public-cache consistency during updates, expiration, purges, and concurrent requests.
  * Prevented stale cache generations or responses from replacing newer entries.
  * Improved graceful shutdown, including reliable persistence of queued observability data.
* **Tests**
  * Expanded coverage for cache invalidation, concurrency, observability, retries, and shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->