### PR TITLE
Raise Yamux stream window

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,9 @@ MANAGEMENT_PUBLIC_URL=https://your-server:8081
 # Optional: include extra hostnames/IPs in the auto-generated management TLS cert.
 # MANAGEMENT_TLS_EXTRA_HOSTS=proxy.example.com,192.0.2.10
 
-# Optional: raise for high-RTT/high-bandwidth agent tunnel streams.
-# TUNNEL_MAX_STREAM_WINDOW_BYTES=8388608
+# Optional: tune agent tunnel throughput within the bounded aggregate receive-window budget.
+# TUNNEL_MAX_STREAM_WINDOW_BYTES=2097152
+# TUNNEL_MAX_CONCURRENT_REQUESTS=64
 
 P2PSTREAM_HTTP_PORT=80
 P2PSTREAM_HTTPS_PORT=443

--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,13 @@
 MANAGEMENT_PUBLIC_URL=https://your-server:8081
 
-# Optional: disable the browser management UI while keeping the API and agent WebSocket available.
+# Optional: disable the browser management UI while keeping the API and agent Yamux tunnel available.
 # MANAGEMENT_UI_DISABLED=false
 
 # Optional: include extra hostnames/IPs in the auto-generated management TLS cert.
 # MANAGEMENT_TLS_EXTRA_HOSTS=proxy.example.com,192.0.2.10
+
+# Optional: raise for high-RTT/high-bandwidth agent tunnel streams.
+# TUNNEL_MAX_STREAM_WINDOW_BYTES=8388608
 
 P2PSTREAM_HTTP_PORT=80
 P2PSTREAM_HTTPS_PORT=443

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -72,18 +72,24 @@ var agentCmd = &cobra.Command{
 			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
+		tunnelMaxConcurrentRequests, err := agentTunnelMaxConcurrentRequests(cmd)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			os.Exit(1)
+		}
 
 		if err := agent.Run(agent.Options{
-			ManagementURL:              mgmtURL,
-			PublicID:                   agentID,
-			Name:                       agentName,
-			Token:                      agentToken,
-			ManagementCAFile:           managementCAFile,
-			ManagementCAPEMBase64:      managementCAPEMBase64,
-			TLSCertFile:                tlsCertFile,
-			TLSKeyFile:                 tlsKeyFile,
-			AllowInsecureManagement:    allowInsecureManagement,
-			TunnelMaxStreamWindowBytes: tunnelMaxStreamWindowBytes,
+			ManagementURL:               mgmtURL,
+			PublicID:                    agentID,
+			Name:                        agentName,
+			Token:                       agentToken,
+			ManagementCAFile:            managementCAFile,
+			ManagementCAPEMBase64:       managementCAPEMBase64,
+			TLSCertFile:                 tlsCertFile,
+			TLSKeyFile:                  tlsKeyFile,
+			AllowInsecureManagement:     allowInsecureManagement,
+			TunnelMaxStreamWindowBytes:  tunnelMaxStreamWindowBytes,
+			TunnelMaxConcurrentRequests: tunnelMaxConcurrentRequests,
 		}); err != nil {
 			fmt.Fprintln(os.Stderr, "agent failed: "+err.Error())
 			os.Exit(1)
@@ -103,6 +109,7 @@ func init() {
 	agentCmd.Flags().String("tls-key-file", "", "PEM private key for management mTLS")
 	agentCmd.Flags().Bool("allow-insecure-management", false, "Allow an insecure HTTP management URL")
 	agentCmd.Flags().Int64("tunnel-max-stream-window-bytes", tunnel.DefaultMaxStreamWindowSizeBytes, "Maximum Yamux receive window per tunnel stream in bytes")
+	agentCmd.Flags().Int64("tunnel-max-concurrent-requests", tunnel.DefaultMaxConcurrentAgentRequests, "Maximum concurrent requests served through the agent tunnel")
 }
 
 func defaultAgentManagementURL() string {
@@ -181,6 +188,21 @@ func agentTunnelMaxStreamWindowBytes(cmd *cobra.Command) (int64, error) {
 	value, err := strconv.ParseInt(raw, 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("invalid TUNNEL_MAX_STREAM_WINDOW_BYTES %q: %w", raw, err)
+	}
+	return value, nil
+}
+
+func agentTunnelMaxConcurrentRequests(cmd *cobra.Command) (int64, error) {
+	if cmd.Flags().Changed("tunnel-max-concurrent-requests") {
+		return cmd.Flags().GetInt64("tunnel-max-concurrent-requests")
+	}
+	raw := strings.TrimSpace(os.Getenv("TUNNEL_MAX_CONCURRENT_REQUESTS"))
+	if raw == "" {
+		return tunnel.DefaultMaxConcurrentAgentRequests, nil
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid TUNNEL_MAX_CONCURRENT_REQUESTS %q: %w", raw, err)
 	}
 	return value, nil
 }

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"p2pstream/internal/agent"
+	"p2pstream/internal/tunnel"
 )
 
 var agentCmd = &cobra.Command{
@@ -65,17 +67,23 @@ var agentCmd = &cobra.Command{
 		if !allowInsecureManagement {
 			allowInsecureManagement = envBool("AGENT_ALLOW_INSECURE_MANAGEMENT")
 		}
+		tunnelMaxStreamWindowBytes, err := agentTunnelMaxStreamWindowBytes(cmd)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			os.Exit(1)
+		}
 
 		if err := agent.Run(agent.Options{
-			ManagementURL:           mgmtURL,
-			PublicID:                agentID,
-			Name:                    agentName,
-			Token:                   agentToken,
-			ManagementCAFile:        managementCAFile,
-			ManagementCAPEMBase64:   managementCAPEMBase64,
-			TLSCertFile:             tlsCertFile,
-			TLSKeyFile:              tlsKeyFile,
-			AllowInsecureManagement: allowInsecureManagement,
+			ManagementURL:              mgmtURL,
+			PublicID:                   agentID,
+			Name:                       agentName,
+			Token:                      agentToken,
+			ManagementCAFile:           managementCAFile,
+			ManagementCAPEMBase64:      managementCAPEMBase64,
+			TLSCertFile:                tlsCertFile,
+			TLSKeyFile:                 tlsKeyFile,
+			AllowInsecureManagement:    allowInsecureManagement,
+			TunnelMaxStreamWindowBytes: tunnelMaxStreamWindowBytes,
 		}); err != nil {
 			fmt.Fprintln(os.Stderr, "agent failed: "+err.Error())
 			os.Exit(1)
@@ -94,6 +102,7 @@ func init() {
 	agentCmd.Flags().String("tls-cert-file", "", "PEM client certificate for management mTLS")
 	agentCmd.Flags().String("tls-key-file", "", "PEM private key for management mTLS")
 	agentCmd.Flags().Bool("allow-insecure-management", false, "Allow an insecure HTTP management URL")
+	agentCmd.Flags().Int64("tunnel-max-stream-window-bytes", tunnel.DefaultMaxStreamWindowSizeBytes, "Maximum Yamux receive window per tunnel stream in bytes")
 }
 
 func defaultAgentManagementURL() string {
@@ -159,4 +168,19 @@ func envBool(key string) bool {
 	default:
 		return false
 	}
+}
+
+func agentTunnelMaxStreamWindowBytes(cmd *cobra.Command) (int64, error) {
+	if cmd.Flags().Changed("tunnel-max-stream-window-bytes") {
+		return cmd.Flags().GetInt64("tunnel-max-stream-window-bytes")
+	}
+	raw := strings.TrimSpace(os.Getenv("TUNNEL_MAX_STREAM_WINDOW_BYTES"))
+	if raw == "" {
+		return tunnel.DefaultMaxStreamWindowSizeBytes, nil
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid TUNNEL_MAX_STREAM_WINDOW_BYTES %q: %w", raw, err)
+	}
+	return value, nil
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -41,6 +41,7 @@ p2pstream agent [flags]
 | `--tls-cert-file` | `AGENT_TLS_CERT_FILE` | Client certificate for management mTLS. |
 | `--tls-key-file` | `AGENT_TLS_KEY_FILE` | Client private key for management mTLS. |
 | `--allow-insecure-management` | `AGENT_ALLOW_INSECURE_MANAGEMENT` | Permit HTTP management URL. |
+| `--tunnel-max-stream-window-bytes` | `TUNNEL_MAX_STREAM_WINDOW_BYTES` | Maximum Yamux receive window per tunnel stream. |
 
 ## Validation Rules
 
@@ -48,6 +49,7 @@ p2pstream agent [flags]
 - Use only one password source: prompt, `--password-env`, or `--password-file`.
 - `agent` requires `AGENT_ID` and `AGENT_TOKEN`.
 - Agent HTTP management URLs are rejected unless `--allow-insecure-management` or `AGENT_ALLOW_INSECURE_MANAGEMENT` is set.
+- `--tunnel-max-stream-window-bytes` must be at least `262144` and at most `1073741824`.
 
 ## Runtime Effects
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -42,6 +42,7 @@ p2pstream agent [flags]
 | `--tls-key-file` | `AGENT_TLS_KEY_FILE` | Client private key for management mTLS. |
 | `--allow-insecure-management` | `AGENT_ALLOW_INSECURE_MANAGEMENT` | Permit HTTP management URL. |
 | `--tunnel-max-stream-window-bytes` | `TUNNEL_MAX_STREAM_WINDOW_BYTES` | Maximum Yamux receive window per tunnel stream. |
+| `--tunnel-max-concurrent-requests` | `TUNNEL_MAX_CONCURRENT_REQUESTS` | Maximum concurrent requests handled by the agent tunnel. |
 
 ## Validation Rules
 
@@ -49,7 +50,9 @@ p2pstream agent [flags]
 - Use only one password source: prompt, `--password-env`, or `--password-file`.
 - `agent` requires `AGENT_ID` and `AGENT_TOKEN`.
 - Agent HTTP management URLs are rejected unless `--allow-insecure-management` or `AGENT_ALLOW_INSECURE_MANAGEMENT` is set.
-- `--tunnel-max-stream-window-bytes` must be at least `262144` and at most `1073741824`.
+- `--tunnel-max-stream-window-bytes` must be at least `262144` and at most `67108864`.
+- `--tunnel-max-concurrent-requests` must be between `1` and `2048`.
+- The stream window multiplied by `--tunnel-max-concurrent-requests` cannot exceed `536870912` bytes.
 
 ## Runtime Effects
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -38,7 +38,7 @@ Set these on the server process via `.env` or environment. They control manageme
 | `OBSERVABILITY_MAX_ROWS`         | `1000000`                    | Maximum retained proxy request events and agent stat rows. Set `0` to disable this cap.       |
 | `LOGIN_THROTTLE_MAX_KEYS`        | `50000`                      | Maximum in-memory login throttle keys; active blocks are retained until expiry.              |
 | `TUNNEL_MAX_STREAM_WINDOW_BYTES` | `2097152`                    | Maximum Yamux receive window per tunnel stream. Raise for high-RTT/high-bandwidth agent links. |
-| `TUNNEL_MAX_CONCURRENT_REQUESTS` | `64`                         | Maximum concurrent public requests using agent tunnels across the server.                     |
+| `TUNNEL_MAX_CONCURRENT_REQUESTS` | `64`                         | Maximum concurrent public agent-route requests and live agent tunnel streams across the server. |
 
 If every login throttle slot is occupied by an active block, new failed-login keys are not tracked until a blocked key expires or a login succeeds for an existing key.
 
@@ -83,7 +83,7 @@ Set these as environment variables before running the Linux agent installer scri
 - `MANAGEMENT_PUBLIC_URL` must be absolute and must use `https`, unless management TLS is off and insecure HTTP is explicitly allowed.
 - `MANAGEMENT_BIND_ADDRESS` defaults to all interfaces so agents and remote clients can connect. Set it to `127.0.0.1` only for local-only management or when a local reverse proxy fronts management.
 - `TUNNEL_MAX_STREAM_WINDOW_BYTES` must be at least `262144` and at most `67108864`.
-- `TUNNEL_MAX_CONCURRENT_REQUESTS` must be between `1` and `2048`. Its product with `TUNNEL_MAX_STREAM_WINDOW_BYTES` cannot exceed `536870912` bytes, bounding attacker-controlled aggregate Yamux receive windows.
+- `TUNNEL_MAX_CONCURRENT_REQUESTS` must be between `1` and `2048`. Its product with `TUNNEL_MAX_STREAM_WINDOW_BYTES` cannot exceed `536870912` bytes. The server holds a slot for every live Yamux stream, including pooled idle HTTP connections, and the agent holds a slot for every handled stream, so the product bounds attacker-controlled aggregate receive windows at both ends.
 - Bootstrap agent ID, name, and token must all be set together.
 - Agent boolean parsing accepts `1`, `true`, `yes`, `y`, and `on`.
 - Linux agent installs require `AGENT_TLS_CERT_FILE` and `AGENT_TLS_KEY_FILE` together, require user-supplied TLS files to be readable, and reject CA/client-certificate settings with HTTP management URLs.
@@ -94,7 +94,7 @@ Set these as environment variables before running the Linux agent installer scri
 
 Management session cookies are Secure when management TLS is enabled, `ENV=production`, or `MANAGEMENT_COOKIE_SECURE=true`.
 
-When the tunnel concurrency limit is reached, additional public agent-route requests receive `503 Service Unavailable` and the agent is not marked passively unhealthy. Lower the stream window or concurrency limit for tighter memory bounds; raise either only while keeping their documented aggregate budget.
+When either the public-request cap or live-stream cap is reached, additional public agent-route requests receive `503 Service Unavailable` and the agent is not marked passively unhealthy. Environment and health-check dials share the server live-stream cap. Lower the stream window or concurrency limit for tighter memory bounds; raise either only while keeping their documented aggregate budget.
 
 ## Examples
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -37,13 +37,16 @@ Set these on the server process via `.env` or environment. They control manageme
 | `OBSERVABILITY_RETENTION_DAYS`   | `30`                         | Retention window for recorded observability data.                                            |
 | `OBSERVABILITY_MAX_ROWS`         | `1000000`                    | Maximum retained proxy request events and agent stat rows. Set `0` to disable this cap.       |
 | `LOGIN_THROTTLE_MAX_KEYS`        | `50000`                      | Maximum in-memory login throttle keys; active blocks are retained until expiry.              |
-| `TUNNEL_MAX_STREAM_WINDOW_BYTES` | `8388608`                    | Maximum Yamux receive window per tunnel stream. Raise for high-RTT/high-bandwidth agent links. |
+| `TUNNEL_MAX_STREAM_WINDOW_BYTES` | `2097152`                    | Maximum Yamux receive window per tunnel stream. Raise for high-RTT/high-bandwidth agent links. |
+| `TUNNEL_MAX_CONCURRENT_REQUESTS` | `64`                         | Maximum concurrent public requests using agent tunnels across the server.                     |
 
 If every login throttle slot is occupied by an active block, new failed-login keys are not tracked until a blocked key expires or a login succeeds for an existing key.
 
 ### Agent Variables
 
 Set these on each agent host via `/etc/p2pstream/agent.env` or the generated installer environment. The agent installer writes these automatically from the setup dialog.
+
+When tunnel window or concurrency values are supplied to the installer, they are written to `agent.env` and preserved by later reinstalls that do not provide replacements.
 
 | Variable                          | Description                                                          |
 | --------------------------------- | -------------------------------------------------------------------- |
@@ -56,7 +59,8 @@ Set these on each agent host via `/etc/p2pstream/agent.env` or the generated ins
 | `AGENT_TLS_CERT_FILE`             | Optional client certificate for management mTLS.                     |
 | `AGENT_TLS_KEY_FILE`              | Optional client private key for management mTLS.                     |
 | `AGENT_ALLOW_INSECURE_MANAGEMENT` | Allows HTTP management URL when truthy.                              |
-| `TUNNEL_MAX_STREAM_WINDOW_BYTES`  | Maximum Yamux receive window per tunnel stream. Defaults to `8388608`. |
+| `TUNNEL_MAX_STREAM_WINDOW_BYTES`  | Maximum Yamux receive window per tunnel stream. Defaults to `2097152`. |
+| `TUNNEL_MAX_CONCURRENT_REQUESTS`  | Maximum concurrent requests handled by this agent. Defaults to `64`. |
 
 ### Installer Variables
 
@@ -78,7 +82,8 @@ Set these as environment variables before running the Linux agent installer scri
 - `MANAGEMENT_TLS_MODE=off` requires `MANAGEMENT_ALLOW_INSECURE_HTTP=true`.
 - `MANAGEMENT_PUBLIC_URL` must be absolute and must use `https`, unless management TLS is off and insecure HTTP is explicitly allowed.
 - `MANAGEMENT_BIND_ADDRESS` defaults to all interfaces so agents and remote clients can connect. Set it to `127.0.0.1` only for local-only management or when a local reverse proxy fronts management.
-- `TUNNEL_MAX_STREAM_WINDOW_BYTES` must be at least `262144` and at most `1073741824`.
+- `TUNNEL_MAX_STREAM_WINDOW_BYTES` must be at least `262144` and at most `67108864`.
+- `TUNNEL_MAX_CONCURRENT_REQUESTS` must be between `1` and `2048`. Its product with `TUNNEL_MAX_STREAM_WINDOW_BYTES` cannot exceed `536870912` bytes, bounding attacker-controlled aggregate Yamux receive windows.
 - Bootstrap agent ID, name, and token must all be set together.
 - Agent boolean parsing accepts `1`, `true`, `yes`, `y`, and `on`.
 - Linux agent installs require `AGENT_TLS_CERT_FILE` and `AGENT_TLS_KEY_FILE` together, require user-supplied TLS files to be readable, and reject CA/client-certificate settings with HTTP management URLs.
@@ -88,6 +93,8 @@ Set these as environment variables before running the Linux agent installer scri
 `CONFIG_DIR` is created with `0700` permissions. The managed certificate directory is `${CONFIG_DIR}/certs`. SQLite database directories are created or tightened to `0700`, and database/WAL/SHM files are set to `0600`. If `DATABASE_URL` is unset, p2pstream also migrates a legacy local `p2pstream.db` into `${CONFIG_DIR}/p2pstream.db` when needed.
 
 Management session cookies are Secure when management TLS is enabled, `ENV=production`, or `MANAGEMENT_COOKIE_SECURE=true`.
+
+When the tunnel concurrency limit is reached, additional public agent-route requests receive `503 Service Unavailable` and the agent is not marked passively unhealthy. Lower the stream window or concurrency limit for tighter memory bounds; raise either only while keeping their documented aggregate budget.
 
 ## Examples
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -37,6 +37,7 @@ Set these on the server process via `.env` or environment. They control manageme
 | `OBSERVABILITY_RETENTION_DAYS`   | `30`                         | Retention window for recorded observability data.                                            |
 | `OBSERVABILITY_MAX_ROWS`         | `1000000`                    | Maximum retained proxy request events and agent stat rows. Set `0` to disable this cap.       |
 | `LOGIN_THROTTLE_MAX_KEYS`        | `50000`                      | Maximum in-memory login throttle keys; active blocks are retained until expiry.              |
+| `TUNNEL_MAX_STREAM_WINDOW_BYTES` | `8388608`                    | Maximum Yamux receive window per tunnel stream. Raise for high-RTT/high-bandwidth agent links. |
 
 If every login throttle slot is occupied by an active block, new failed-login keys are not tracked until a blocked key expires or a login succeeds for an existing key.
 
@@ -55,6 +56,7 @@ Set these on each agent host via `/etc/p2pstream/agent.env` or the generated ins
 | `AGENT_TLS_CERT_FILE`             | Optional client certificate for management mTLS.                     |
 | `AGENT_TLS_KEY_FILE`              | Optional client private key for management mTLS.                     |
 | `AGENT_ALLOW_INSECURE_MANAGEMENT` | Allows HTTP management URL when truthy.                              |
+| `TUNNEL_MAX_STREAM_WINDOW_BYTES`  | Maximum Yamux receive window per tunnel stream. Defaults to `8388608`. |
 
 ### Installer Variables
 
@@ -76,6 +78,7 @@ Set these as environment variables before running the Linux agent installer scri
 - `MANAGEMENT_TLS_MODE=off` requires `MANAGEMENT_ALLOW_INSECURE_HTTP=true`.
 - `MANAGEMENT_PUBLIC_URL` must be absolute and must use `https`, unless management TLS is off and insecure HTTP is explicitly allowed.
 - `MANAGEMENT_BIND_ADDRESS` defaults to all interfaces so agents and remote clients can connect. Set it to `127.0.0.1` only for local-only management or when a local reverse proxy fronts management.
+- `TUNNEL_MAX_STREAM_WINDOW_BYTES` must be at least `262144` and at most `1073741824`.
 - Bootstrap agent ID, name, and token must all be set together.
 - Agent boolean parsing accepts `1`, `true`, `yes`, `y`, and `on`.
 - Linux agent installs require `AGENT_TLS_CERT_FILE` and `AGENT_TLS_KEY_FILE` together, require user-supplied TLS files to be readable, and reject CA/client-certificate settings with HTTP management URLs.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -46,7 +46,7 @@ If every login throttle slot is occupied by an active block, new failed-login ke
 
 Set these on each agent host via `/etc/p2pstream/agent.env` or the generated installer environment. The agent installer writes these automatically from the setup dialog.
 
-When tunnel window or concurrency values are supplied to the installer, they are written to `agent.env` and preserved by later reinstalls that do not provide replacements.
+When tunnel window or concurrency values are supplied to the installer, they are written to `agent.env` and the effective last numeric assignments are preserved by later reinstalls that do not provide replacements. Preservation is preflighted before installer mutations and fails closed if the existing environment file is unreadable or uses unsupported or multiline syntax. Supplying both values explicitly replaces them without reading the old file.
 
 | Variable                          | Description                                                          |
 | --------------------------------- | -------------------------------------------------------------------- |

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -45,19 +45,23 @@ var (
 	agentReconnectBackoffMax      = 30 * time.Second
 )
 
-const agentTunnelResponseHeaderTimeout = 15 * time.Second
+const (
+	agentTunnelResponseHeaderTimeout = 15 * time.Second
+	agentCapacityResponseTimeout     = time.Second
+)
 
 type Options struct {
-	ManagementURL              string
-	PublicID                   string
-	Name                       string
-	Token                      string
-	ManagementCAFile           string
-	ManagementCAPEMBase64      string
-	TLSCertFile                string
-	TLSKeyFile                 string
-	AllowInsecureManagement    bool
-	TunnelMaxStreamWindowBytes int64
+	ManagementURL               string
+	PublicID                    string
+	Name                        string
+	Token                       string
+	ManagementCAFile            string
+	ManagementCAPEMBase64       string
+	TLSCertFile                 string
+	TLSKeyFile                  string
+	AllowInsecureManagement     bool
+	TunnelMaxStreamWindowBytes  int64
+	TunnelMaxConcurrentRequests int64
 }
 
 // Run is the main entry point to start the agent loop
@@ -85,7 +89,15 @@ func Run(opts Options) error {
 		log.Info().Str("tunnel_url", tunnelURL).Msg("Attempting to connect to management server...")
 
 		connectedAt := time.Now()
-		err := connectAndServe(tunnelClient, tunnelURL, opts.PublicID, opts.Name, opts.Token, opts.TunnelMaxStreamWindowBytes)
+		err := connectAndServe(
+			tunnelClient,
+			tunnelURL,
+			opts.PublicID,
+			opts.Name,
+			opts.Token,
+			opts.TunnelMaxStreamWindowBytes,
+			opts.TunnelMaxConcurrentRequests,
+		)
 		if err != nil {
 			log.Warn().Err(err).Msg("Disconnected")
 		}
@@ -145,7 +157,7 @@ func validateOptions(opts Options) error {
 	if parsed.Scheme != "https" && (hasClientCert || strings.TrimSpace(opts.ManagementCAFile) != "" || strings.TrimSpace(opts.ManagementCAPEMBase64) != "") {
 		return fmt.Errorf("agent TLS files require an https management URL")
 	}
-	if _, err := tunnel.NormalizeMaxStreamWindowSizeBytes(opts.TunnelMaxStreamWindowBytes); err != nil {
+	if err := tunnel.ValidateAggregateStreamWindowBudget(opts.TunnelMaxStreamWindowBytes, opts.TunnelMaxConcurrentRequests); err != nil {
 		return err
 	}
 	return nil
@@ -273,7 +285,7 @@ func managementTunnelHTTPClient(base *http.Client) (*http.Client, error) {
 	}, nil
 }
 
-func connectAndServe(client *http.Client, tunnelURL string, agentPublicID string, agentName string, agentToken string, maxStreamWindowSizeBytes int64) error {
+func connectAndServe(client *http.Client, tunnelURL string, agentPublicID string, agentName string, agentToken string, maxStreamWindowSizeBytes int64, maxConcurrentRequests int64) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -332,7 +344,7 @@ func connectAndServe(client *http.Client, tunnelURL string, agentPublicID string
 		_ = session.Close()
 	}()
 
-	if err := serveTunnelSession(ctx, session); err != nil {
+	if err := serveTunnelSessionWithLimit(ctx, session, maxConcurrentRequests); err != nil {
 		log.Debug().Err(err).Msg("Tunnel session ended")
 		return err
 	}
@@ -341,6 +353,14 @@ func connectAndServe(client *http.Client, tunnelURL string, agentPublicID string
 }
 
 func serveTunnelSession(ctx context.Context, session *yamux.Session) error {
+	return serveTunnelSessionWithLimit(ctx, session, 0)
+}
+
+func serveTunnelSessionWithLimit(ctx context.Context, session *yamux.Session, maxConcurrentRequests int64) error {
+	limiter, err := tunnel.NewStreamLimiter(maxConcurrentRequests)
+	if err != nil {
+		return fmt.Errorf("invalid tunnel request limit: %w", err)
+	}
 	for {
 		stream, err := session.Accept()
 		if err != nil {
@@ -351,8 +371,30 @@ func serveTunnelSession(ctx context.Context, session *yamux.Session) error {
 			log.Debug().Err(err).Msg("Tunnel stream accept loop stopped")
 			return fmt.Errorf("accept tunnel stream: %w", err)
 		}
-		go handleTunnelStream(ctx, stream)
+		release, ok := limiter.TryAcquire()
+		if !ok {
+			reqServerError.Add(1)
+			rejectTunnelStreamAtCapacity(stream)
+			continue
+		}
+		go func() {
+			defer release()
+			handleTunnelStream(ctx, stream)
+		}()
 	}
+}
+
+func rejectTunnelStreamAtCapacity(stream net.Conn) {
+	defer stream.Close()
+	_ = stream.SetDeadline(time.Now().Add(agentCapacityResponseTimeout))
+	if _, err := tunnel.ReadOpenRequest(stream); err != nil {
+		return
+	}
+	_ = tunnel.WriteOpenResponse(stream, tunnel.OpenResponse{
+		OK:        false,
+		ErrorKind: "agent_capacity",
+		Error:     "agent tunnel request capacity reached",
+	})
 }
 
 func handleTunnelStream(ctx context.Context, stream net.Conn) {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -48,15 +48,16 @@ var (
 const agentTunnelResponseHeaderTimeout = 15 * time.Second
 
 type Options struct {
-	ManagementURL           string
-	PublicID                string
-	Name                    string
-	Token                   string
-	ManagementCAFile        string
-	ManagementCAPEMBase64   string
-	TLSCertFile             string
-	TLSKeyFile              string
-	AllowInsecureManagement bool
+	ManagementURL              string
+	PublicID                   string
+	Name                       string
+	Token                      string
+	ManagementCAFile           string
+	ManagementCAPEMBase64      string
+	TLSCertFile                string
+	TLSKeyFile                 string
+	AllowInsecureManagement    bool
+	TunnelMaxStreamWindowBytes int64
 }
 
 // Run is the main entry point to start the agent loop
@@ -84,7 +85,7 @@ func Run(opts Options) error {
 		log.Info().Str("tunnel_url", tunnelURL).Msg("Attempting to connect to management server...")
 
 		connectedAt := time.Now()
-		err := connectAndServe(tunnelClient, tunnelURL, opts.PublicID, opts.Name, opts.Token)
+		err := connectAndServe(tunnelClient, tunnelURL, opts.PublicID, opts.Name, opts.Token, opts.TunnelMaxStreamWindowBytes)
 		if err != nil {
 			log.Warn().Err(err).Msg("Disconnected")
 		}
@@ -143,6 +144,9 @@ func validateOptions(opts Options) error {
 	}
 	if parsed.Scheme != "https" && (hasClientCert || strings.TrimSpace(opts.ManagementCAFile) != "" || strings.TrimSpace(opts.ManagementCAPEMBase64) != "") {
 		return fmt.Errorf("agent TLS files require an https management URL")
+	}
+	if _, err := tunnel.NormalizeMaxStreamWindowSizeBytes(opts.TunnelMaxStreamWindowBytes); err != nil {
+		return err
 	}
 	return nil
 }
@@ -269,7 +273,7 @@ func managementTunnelHTTPClient(base *http.Client) (*http.Client, error) {
 	}, nil
 }
 
-func connectAndServe(client *http.Client, tunnelURL string, agentPublicID string, agentName string, agentToken string) error {
+func connectAndServe(client *http.Client, tunnelURL string, agentPublicID string, agentName string, agentToken string, maxStreamWindowSizeBytes int64) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -309,7 +313,12 @@ func connectAndServe(client *http.Client, tunnelURL string, agentPublicID string
 		_ = resp.Body.Close()
 		return fmt.Errorf("agent tunnel response body is %T, want io.ReadWriteCloser", resp.Body)
 	}
-	session, err := yamux.Client(rwc, tunnel.DefaultYamuxConfig(nil))
+	yamuxConfig, err := tunnel.NewYamuxConfig(nil, maxStreamWindowSizeBytes)
+	if err != nil {
+		_ = rwc.Close()
+		return fmt.Errorf("invalid tunnel yamux configuration: %w", err)
+	}
+	session, err := yamux.Client(rwc, yamuxConfig)
 	if err != nil {
 		_ = rwc.Close()
 		return fmt.Errorf("failed to initialize tunnel session: %w", err)

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -100,6 +100,79 @@ func TestTunnelSessionRelaysTCPStream(t *testing.T) {
 	}
 }
 
+func TestTunnelSessionBoundsConcurrentRequests(t *testing.T) {
+	resetAgentRequestCounters()
+	t.Cleanup(resetAgentRequestCounters)
+
+	upstream := startEchoListener(t)
+	clientConn, serverConn := net.Pipe()
+	agentSession, err := yamux.Client(clientConn, tunnel.DefaultYamuxConfig(nil))
+	if err != nil {
+		t.Fatalf("agent yamux client: %v", err)
+	}
+	serverSession, err := yamux.Server(serverConn, tunnel.DefaultYamuxConfig(nil))
+	if err != nil {
+		t.Fatalf("server yamux session: %v", err)
+	}
+	defer agentSession.Close()
+	defer serverSession.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_ = serveTunnelSessionWithLimit(ctx, agentSession, 1)
+	}()
+
+	first, err := serverSession.Open()
+	if err != nil {
+		t.Fatalf("open first stream: %v", err)
+	}
+	if err := tunnel.WriteOpenRequest(first, tunnel.NewOpenRequest("req-1", "tcp", upstream.Addr().String())); err != nil {
+		t.Fatalf("write first open request: %v", err)
+	}
+	if resp, err := tunnel.ReadOpenResponse(first); err != nil || !resp.OK {
+		t.Fatalf("first open response = %+v, err=%v, want ok", resp, err)
+	}
+
+	second, err := serverSession.Open()
+	if err != nil {
+		t.Fatalf("open second stream: %v", err)
+	}
+	if err := tunnel.WriteOpenRequest(second, tunnel.NewOpenRequest("req-2", "tcp", upstream.Addr().String())); err != nil {
+		t.Fatalf("write second open request: %v", err)
+	}
+	_ = second.SetReadDeadline(time.Now().Add(time.Second))
+	resp, err := tunnel.ReadOpenResponse(second)
+	if err != nil {
+		t.Fatalf("read capacity response: %v", err)
+	}
+	if resp.OK || resp.ErrorKind != "agent_capacity" {
+		t.Fatalf("second open response = %+v, want agent_capacity", resp)
+	}
+	_ = second.Close()
+
+	_ = first.Close()
+	deadline := time.Now().Add(2 * time.Second)
+	for activeRequests.Load() != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := activeRequests.Load(); got != 0 {
+		t.Fatalf("active requests after first close = %d, want 0", got)
+	}
+
+	third, err := serverSession.Open()
+	if err != nil {
+		t.Fatalf("open third stream: %v", err)
+	}
+	defer third.Close()
+	if err := tunnel.WriteOpenRequest(third, tunnel.NewOpenRequest("req-3", "tcp", upstream.Addr().String())); err != nil {
+		t.Fatalf("write third open request: %v", err)
+	}
+	if resp, err := tunnel.ReadOpenResponse(third); err != nil || !resp.OK {
+		t.Fatalf("third open response = %+v, err=%v, want capacity to recover", resp, err)
+	}
+}
+
 func TestTunnelSessionReturnsDialFailure(t *testing.T) {
 	resetAgentRequestCounters()
 	t.Cleanup(resetAgentRequestCounters)

--- a/internal/agent/management_tls_test.go
+++ b/internal/agent/management_tls_test.go
@@ -243,6 +243,10 @@ func TestManagementHTTPClientValidation(t *testing.T) {
 			name: "unsupported scheme",
 			opts: Options{ManagementURL: "unix:///tmp/socket"},
 		},
+		{
+			name: "small tunnel stream window",
+			opts: Options{ManagementURL: "https://example.test", TunnelMaxStreamWindowBytes: 1},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/agent/management_tls_test.go
+++ b/internal/agent/management_tls_test.go
@@ -247,6 +247,14 @@ func TestManagementHTTPClientValidation(t *testing.T) {
 			name: "small tunnel stream window",
 			opts: Options{ManagementURL: "https://example.test", TunnelMaxStreamWindowBytes: 1},
 		},
+		{
+			name: "excessive concurrent tunnel requests",
+			opts: Options{ManagementURL: "https://example.test", TunnelMaxConcurrentRequests: 2049},
+		},
+		{
+			name: "aggregate tunnel receive window",
+			opts: Options{ManagementURL: "https://example.test", TunnelMaxStreamWindowBytes: 64 * 1024 * 1024, TunnelMaxConcurrentRequests: 9},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/caarlos0/env/v10"
 	"github.com/joho/godotenv"
+
+	"p2pstream/internal/tunnel"
 )
 
 const (
@@ -46,6 +48,7 @@ type Config struct {
 	ObservabilityRetentionDays  int    `env:"OBSERVABILITY_RETENTION_DAYS" envDefault:"30"`
 	ObservabilityMaxRows        int64  `env:"OBSERVABILITY_MAX_ROWS" envDefault:"1000000"`
 	LoginThrottleMaxKeys        int    `env:"LOGIN_THROTTLE_MAX_KEYS" envDefault:"50000"`
+	TunnelMaxStreamWindowBytes  int64  `env:"TUNNEL_MAX_STREAM_WINDOW_BYTES" envDefault:"8388608"`
 
 	CertsDir                        string `env:"-"`
 	ManagementTLSEnabled            bool   `env:"-"`
@@ -107,6 +110,9 @@ func validateManagementTLSConfig(cfg *Config) error {
 	}
 	if cfg.LoginThrottleMaxKeys <= 0 {
 		return errors.New("LOGIN_THROTTLE_MAX_KEYS must be greater than 0")
+	}
+	if _, err := tunnel.NormalizeMaxStreamWindowSizeBytes(cfg.TunnelMaxStreamWindowBytes); err != nil {
+		return err
 	}
 	cfg.ManagementTLSCertFile = strings.TrimSpace(cfg.ManagementTLSCertFile)
 	cfg.ManagementTLSKeyFile = strings.TrimSpace(cfg.ManagementTLSKeyFile)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,7 +48,8 @@ type Config struct {
 	ObservabilityRetentionDays  int    `env:"OBSERVABILITY_RETENTION_DAYS" envDefault:"30"`
 	ObservabilityMaxRows        int64  `env:"OBSERVABILITY_MAX_ROWS" envDefault:"1000000"`
 	LoginThrottleMaxKeys        int    `env:"LOGIN_THROTTLE_MAX_KEYS" envDefault:"50000"`
-	TunnelMaxStreamWindowBytes  int64  `env:"TUNNEL_MAX_STREAM_WINDOW_BYTES" envDefault:"8388608"`
+	TunnelMaxStreamWindowBytes  int64  `env:"TUNNEL_MAX_STREAM_WINDOW_BYTES" envDefault:"2097152"`
+	TunnelMaxConcurrentRequests int64  `env:"TUNNEL_MAX_CONCURRENT_REQUESTS" envDefault:"64"`
 
 	CertsDir                        string `env:"-"`
 	ManagementTLSEnabled            bool   `env:"-"`
@@ -111,7 +112,7 @@ func validateManagementTLSConfig(cfg *Config) error {
 	if cfg.LoginThrottleMaxKeys <= 0 {
 		return errors.New("LOGIN_THROTTLE_MAX_KEYS must be greater than 0")
 	}
-	if _, err := tunnel.NormalizeMaxStreamWindowSizeBytes(cfg.TunnelMaxStreamWindowBytes); err != nil {
+	if err := tunnel.ValidateAggregateStreamWindowBudget(cfg.TunnelMaxStreamWindowBytes, cfg.TunnelMaxConcurrentRequests); err != nil {
 		return err
 	}
 	cfg.ManagementTLSCertFile = strings.TrimSpace(cfg.ManagementTLSCertFile)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -115,8 +115,11 @@ func TestLoadManagementBindAndSecurityDefaults(t *testing.T) {
 	if cfg.LoginThrottleMaxKeys != 50_000 {
 		t.Fatalf("LoginThrottleMaxKeys = %d, want 50000", cfg.LoginThrottleMaxKeys)
 	}
-	if cfg.TunnelMaxStreamWindowBytes != 8*1024*1024 {
-		t.Fatalf("TunnelMaxStreamWindowBytes = %d, want 8388608", cfg.TunnelMaxStreamWindowBytes)
+	if cfg.TunnelMaxStreamWindowBytes != 2*1024*1024 {
+		t.Fatalf("TunnelMaxStreamWindowBytes = %d, want 2097152", cfg.TunnelMaxStreamWindowBytes)
+	}
+	if cfg.TunnelMaxConcurrentRequests != 64 {
+		t.Fatalf("TunnelMaxConcurrentRequests = %d, want 64", cfg.TunnelMaxConcurrentRequests)
 	}
 }
 
@@ -182,10 +185,21 @@ func TestLoadValidatesSecurityLimitBounds(t *testing.T) {
 	t.Run("large tunnel stream window rejected", func(t *testing.T) {
 		workDir := isolatedConfigTestDir(t)
 		t.Setenv("CONFIG_DIR", filepath.Join(workDir, "data"))
-		t.Setenv("TUNNEL_MAX_STREAM_WINDOW_BYTES", "1073741825")
+		t.Setenv("TUNNEL_MAX_STREAM_WINDOW_BYTES", "67108865")
 
 		if _, err := Load(); err == nil {
 			t.Fatal("expected large TUNNEL_MAX_STREAM_WINDOW_BYTES to fail")
+		}
+	})
+
+	t.Run("aggregate tunnel window budget rejected", func(t *testing.T) {
+		workDir := isolatedConfigTestDir(t)
+		t.Setenv("CONFIG_DIR", filepath.Join(workDir, "data"))
+		t.Setenv("TUNNEL_MAX_STREAM_WINDOW_BYTES", "67108864")
+		t.Setenv("TUNNEL_MAX_CONCURRENT_REQUESTS", "9")
+
+		if _, err := Load(); err == nil {
+			t.Fatal("expected aggregate tunnel receive-window budget to fail")
 		}
 	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -115,6 +115,9 @@ func TestLoadManagementBindAndSecurityDefaults(t *testing.T) {
 	if cfg.LoginThrottleMaxKeys != 50_000 {
 		t.Fatalf("LoginThrottleMaxKeys = %d, want 50000", cfg.LoginThrottleMaxKeys)
 	}
+	if cfg.TunnelMaxStreamWindowBytes != 8*1024*1024 {
+		t.Fatalf("TunnelMaxStreamWindowBytes = %d, want 8388608", cfg.TunnelMaxStreamWindowBytes)
+	}
 }
 
 func TestLoadRespectsExplicitManagementBindAddress(t *testing.T) {
@@ -163,6 +166,26 @@ func TestLoadValidatesSecurityLimitBounds(t *testing.T) {
 
 		if _, err := Load(); err == nil {
 			t.Fatal("expected zero LOGIN_THROTTLE_MAX_KEYS to fail")
+		}
+	})
+
+	t.Run("small tunnel stream window rejected", func(t *testing.T) {
+		workDir := isolatedConfigTestDir(t)
+		t.Setenv("CONFIG_DIR", filepath.Join(workDir, "data"))
+		t.Setenv("TUNNEL_MAX_STREAM_WINDOW_BYTES", "1")
+
+		if _, err := Load(); err == nil {
+			t.Fatal("expected small TUNNEL_MAX_STREAM_WINDOW_BYTES to fail")
+		}
+	})
+
+	t.Run("large tunnel stream window rejected", func(t *testing.T) {
+		workDir := isolatedConfigTestDir(t)
+		t.Setenv("CONFIG_DIR", filepath.Join(workDir, "data"))
+		t.Setenv("TUNNEL_MAX_STREAM_WINDOW_BYTES", "1073741825")
+
+		if _, err := Load(); err == nil {
+			t.Fatal("expected large TUNNEL_MAX_STREAM_WINDOW_BYTES to fail")
 		}
 	})
 }

--- a/internal/server/agent_registry_test.go
+++ b/internal/server/agent_registry_test.go
@@ -321,6 +321,178 @@ func TestRotateAgentTokenClosesTunnelConnection(t *testing.T) {
 	waitForAgentHubConnection(t, app, agent.ID, true)
 }
 
+func TestAgentTunnelRejectsAgentInitiatedStreams(t *testing.T) {
+	database := newAgentRegistryTestDB(t)
+	app := NewApp(&config.Config{ManagementUIDisabled: true}, database)
+	agent := createAgentRegistryTestAgent(t, database, "agent-stream-direction", "Stream Direction", "token")
+	mux := http.NewServeMux()
+	app.RegisterManagementRoutes(mux)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	agentSession, conn, err := dialAgentRegistryTestTunnel(server.URL, agent.PublicID, "token")
+	if err != nil {
+		t.Fatalf("dial agent tunnel: %v", err)
+	}
+	defer conn.Close()
+	defer agentSession.Close()
+	waitForAgentHubConnection(t, app, agent.ID, true)
+
+	serverAgent := app.AgentHub.connectedByID(agent.ID)
+	if serverAgent == nil || serverAgent.Session == nil {
+		t.Fatal("agent tunnel session was not registered")
+	}
+
+	// A ping round trip is an ordering barrier: the agent must process the
+	// server's GoAway frame before the later ping response can arrive.
+	if _, err := agentSession.Ping(); err != nil {
+		t.Fatalf("ping agent tunnel after server GoAway: %v", err)
+	}
+	if stream, err := agentSession.Open(); !errors.Is(err, yamux.ErrRemoteGoAway) {
+		if stream != nil {
+			_ = stream.Close()
+		}
+		t.Fatalf("agent-initiated stream error = %v, want %v", err, yamux.ErrRemoteGoAway)
+	}
+	assertYamuxStreamCounts(t, serverAgent.Session, agentSession, 0)
+
+	acceptedCh := make(chan net.Conn, 1)
+	acceptErrCh := make(chan error, 1)
+	go func() {
+		stream, err := agentSession.Accept()
+		if err != nil {
+			acceptErrCh <- err
+			return
+		}
+		acceptedCh <- stream
+	}()
+
+	serverStream, err := serverAgent.Session.Open()
+	if err != nil {
+		t.Fatalf("open server-initiated stream: %v", err)
+	}
+	var agentStream net.Conn
+	select {
+	case agentStream = <-acceptedCh:
+	case err := <-acceptErrCh:
+		_ = serverStream.Close()
+		t.Fatalf("accept server-initiated stream: %v", err)
+	case <-time.After(2 * time.Second):
+		_ = serverStream.Close()
+		t.Fatal("timed out accepting server-initiated stream")
+	}
+
+	if err := serverStream.Close(); err != nil {
+		t.Fatalf("close server stream: %v", err)
+	}
+	if err := agentStream.Close(); err != nil {
+		t.Fatalf("close agent stream: %v", err)
+	}
+	assertYamuxStreamCounts(t, serverAgent.Session, agentSession, 0)
+}
+
+func TestAgentTunnelReadGateRejectsSYNQueuedBeforeGoAway(t *testing.T) {
+	serverConn, rawAgentConn := newAgentRegistryLocalTCPPair(t)
+	gatedConn := &agentTunnelReadGateConn{Conn: serverConn, ready: make(chan struct{})}
+	t.Cleanup(gatedConn.releaseReads)
+	serverSession, err := yamux.Server(gatedConn, tunnel.DefaultYamuxConfig(nil))
+	if err != nil {
+		t.Fatalf("create server session: %v", err)
+	}
+	defer serverSession.Close()
+
+	agentSession, err := yamux.Client(rawAgentConn, tunnel.DefaultYamuxConfig(nil))
+	if err != nil {
+		t.Fatalf("create agent session: %v", err)
+	}
+	defer agentSession.Close()
+
+	type openResult struct {
+		stream net.Conn
+		err    error
+	}
+	openCh := make(chan openResult, 1)
+	go func() {
+		stream, err := agentSession.Open()
+		openCh <- openResult{stream: stream, err: err}
+	}()
+
+	var preGoAwayStream net.Conn
+	select {
+	case result := <-openCh:
+		if result.err != nil {
+			t.Fatalf("prebuffer pre-GoAway agent SYN: %v", result.err)
+		}
+		if result.stream == nil {
+			t.Fatal("pre-GoAway agent SYN returned a nil stream")
+		}
+		preGoAwayStream = result.stream
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out prebuffering pre-GoAway agent SYN")
+	}
+	defer preGoAwayStream.Close()
+	if got := serverSession.NumStreams(); got != 0 {
+		t.Fatalf("server streams before releasing read gate = %d, want 0", got)
+	}
+
+	if err := serverSession.GoAway(); err != nil {
+		t.Fatalf("send server GoAway: %v", err)
+	}
+	gatedConn.releaseReads()
+
+	// The ping response follows the GoAway and RST frames on the server wire,
+	// so its completion proves the queued SYN has been rejected and drained.
+	if _, err := agentSession.Ping(); err != nil {
+		t.Fatalf("ping after releasing read gate: %v", err)
+	}
+	if err := preGoAwayStream.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set rejected stream deadline: %v", err)
+	}
+	if _, err := preGoAwayStream.Read(make([]byte, 1)); !errors.Is(err, yamux.ErrConnectionReset) {
+		t.Fatalf("pre-GoAway agent stream read error = %v, want %v", err, yamux.ErrConnectionReset)
+	}
+	assertYamuxStreamCounts(t, serverSession, agentSession, 0)
+
+	if stream, err := agentSession.Open(); !errors.Is(err, yamux.ErrRemoteGoAway) {
+		if stream != nil {
+			_ = stream.Close()
+		}
+		t.Fatalf("post-GoAway agent stream error = %v, want %v", err, yamux.ErrRemoteGoAway)
+	}
+
+	acceptedCh := make(chan net.Conn, 1)
+	acceptErrCh := make(chan error, 1)
+	go func() {
+		stream, err := agentSession.Accept()
+		if err != nil {
+			acceptErrCh <- err
+			return
+		}
+		acceptedCh <- stream
+	}()
+	serverStream, err := serverSession.Open()
+	if err != nil {
+		t.Fatalf("open server stream after GoAway: %v", err)
+	}
+	var agentStream net.Conn
+	select {
+	case agentStream = <-acceptedCh:
+	case err := <-acceptErrCh:
+		_ = serverStream.Close()
+		t.Fatalf("accept server stream after GoAway: %v", err)
+	case <-time.After(2 * time.Second):
+		_ = serverStream.Close()
+		t.Fatal("timed out accepting server stream after GoAway")
+	}
+	if err := serverStream.Close(); err != nil {
+		t.Fatalf("close server stream after GoAway: %v", err)
+	}
+	if err := agentStream.Close(); err != nil {
+		t.Fatalf("close agent stream after GoAway: %v", err)
+	}
+	assertYamuxStreamCounts(t, serverSession, agentSession, 0)
+}
+
 func TestAgentTunnelRechecksTokenBeforeRegisteringAfterRotation(t *testing.T) {
 	database := newAgentRegistryTestDB(t)
 	app := NewApp(&config.Config{ManagementUIDisabled: true}, database)
@@ -839,16 +1011,76 @@ func dialAgentRegistryTestTunnel(serverURL string, publicID string, token string
 		conn.Close()
 		return nil, nil, fmt.Errorf("agent tunnel upgrade header = %q", got)
 	}
-	if reader.Buffered() > 0 {
-		conn.Close()
-		return nil, nil, fmt.Errorf("agent tunnel response left %d buffered bytes", reader.Buffered())
-	}
-	session, err := yamux.Client(conn, tunnel.DefaultYamuxConfig(nil))
+	bufferedConn := &agentRegistryBufferedConn{Conn: conn, reader: reader}
+	session, err := yamux.Client(bufferedConn, tunnel.DefaultYamuxConfig(nil))
 	if err != nil {
 		conn.Close()
 		return nil, nil, err
 	}
-	return session, conn, nil
+	return session, bufferedConn, nil
+}
+
+type agentRegistryBufferedConn struct {
+	net.Conn
+	reader *bufio.Reader
+}
+
+func (c *agentRegistryBufferedConn) Read(p []byte) (int, error) {
+	return c.reader.Read(p)
+}
+
+func newAgentRegistryLocalTCPPair(t *testing.T) (net.Conn, net.Conn) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for local TCP pair: %v", err)
+	}
+	defer listener.Close()
+
+	type acceptResult struct {
+		conn net.Conn
+		err  error
+	}
+	acceptedCh := make(chan acceptResult, 1)
+	go func() {
+		conn, err := listener.Accept()
+		acceptedCh <- acceptResult{conn: conn, err: err}
+	}()
+
+	agentConn, err := net.DialTimeout("tcp", listener.Addr().String(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial local TCP pair: %v", err)
+	}
+	select {
+	case result := <-acceptedCh:
+		if result.err != nil {
+			_ = agentConn.Close()
+			t.Fatalf("accept local TCP pair: %v", result.err)
+		}
+		return result.conn, agentConn
+	case <-time.After(2 * time.Second):
+		_ = agentConn.Close()
+		t.Fatal("timed out accepting local TCP pair")
+		return nil, nil
+	}
+}
+
+func assertYamuxStreamCounts(t *testing.T, serverSession *yamux.Session, agentSession *yamux.Session, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if serverSession.NumStreams() == want && agentSession.NumStreams() == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf(
+		"yamux stream counts = server %d/agent %d, want %d/%d",
+		serverSession.NumStreams(),
+		agentSession.NumStreams(),
+		want,
+		want,
+	)
 }
 
 func rotateAgentTokenForTest(t *testing.T, app *App, header http.Header, agentID int64) *connect.Response[p2pstreamv1.RotateAgentTokenResponse] {

--- a/internal/server/agent_request_limiter.go
+++ b/internal/server/agent_request_limiter.go
@@ -21,12 +21,19 @@ func newAgentRequestLimiter(limit int64) *tunnel.StreamLimiter {
 type agentTunnelStreamConn struct {
 	net.Conn
 	release   func()
+	readMu    sync.Mutex
 	closeOnce sync.Once
 	closeErr  error
 }
 
 func newAgentTunnelStreamConn(conn net.Conn, release func()) net.Conn {
 	return &agentTunnelStreamConn{Conn: conn, release: release}
+}
+
+func (c *agentTunnelStreamConn) Read(p []byte) (int, error) {
+	c.readMu.Lock()
+	defer c.readMu.Unlock()
+	return c.Conn.Read(p)
 }
 
 func (c *agentTunnelStreamConn) Close() error {
@@ -44,6 +51,11 @@ func (c *agentTunnelStreamConn) releaseAfterStreamClosed() {
 	// (and can retain its receive window) until the peer replies with FIN or the
 	// configured StreamCloseTimeout forces cleanup. Drain the read side until
 	// either event is observable before returning the capacity slot.
+	// Serialize with an existing HTTP transport reader. Yamux wakes one blocked
+	// reader per state notification, so competing reads could otherwise leave
+	// either the transport reader or this cleanup goroutine blocked forever.
+	c.readMu.Lock()
+	defer c.readMu.Unlock()
 	_ = c.Conn.SetReadDeadline(time.Time{})
 	var buf [4 * 1024]byte
 	for {

--- a/internal/server/agent_request_limiter.go
+++ b/internal/server/agent_request_limiter.go
@@ -1,6 +1,11 @@
 package server
 
-import "p2pstream/internal/tunnel"
+import (
+	"net"
+	"sync"
+
+	"p2pstream/internal/tunnel"
+)
 
 func newAgentRequestLimiter(limit int64) *tunnel.StreamLimiter {
 	limiter, err := tunnel.NewStreamLimiter(limit)
@@ -8,4 +13,27 @@ func newAgentRequestLimiter(limit int64) *tunnel.StreamLimiter {
 		limiter, _ = tunnel.NewStreamLimiter(tunnel.DefaultMaxConcurrentAgentRequests)
 	}
 	return limiter
+}
+
+// agentTunnelStreamConn keeps a server stream slot for the complete lifetime
+// of a Yamux stream, including while an HTTP transport holds it idle.
+type agentTunnelStreamConn struct {
+	net.Conn
+	release   func()
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func newAgentTunnelStreamConn(conn net.Conn, release func()) net.Conn {
+	return &agentTunnelStreamConn{Conn: conn, release: release}
+}
+
+func (c *agentTunnelStreamConn) Close() error {
+	c.closeOnce.Do(func() {
+		c.closeErr = c.Conn.Close()
+		if c.release != nil {
+			c.release()
+		}
+	})
+	return c.closeErr
 }

--- a/internal/server/agent_request_limiter.go
+++ b/internal/server/agent_request_limiter.go
@@ -1,0 +1,11 @@
+package server
+
+import "p2pstream/internal/tunnel"
+
+func newAgentRequestLimiter(limit int64) *tunnel.StreamLimiter {
+	limiter, err := tunnel.NewStreamLimiter(limit)
+	if err != nil {
+		limiter, _ = tunnel.NewStreamLimiter(tunnel.DefaultMaxConcurrentAgentRequests)
+	}
+	return limiter
+}

--- a/internal/server/agent_request_limiter.go
+++ b/internal/server/agent_request_limiter.go
@@ -3,6 +3,7 @@ package server
 import (
 	"net"
 	"sync"
+	"time"
 
 	"p2pstream/internal/tunnel"
 )
@@ -32,8 +33,23 @@ func (c *agentTunnelStreamConn) Close() error {
 	c.closeOnce.Do(func() {
 		c.closeErr = c.Conn.Close()
 		if c.release != nil {
-			c.release()
+			go c.releaseAfterStreamClosed()
 		}
 	})
 	return c.closeErr
+}
+
+func (c *agentTunnelStreamConn) releaseAfterStreamClosed() {
+	// yamux.Stream.Close sends a local FIN. The stream remains in the session
+	// (and can retain its receive window) until the peer replies with FIN or the
+	// configured StreamCloseTimeout forces cleanup. Drain the read side until
+	// either event is observable before returning the capacity slot.
+	_ = c.Conn.SetReadDeadline(time.Time{})
+	var buf [4 * 1024]byte
+	for {
+		if _, err := c.Conn.Read(buf[:]); err != nil {
+			c.release()
+			return
+		}
+	}
 }

--- a/internal/server/agent_request_limiter_test.go
+++ b/internal/server/agent_request_limiter_test.go
@@ -2,9 +2,11 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -71,10 +73,23 @@ func TestAgentTunnelStreamConnReleasesAfterRemoteClose(t *testing.T) {
 	defer local.Close()
 	defer peer.Close()
 	remoteClosed := make(chan struct{})
+	readStarted := make(chan struct{})
 	conn := newAgentTunnelStreamConn(&delayedRemoteCloseConn{
 		Conn:         local,
 		remoteClosed: remoteClosed,
+		readStarted:  readStarted,
 	}, release)
+	readerDone := make(chan error, 1)
+	go func() {
+		var buf [1]byte
+		_, err := conn.Read(buf[:])
+		readerDone <- err
+	}()
+	select {
+	case <-readStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for existing connection reader")
+	}
 
 	if err := conn.Close(); err != nil {
 		t.Fatalf("close connection: %v", err)
@@ -87,6 +102,14 @@ func TestAgentTunnelStreamConnReleasesAfterRemoteClose(t *testing.T) {
 	}
 
 	close(remoteClosed)
+	select {
+	case err := <-readerDone:
+		if !errors.Is(err, io.EOF) {
+			t.Fatalf("existing reader error = %v, want EOF", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("existing reader did not finish after remote close")
+	}
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if limiter.InUse() == 0 {
@@ -99,7 +122,9 @@ func TestAgentTunnelStreamConnReleasesAfterRemoteClose(t *testing.T) {
 
 type delayedRemoteCloseConn struct {
 	net.Conn
-	remoteClosed <-chan struct{}
+	remoteClosed  <-chan struct{}
+	readStarted   chan struct{}
+	readStartOnce sync.Once
 }
 
 func (c *delayedRemoteCloseConn) Close() error {
@@ -107,6 +132,7 @@ func (c *delayedRemoteCloseConn) Close() error {
 }
 
 func (c *delayedRemoteCloseConn) Read([]byte) (int, error) {
+	c.readStartOnce.Do(func() { close(c.readStarted) })
 	<-c.remoteClosed
 	return 0, io.EOF
 }

--- a/internal/server/agent_request_limiter_test.go
+++ b/internal/server/agent_request_limiter_test.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"p2pstream/internal/tunnel"
+)
+
+func TestAgentRequestLimiterBoundsAndReleasesCapacity(t *testing.T) {
+	limiter := newAgentRequestLimiter(2)
+	releaseFirst, ok := limiter.TryAcquire()
+	if !ok {
+		t.Fatal("first acquire failed")
+	}
+	releaseSecond, ok := limiter.TryAcquire()
+	if !ok {
+		t.Fatal("second acquire failed")
+	}
+	if got := limiter.InUse(); got != 2 {
+		t.Fatalf("in-use requests = %d, want 2", got)
+	}
+	if release, ok := limiter.TryAcquire(); ok {
+		release()
+		t.Fatal("acquire beyond configured capacity succeeded")
+	}
+
+	releaseFirst()
+	releaseFirst()
+	if got := limiter.InUse(); got != 1 {
+		t.Fatalf("in-use requests after idempotent release = %d, want 1", got)
+	}
+	releaseThird, ok := limiter.TryAcquire()
+	if !ok {
+		t.Fatal("capacity was not reusable after release")
+	}
+	releaseThird()
+	releaseSecond()
+	if got := limiter.InUse(); got != 0 {
+		t.Fatalf("in-use requests after release = %d, want 0", got)
+	}
+}
+
+func TestAgentCapacityDoesNotMarkPassiveFailure(t *testing.T) {
+	err := fmt.Errorf("dial agent: %w", agentDialError{Kind: "agent_capacity", Err: "full"})
+	if shouldMarkAgentPassiveFailure(context.Background(), err) {
+		t.Fatal("agent capacity should not mark the agent passively unhealthy")
+	}
+}
+
+func TestAgentRequestLimiterUsesSafeDefaultForUnsetOrInvalidLimit(t *testing.T) {
+	for _, limit := range []int64{0, -1} {
+		limiter := newAgentRequestLimiter(limit)
+		if got := limiter.Capacity(); got != int(tunnel.DefaultMaxConcurrentAgentRequests) {
+			t.Fatalf("limit %d created capacity %d, want %d", limit, got, tunnel.DefaultMaxConcurrentAgentRequests)
+		}
+	}
+}

--- a/internal/server/agent_request_limiter_test.go
+++ b/internal/server/agent_request_limiter_test.go
@@ -3,7 +3,10 @@ package server
 import (
 	"context"
 	"fmt"
+	"io"
+	"net"
 	"testing"
+	"time"
 
 	"p2pstream/internal/tunnel"
 )
@@ -56,4 +59,54 @@ func TestAgentRequestLimiterUsesSafeDefaultForUnsetOrInvalidLimit(t *testing.T) 
 			t.Fatalf("limit %d created capacity %d, want %d", limit, got, tunnel.DefaultMaxConcurrentAgentRequests)
 		}
 	}
+}
+
+func TestAgentTunnelStreamConnReleasesAfterRemoteClose(t *testing.T) {
+	limiter := newAgentRequestLimiter(1)
+	release, ok := limiter.TryAcquire()
+	if !ok {
+		t.Fatal("acquire stream slot failed")
+	}
+	local, peer := net.Pipe()
+	defer local.Close()
+	defer peer.Close()
+	remoteClosed := make(chan struct{})
+	conn := newAgentTunnelStreamConn(&delayedRemoteCloseConn{
+		Conn:         local,
+		remoteClosed: remoteClosed,
+	}, release)
+
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close connection: %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close connection again: %v", err)
+	}
+	if got := limiter.InUse(); got != 1 {
+		t.Fatalf("stream slots after local close = %d, want 1 until remote close", got)
+	}
+
+	close(remoteClosed)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if limiter.InUse() == 0 {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("stream slots after remote close = %d, want 0", limiter.InUse())
+}
+
+type delayedRemoteCloseConn struct {
+	net.Conn
+	remoteClosed <-chan struct{}
+}
+
+func (c *delayedRemoteCloseConn) Close() error {
+	return nil
+}
+
+func (c *delayedRemoteCloseConn) Read([]byte) (int, error) {
+	<-c.remoteClosed
+	return 0, io.EOF
 }

--- a/internal/server/agent_transport_pool_test.go
+++ b/internal/server/agent_transport_pool_test.go
@@ -33,6 +33,49 @@ func TestAgentTransportPoolReusesPublicRouteTargetConnection(t *testing.T) {
 	}
 }
 
+func TestAgentTransportPoolIdleStreamRetainsCapacityUntilPoolClose(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	app, firstTarget, agent, fake := newAgentProxyTunnelTestApp(t, 7, upstream.URL, 2*time.Second)
+	app.agentTunnelStreams = newAgentRequestLimiter(1)
+
+	first := httptest.NewRecorder()
+	proxyAgentTargetForTest(app, first, httptest.NewRequest(http.MethodGet, "http://public.test/first", nil), firstTarget, agent)
+	if first.Code != http.StatusOK {
+		t.Fatalf("first request status = %d body=%q, want 200", first.Code, first.Body.String())
+	}
+	fake.waitOpenRequestCount(t, 1)
+	if got := app.agentTunnelStreams.InUse(); got != 1 {
+		t.Fatalf("stream slots after pooled request = %d, want 1", got)
+	}
+
+	secondTarget := firstTarget
+	secondTarget.ID++
+	secondTarget.Name = "second-target"
+	second := httptest.NewRecorder()
+	proxyAgentTargetForTest(app, second, httptest.NewRequest(http.MethodGet, "http://public.test/second", nil), secondTarget, agent)
+	if second.Code != http.StatusServiceUnavailable {
+		t.Fatalf("second target status = %d body=%q, want 503 at stream capacity", second.Code, second.Body.String())
+	}
+	fake.waitOpenRequestCount(t, 1)
+	if !app.TargetHealth.agentAvailable(secondTarget.ID, agent.AgentID) {
+		t.Fatal("server stream capacity should not mark the agent passively unhealthy")
+	}
+
+	app.AgentTransports.closeRouteTarget(firstTarget.ID)
+	waitForAgentTunnelStreams(t, app, 0)
+
+	third := httptest.NewRecorder()
+	proxyAgentTargetForTest(app, third, httptest.NewRequest(http.MethodGet, "http://public.test/third", nil), secondTarget, agent)
+	if third.Code != http.StatusOK {
+		t.Fatalf("request after pool close status = %d body=%q, want 200", third.Code, third.Body.String())
+	}
+	fake.waitOpenRequestCount(t, 2)
+}
+
 func TestAgentTransportPoolConcurrentPublicRouteTargetRequestsOpenParallelStreams(t *testing.T) {
 	release := make(chan struct{})
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/public_routing.go
+++ b/internal/server/public_routing.go
@@ -458,6 +458,14 @@ func (a *App) proxyRouteTargetRequest(w http.ResponseWriter, r *http.Request, re
 				"load_balancer": resolution.Target.AgentLoadBalancing,
 			})
 		}
+		releaseAgentRequest, ok := a.agentProxyRequests.TryAcquire()
+		if !ok {
+			statusCode = http.StatusServiceUnavailable
+			errorKind = "agent_request_capacity"
+			http.Error(w, "Agent tunnel capacity reached", http.StatusServiceUnavailable)
+			return
+		}
+		defer releaseAgentRequest()
 		agent.ActiveRequests.Add(1)
 		defer agent.ActiveRequests.Add(-1)
 	}
@@ -586,6 +594,12 @@ func (a *App) proxyRouteTargetRequest(w http.ResponseWriter, r *http.Request, re
 					statusCode = http.StatusGatewayTimeout
 					errorKind = "agent_dial_timeout"
 					http.Error(w, "Gateway Timeout", http.StatusGatewayTimeout)
+					return
+				}
+				if dialErr.Kind == "agent_capacity" {
+					statusCode = http.StatusServiceUnavailable
+					errorKind = "agent_capacity"
+					http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
 					return
 				}
 				statusCode = http.StatusBadGateway
@@ -839,6 +853,10 @@ func requestContextCanceled(ctx context.Context, err error) bool {
 
 func shouldMarkAgentPassiveFailure(requestCtx context.Context, err error) bool {
 	if err == nil {
+		return false
+	}
+	var dialErr agentDialError
+	if errors.As(err, &dialErr) && dialErr.Kind == "agent_capacity" {
 		return false
 	}
 	return !requestContextCanceled(requestCtx, err)

--- a/internal/server/public_routing.go
+++ b/internal/server/public_routing.go
@@ -629,6 +629,11 @@ type agentDialError struct {
 	Err  string
 }
 
+type agentStreamOpenResult struct {
+	conn net.Conn
+	err  error
+}
+
 func (e agentDialError) Error() string {
 	if e.Err == "" {
 		return e.Kind
@@ -643,14 +648,48 @@ func (a *App) agentTargetTransport(agent *AgentConn, target publicRouteTargetCon
 	return a.AgentTransports.publicRouteTargetTransport(a, agent, target)
 }
 
+func startAgentStreamOpen(
+	ctx context.Context,
+	agentDone <-chan struct{},
+	open func() (net.Conn, error),
+) <-chan agentStreamOpenResult {
+	// Keep this channel unbuffered so ownership cannot be transferred after the
+	// caller has stopped receiving. A buffered result channel can accept a
+	// delayed successful Open even when ctx is already done, leaking that stream.
+	results := make(chan agentStreamOpenResult)
+	go func() {
+		conn, err := open()
+		result := agentStreamOpenResult{conn: conn, err: err}
+		select {
+		case results <- result:
+		case <-ctx.Done():
+			if conn != nil {
+				_ = conn.Close()
+			}
+		case <-agentDone:
+			if conn != nil {
+				_ = conn.Close()
+			}
+		}
+	}()
+	return results
+}
+
 func (a *App) dialViaAgent(ctx context.Context, agent *AgentConn, network string, address string, requestID string) (net.Conn, error) {
 	if agent == nil || agent.Session == nil || agent.Session.IsClosed() {
 		return nil, errAgentDisconnected
 	}
-	openCh := make(chan struct {
-		conn net.Conn
-		err  error
-	}, 1)
+	releaseStream, ok := a.agentTunnelStreams.TryAcquire()
+	if !ok {
+		return nil, agentDialError{Kind: "agent_capacity", Err: "server tunnel stream capacity reached"}
+	}
+	releaseOnReturn := true
+	defer func() {
+		if releaseOnReturn {
+			releaseStream()
+		}
+	}()
+
 	openDone := make(chan struct{})
 	stopOpenWatch := func() {
 		select {
@@ -669,24 +708,7 @@ func (a *App) dialViaAgent(ctx context.Context, agent *AgentConn, network string
 		case <-openDone:
 		}
 	}()
-	go func() {
-		conn, err := session.Open()
-		result := struct {
-			conn net.Conn
-			err  error
-		}{conn: conn, err: err}
-		select {
-		case openCh <- result:
-		case <-ctx.Done():
-			if conn != nil {
-				_ = conn.Close()
-			}
-		case <-agent.Done:
-			if conn != nil {
-				_ = conn.Close()
-			}
-		}
-	}()
+	openCh := startAgentStreamOpen(ctx, agent.Done, session.Open)
 
 	var conn net.Conn
 	select {
@@ -726,6 +748,8 @@ func (a *App) dialViaAgent(ctx context.Context, agent *AgentConn, network string
 			Msg("Agent disconnected before tunnel stream opened")
 		return nil, errAgentDisconnected
 	}
+	conn = newAgentTunnelStreamConn(conn, releaseStream)
+	releaseOnReturn = false
 
 	if deadline, ok := ctx.Deadline(); ok {
 		_ = conn.SetDeadline(deadline)

--- a/internal/server/public_routing_timeout_test.go
+++ b/internal/server/public_routing_timeout_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -85,6 +86,126 @@ func TestAgentProxyRelaysThroughYamuxTunnel(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for fake agent open request")
+	}
+}
+
+func TestDialViaAgentStreamCapacityFollowsConnectionLifetime(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer upstream.Close()
+	origin, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+
+	app := NewApp(nil, nil)
+	app.agentTunnelStreams = newAgentRequestLimiter(1)
+	agent, fake := newFakeYamuxAgent(t, 7, "agent-stream-capacity-test")
+
+	first, err := app.dialViaAgent(context.Background(), agent, "tcp", origin.Host, "first")
+	if err != nil {
+		t.Fatalf("first dialViaAgent() error = %v", err)
+	}
+	if got := app.agentTunnelStreams.InUse(); got != 1 {
+		t.Fatalf("stream slots after first dial = %d, want 1", got)
+	}
+
+	second, err := app.dialViaAgent(context.Background(), agent, "tcp", origin.Host, "second")
+	if second != nil {
+		_ = second.Close()
+		t.Fatal("second dial unexpectedly returned a connection over capacity")
+	}
+	var dialErr agentDialError
+	if !errors.As(err, &dialErr) || dialErr.Kind != "agent_capacity" {
+		t.Fatalf("second dial error = %v, want agent_capacity", err)
+	}
+	fake.waitOpenRequestCount(t, 1)
+
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first connection: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first connection again: %v", err)
+	}
+	waitForAgentTunnelStreams(t, app, 0)
+
+	third, err := app.dialViaAgent(context.Background(), agent, "tcp", origin.Host, "third")
+	if err != nil {
+		t.Fatalf("third dialViaAgent() after release error = %v", err)
+	}
+	fake.waitOpenRequestCount(t, 2)
+	if got := app.agentTunnelStreams.InUse(); got != 1 {
+		t.Fatalf("stream slots after third dial = %d, want 1", got)
+	}
+	if err := third.Close(); err != nil {
+		t.Fatalf("close third connection: %v", err)
+	}
+	waitForAgentTunnelStreams(t, app, 0)
+}
+
+func TestDialViaAgentReleasesStreamCapacityAfterHandshakeFailure(t *testing.T) {
+	app := NewApp(nil, nil)
+	app.agentTunnelStreams = newAgentRequestLimiter(1)
+	agent, _ := newFakeYamuxAgent(t, 7, "agent-stream-failure-test")
+
+	conn, err := app.dialViaAgent(context.Background(), agent, "tcp", "127.0.0.1:0", "failed")
+	if conn != nil {
+		_ = conn.Close()
+		t.Fatal("failed dial unexpectedly returned a connection")
+	}
+	var dialErr agentDialError
+	if !errors.As(err, &dialErr) || dialErr.Kind != "dial_failed" {
+		t.Fatalf("failed dial error = %v, want dial_failed", err)
+	}
+	waitForAgentTunnelStreams(t, app, 0)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer upstream.Close()
+	origin, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+	conn, err = app.dialViaAgent(context.Background(), agent, "tcp", origin.Host, "recovered")
+	if err != nil {
+		t.Fatalf("dial after handshake failure error = %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close recovered connection: %v", err)
+	}
+	waitForAgentTunnelStreams(t, app, 0)
+}
+
+func TestAgentStreamOpenDelayedSuccessAfterCancelClosesStream(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	openStarted := make(chan struct{})
+	releaseOpen := make(chan struct{})
+	stream, peer := net.Pipe()
+	defer stream.Close()
+	defer peer.Close()
+
+	results := startAgentStreamOpen(ctx, make(chan struct{}), func() (net.Conn, error) {
+		close(openStarted)
+		<-releaseOpen
+		return stream, nil
+	})
+
+	<-openStarted
+	cancel()
+	close(releaseOpen)
+
+	if err := peer.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set peer deadline: %v", err)
+	}
+	buf := make([]byte, 1)
+	if _, err := peer.Read(buf); !errors.Is(err, io.EOF) {
+		t.Fatalf("read after delayed open = %v, want EOF from closed abandoned stream", err)
+	}
+	select {
+	case result := <-results:
+		if result.conn != nil {
+			_ = result.conn.Close()
+		}
+		t.Fatal("delayed open transferred stream ownership after cancellation")
+	default:
 	}
 }
 
@@ -489,6 +610,18 @@ func waitForAgentActiveRequests(t *testing.T, agent *AgentConn, want int64) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("agent active requests = %d, want %d", agent.ActiveRequests.Load(), want)
+}
+
+func waitForAgentTunnelStreams(t *testing.T, app *App, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := app.agentTunnelStreams.InUse(); got == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("agent tunnel streams = %d, want %d", app.agentTunnelStreams.InUse(), want)
 }
 
 func withTrustedHTTPDefaultTransport(t *testing.T, cert *x509.Certificate) {

--- a/internal/server/public_routing_timeout_test.go
+++ b/internal/server/public_routing_timeout_test.go
@@ -90,6 +90,50 @@ func TestAgentProxyRelaysThroughYamuxTunnel(t *testing.T) {
 	}
 }
 
+func TestAgentProxyRequestCapacityRejectsBeforeOpeningStream(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("capacity-rejected request unexpectedly reached upstream")
+	}))
+	defer upstream.Close()
+
+	app, target, agent, fake := newAgentProxyTunnelTestApp(t, 7, upstream.URL, 2*time.Second)
+	app.agentProxyRequests = newAgentRequestLimiter(1)
+	release, ok := app.agentProxyRequests.TryAcquire()
+	if !ok {
+		t.Fatal("failed to occupy the only agent request slot")
+	}
+	defer release()
+	if !app.TargetHealth.agentAvailable(target.ID, agent.AgentID) {
+		t.Fatal("agent was unavailable before capacity rejection")
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://public.test/at-capacity", nil)
+	proxyAgentTargetForTest(app, rec, req, target, agent)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("capacity response = status %d body %q, want 503", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Agent tunnel capacity reached") {
+		t.Fatalf("capacity response body = %q, want capacity error", rec.Body.String())
+	}
+	fake.mu.Lock()
+	openRequests := fake.openRequests
+	fake.mu.Unlock()
+	if openRequests != 0 || app.agentTunnelStreams.InUse() != 0 {
+		t.Fatalf("capacity rejection opened tunnel state = requests %d/streams %d, want 0/0", openRequests, app.agentTunnelStreams.InUse())
+	}
+	if got := agent.ActiveRequests.Load(); got != 0 {
+		t.Fatalf("agent active requests after capacity rejection = %d, want 0", got)
+	}
+	if !app.TargetHealth.agentAvailable(target.ID, agent.AgentID) {
+		t.Fatal("local request capacity rejection changed passive agent health")
+	}
+	traces, _ := app.TargetHealth.listHealthTraces(target.ID, agent.AgentID, 10, false)
+	if len(traces) != 0 {
+		t.Fatalf("capacity rejection recorded passive health traces: %+v", traces)
+	}
+}
+
 func TestDialViaAgentStreamCapacityFollowsConnectionLifetime(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	defer upstream.Close()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -61,6 +61,7 @@ type App struct {
 	DashboardCache        *dashboardResponseCache
 	LoginThrottle         *loginThrottle
 	agentAuthLocks        *agentAuthLockMap
+	agentProxyRequests    *tunnel.StreamLimiter
 
 	ProxyIsRunning atomic.Bool
 	ProxyLastError atomic.Pointer[string]
@@ -129,6 +130,7 @@ func NewApp(cfg *config.Config, database *db.DB) *App {
 		latestAgentStats:    make(map[int64]stats.AgentStats),
 		proxyState:          p2pstreamv1.ProxyState_PROXY_STATE_STOPPED,
 		publicListenerState: make(map[int64]*publicListenerRuntime),
+		agentProxyRequests:  newAgentRequestLimiter(cfg.TunnelMaxConcurrentRequests),
 	}
 	app.applyServices(newAppServices(cfg, app))
 	if database != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"database/sql"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"strconv"
@@ -37,6 +38,27 @@ type AgentConn struct {
 	ActiveRequests           atomic.Int64
 	ConnectedAt              time.Time
 	ConnectionDBID           int64
+}
+
+type agentTunnelReadGateConn struct {
+	net.Conn
+	ready       chan struct{}
+	readOnce    sync.Once
+	releaseOnce sync.Once
+}
+
+func (c *agentTunnelReadGateConn) Read(p []byte) (int, error) {
+	c.readOnce.Do(func() { <-c.ready })
+	return c.Conn.Read(p)
+}
+
+func (c *agentTunnelReadGateConn) Close() error {
+	c.releaseReads()
+	return c.Conn.Close()
+}
+
+func (c *agentTunnelReadGateConn) releaseReads() {
+	c.releaseOnce.Do(func() { close(c.ready) })
 }
 
 func (c *AgentConn) signalDone() {
@@ -473,12 +495,28 @@ func (a *App) agentTunnelHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	session, err := yamux.Server(rawConn, yamuxConfig)
+	// Yamux starts its receive loop before Server returns. Hold reads until
+	// GoAway has set localGoAway so even a SYN sent during session setup is RST
+	// instead of entering the unbudgeted accept backlog.
+	gatedConn := &agentTunnelReadGateConn{Conn: rawConn, ready: make(chan struct{})}
+	session, err := yamux.Server(gatedConn, yamuxConfig)
 	if err != nil {
+		gatedConn.releaseReads()
 		_ = rawConn.Close()
 		log.Error().Err(err).Str("agent", agent.PublicID).Msg("Failed to initialize agent tunnel session")
 		return
 	}
+	// Agent tunnel streams are always server-initiated. Fence the session before
+	// exposing it so unsolicited agent SYNs are rejected instead of occupying
+	// Yamux's unbudgeted accept backlog.
+	if err := session.GoAway(); err != nil {
+		gatedConn.releaseReads()
+		_ = session.Close()
+		_ = rawConn.Close()
+		log.Error().Err(err).Str("agent", agent.PublicID).Msg("Failed to restrict agent tunnel stream direction")
+		return
+	}
+	gatedConn.releaseReads()
 	agent.Session = session
 
 	if a.DB != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -62,6 +62,7 @@ type App struct {
 	LoginThrottle         *loginThrottle
 	agentAuthLocks        *agentAuthLockMap
 	agentProxyRequests    *tunnel.StreamLimiter
+	agentTunnelStreams    *tunnel.StreamLimiter
 
 	ProxyIsRunning atomic.Bool
 	ProxyLastError atomic.Pointer[string]
@@ -131,6 +132,7 @@ func NewApp(cfg *config.Config, database *db.DB) *App {
 		proxyState:          p2pstreamv1.ProxyState_PROXY_STATE_STOPPED,
 		publicListenerState: make(map[int64]*publicListenerRuntime),
 		agentProxyRequests:  newAgentRequestLimiter(cfg.TunnelMaxConcurrentRequests),
+		agentTunnelStreams:  newAgentRequestLimiter(cfg.TunnelMaxConcurrentRequests),
 	}
 	app.applyServices(newAppServices(cfg, app))
 	if database != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -362,6 +362,12 @@ func (a *App) agentTunnelHandler(w http.ResponseWriter, r *http.Request) {
 		Done:        make(chan struct{}),
 		ConnectedAt: time.Now(),
 	}
+	yamuxConfig, err := tunnel.NewYamuxConfig(nil, a.Config.TunnelMaxStreamWindowBytes)
+	if err != nil {
+		log.Error().Err(err).Str("agent", agent.PublicID).Msg("Invalid agent tunnel yamux configuration")
+		http.Error(w, "invalid agent tunnel configuration", http.StatusInternalServerError)
+		return
+	}
 
 	rawConn, rw, err := hijacker.Hijack()
 	if err != nil {
@@ -385,7 +391,7 @@ func (a *App) agentTunnelHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	session, err := yamux.Server(rawConn, tunnel.DefaultYamuxConfig(nil))
+	session, err := yamux.Server(rawConn, yamuxConfig)
 	if err != nil {
 		_ = rawConn.Close()
 		log.Error().Err(err).Str("agent", agent.PublicID).Msg("Failed to initialize agent tunnel session")

--- a/internal/tunnel/protocol_test.go
+++ b/internal/tunnel/protocol_test.go
@@ -68,10 +68,31 @@ func TestDefaultYamuxConfig(t *testing.T) {
 	if cfg.ConnectionWriteTimeout != 10*time.Second {
 		t.Fatalf("ConnectionWriteTimeout = %s, want 10s", cfg.ConnectionWriteTimeout)
 	}
+	if cfg.MaxStreamWindowSize != uint32(DefaultMaxStreamWindowSizeBytes) {
+		t.Fatalf("MaxStreamWindowSize = %d, want %d", cfg.MaxStreamWindowSize, DefaultMaxStreamWindowSizeBytes)
+	}
 	if cfg.StreamOpenTimeout != 10*time.Second {
 		t.Fatalf("StreamOpenTimeout = %s, want 10s", cfg.StreamOpenTimeout)
 	}
 	if cfg.StreamCloseTimeout != 30*time.Second {
 		t.Fatalf("StreamCloseTimeout = %s, want 30s", cfg.StreamCloseTimeout)
+	}
+}
+
+func TestNewYamuxConfigMaxStreamWindowSizeOverride(t *testing.T) {
+	cfg, err := NewYamuxConfig(nil, 16*1024*1024)
+	if err != nil {
+		t.Fatalf("NewYamuxConfig() error = %v", err)
+	}
+	if cfg.MaxStreamWindowSize != 16*1024*1024 {
+		t.Fatalf("MaxStreamWindowSize = %d, want 16777216", cfg.MaxStreamWindowSize)
+	}
+}
+
+func TestNormalizeMaxStreamWindowSizeBytesRejectsUnsafeBounds(t *testing.T) {
+	for _, value := range []int64{-1, 1, MaxStreamWindowSizeBytesLimit + 1} {
+		if _, err := NormalizeMaxStreamWindowSizeBytes(value); err == nil {
+			t.Fatalf("NormalizeMaxStreamWindowSizeBytes(%d) error = nil, want error", value)
+		}
 	}
 }

--- a/internal/tunnel/protocol_test.go
+++ b/internal/tunnel/protocol_test.go
@@ -96,3 +96,20 @@ func TestNormalizeMaxStreamWindowSizeBytesRejectsUnsafeBounds(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateAggregateStreamWindowBudget(t *testing.T) {
+	if err := ValidateAggregateStreamWindowBudget(0, 0); err != nil {
+		t.Fatalf("default aggregate stream window budget: %v", err)
+	}
+	if err := ValidateAggregateStreamWindowBudget(64*1024*1024, 8); err != nil {
+		t.Fatalf("boundary aggregate stream window budget: %v", err)
+	}
+	if err := ValidateAggregateStreamWindowBudget(64*1024*1024, 9); err == nil {
+		t.Fatal("aggregate stream window budget above limit was accepted")
+	}
+	for _, requests := range []int64{-1, MaxConcurrentAgentRequestsLimit + 1} {
+		if err := ValidateAggregateStreamWindowBudget(DefaultMaxStreamWindowSizeBytes, requests); err == nil {
+			t.Fatalf("concurrent request limit %d was accepted", requests)
+		}
+	}
+}

--- a/internal/tunnel/stream_limiter.go
+++ b/internal/tunnel/stream_limiter.go
@@ -1,0 +1,44 @@
+package tunnel
+
+import "sync"
+
+type StreamLimiter struct {
+	slots chan struct{}
+}
+
+func NewStreamLimiter(limit int64) (*StreamLimiter, error) {
+	limit, err := NormalizeMaxConcurrentAgentRequests(limit)
+	if err != nil {
+		return nil, err
+	}
+	return &StreamLimiter{slots: make(chan struct{}, int(limit))}, nil
+}
+
+func (l *StreamLimiter) TryAcquire() (func(), bool) {
+	if l == nil || l.slots == nil {
+		return func() {}, true
+	}
+	select {
+	case l.slots <- struct{}{}:
+		var once sync.Once
+		return func() {
+			once.Do(func() { <-l.slots })
+		}, true
+	default:
+		return nil, false
+	}
+}
+
+func (l *StreamLimiter) InUse() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.slots)
+}
+
+func (l *StreamLimiter) Capacity() int {
+	if l == nil {
+		return 0
+	}
+	return cap(l.slots)
+}

--- a/internal/tunnel/yamux.go
+++ b/internal/tunnel/yamux.go
@@ -1,6 +1,7 @@
 package tunnel
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -9,13 +10,47 @@ import (
 )
 
 const (
-	DefaultMaxStreamWindowSizeBytes = int64(8 * 1024 * 1024)
-	MaxStreamWindowSizeBytesLimit   = int64(1024 * 1024 * 1024)
+	DefaultMaxStreamWindowSizeBytes    = int64(2 * 1024 * 1024)
+	MaxStreamWindowSizeBytesLimit      = int64(64 * 1024 * 1024)
+	DefaultMaxConcurrentAgentRequests  = int64(64)
+	MaxConcurrentAgentRequestsLimit    = int64(2048)
+	MaxAggregateStreamWindowBytesLimit = int64(512 * 1024 * 1024)
 )
 
 func DefaultYamuxConfig(logger yamux.Logger) *yamux.Config {
 	cfg, _ := NewYamuxConfig(logger, 0)
 	return cfg
+}
+
+func NormalizeMaxConcurrentAgentRequests(requests int64) (int64, error) {
+	if requests == 0 {
+		requests = DefaultMaxConcurrentAgentRequests
+	}
+	if requests < 1 {
+		return 0, errors.New("TUNNEL_MAX_CONCURRENT_REQUESTS must be at least 1")
+	}
+	if requests > MaxConcurrentAgentRequestsLimit {
+		return 0, fmt.Errorf("TUNNEL_MAX_CONCURRENT_REQUESTS must be less than or equal to %d", MaxConcurrentAgentRequestsLimit)
+	}
+	return requests, nil
+}
+
+func ValidateAggregateStreamWindowBudget(windowBytes int64, requests int64) error {
+	window, err := NormalizeMaxStreamWindowSizeBytes(windowBytes)
+	if err != nil {
+		return err
+	}
+	requests, err = NormalizeMaxConcurrentAgentRequests(requests)
+	if err != nil {
+		return err
+	}
+	if int64(window) > MaxAggregateStreamWindowBytesLimit/requests {
+		return fmt.Errorf(
+			"TUNNEL_MAX_STREAM_WINDOW_BYTES times TUNNEL_MAX_CONCURRENT_REQUESTS must be less than or equal to %d bytes",
+			MaxAggregateStreamWindowBytesLimit,
+		)
+	}
+	return nil
 }
 
 func NewYamuxConfig(logger yamux.Logger, maxStreamWindowSizeBytes int64) (*yamux.Config, error) {

--- a/internal/tunnel/yamux.go
+++ b/internal/tunnel/yamux.go
@@ -1,18 +1,34 @@
 package tunnel
 
 import (
+	"fmt"
 	"io"
 	"time"
 
 	"github.com/hashicorp/yamux"
 )
 
+const (
+	DefaultMaxStreamWindowSizeBytes = int64(8 * 1024 * 1024)
+	MaxStreamWindowSizeBytesLimit   = int64(1024 * 1024 * 1024)
+)
+
 func DefaultYamuxConfig(logger yamux.Logger) *yamux.Config {
+	cfg, _ := NewYamuxConfig(logger, 0)
+	return cfg
+}
+
+func NewYamuxConfig(logger yamux.Logger, maxStreamWindowSizeBytes int64) (*yamux.Config, error) {
 	cfg := yamux.DefaultConfig()
 	cfg.AcceptBacklog = 256
 	cfg.EnableKeepAlive = true
 	cfg.KeepAliveInterval = 20 * time.Second
 	cfg.ConnectionWriteTimeout = 10 * time.Second
+	maxStreamWindowSize, err := NormalizeMaxStreamWindowSizeBytes(maxStreamWindowSizeBytes)
+	if err != nil {
+		return nil, err
+	}
+	cfg.MaxStreamWindowSize = maxStreamWindowSize
 	cfg.StreamOpenTimeout = 10 * time.Second
 	cfg.StreamCloseTimeout = 30 * time.Second
 	if logger != nil {
@@ -22,5 +38,19 @@ func DefaultYamuxConfig(logger yamux.Logger) *yamux.Config {
 		cfg.Logger = nil
 		cfg.LogOutput = io.Discard
 	}
-	return cfg
+	return cfg, nil
+}
+
+func NormalizeMaxStreamWindowSizeBytes(sizeBytes int64) (uint32, error) {
+	if sizeBytes == 0 {
+		sizeBytes = DefaultMaxStreamWindowSizeBytes
+	}
+	min := int64(yamux.DefaultConfig().MaxStreamWindowSize)
+	if sizeBytes < min {
+		return 0, fmt.Errorf("TUNNEL_MAX_STREAM_WINDOW_BYTES must be at least %d bytes", min)
+	}
+	if sizeBytes > MaxStreamWindowSizeBytesLimit {
+		return 0, fmt.Errorf("TUNNEL_MAX_STREAM_WINDOW_BYTES must be less than or equal to %d bytes", MaxStreamWindowSizeBytesLimit)
+	}
+	return uint32(sizeBytes), nil
 }

--- a/scripts/install-agent.sh
+++ b/scripts/install-agent.sh
@@ -77,6 +77,26 @@ latest_release_tag() {
   printf '%s' "$tag"
 }
 
+write_optional_agent_env() {
+  local name="$1"
+  local value="$2"
+  local line
+  if [[ -n "$value" ]]; then
+    printf '%s=%s\n' "$name" "$(systemd_env_value "$value")"
+    return
+  fi
+  [[ -f "$ENV_FILE" ]] || return 0
+  while IFS= read -r line; do
+    case "$line" in
+      "${name}="*)
+        printf '%s\n' "$line"
+        return
+        ;;
+    esac
+  done <"$ENV_FILE"
+  return 0
+}
+
 write_agent_env() {
   local tmp_file="$1"
   {
@@ -93,6 +113,8 @@ write_agent_env() {
     if [[ "${AGENT_ALLOW_INSECURE_MANAGEMENT:-}" == "true" ]]; then
       printf 'AGENT_ALLOW_INSECURE_MANAGEMENT="true"\n'
     fi
+    write_optional_agent_env TUNNEL_MAX_STREAM_WINDOW_BYTES "${TUNNEL_MAX_STREAM_WINDOW_BYTES:-}"
+    write_optional_agent_env TUNNEL_MAX_CONCURRENT_REQUESTS "${TUNNEL_MAX_CONCURRENT_REQUESTS:-}"
     printf 'AGENT_ID=%s\n' "$(systemd_env_value "$AGENT_ID")"
     printf 'AGENT_TOKEN=%s\n' "$(systemd_env_value "$AGENT_TOKEN")"
   } >"$tmp_file"

--- a/scripts/install-agent.sh
+++ b/scripts/install-agent.sh
@@ -11,6 +11,13 @@ readonly INSTALL_PATH="${P2PSTREAM_INSTALL_PATH:-/usr/local/bin/p2pstream}"
 readonly MANAGEMENT_CA_PEM_FILE="${CONFIG_DIR}/management-ca.pem"
 readonly SERVICE_USER="p2pstream"
 readonly SERVICE_GROUP="p2pstream"
+readonly DEFAULT_TUNNEL_MAX_STREAM_WINDOW_BYTES="2097152"
+readonly MIN_TUNNEL_MAX_STREAM_WINDOW_BYTES="262144"
+readonly MAX_TUNNEL_MAX_STREAM_WINDOW_BYTES="67108864"
+readonly DEFAULT_TUNNEL_MAX_CONCURRENT_REQUESTS="64"
+readonly MIN_TUNNEL_MAX_CONCURRENT_REQUESTS="1"
+readonly MAX_TUNNEL_MAX_CONCURRENT_REQUESTS="2048"
+readonly MAX_TUNNEL_AGGREGATE_WINDOW_BYTES="536870912"
 INSTALL_TMP_DIR=""
 
 fail() {
@@ -77,24 +84,187 @@ latest_release_tag() {
   printf '%s' "$tag"
 }
 
+normalize_decimal() {
+  local value="$1"
+  while [[ ${#value} -gt 1 && "$value" == 0* ]]; do
+    value="${value:1}"
+  done
+  printf '%s' "$value"
+}
+
+decimal_is_at_least() {
+  local value="$1"
+  local minimum="$2"
+  if [[ ${#value} -ne ${#minimum} ]]; then
+    [[ ${#value} -gt ${#minimum} ]]
+    return
+  fi
+  [[ "$value" == "$minimum" || "$value" > "$minimum" ]]
+}
+
+decimal_is_at_most() {
+  local value="$1"
+  local maximum="$2"
+  if [[ ${#value} -ne ${#maximum} ]]; then
+    [[ ${#value} -lt ${#maximum} ]]
+    return
+  fi
+  [[ "$value" == "$maximum" || "$value" < "$maximum" ]]
+}
+
+parse_numeric_env_value() {
+  local raw="$1"
+  local value
+  if [[ "$raw" =~ ^[[:space:]]*([0-9]+)[[:space:]]*$ ]]; then
+    value="${BASH_REMATCH[1]}"
+  elif [[ "$raw" =~ ^[[:space:]]*\"([0-9]+)\"[[:space:]]*$ ]]; then
+    value="${BASH_REMATCH[1]}"
+  elif [[ "$raw" =~ ^[[:space:]]*\'([0-9]+)\'[[:space:]]*$ ]]; then
+    value="${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+  normalize_decimal "$value"
+}
+
+validate_tunnel_setting() {
+  local name="$1"
+  local raw="$2"
+  local minimum="$3"
+  local maximum="$4"
+  local value
+  value="$(parse_numeric_env_value "$raw")" \
+    || fail "${name} must be a single quoted or unquoted decimal integer"
+  decimal_is_at_least "$value" "$minimum" \
+    || fail "${name} must be at least ${minimum}"
+  decimal_is_at_most "$value" "$maximum" \
+    || fail "${name} must be at most ${maximum}"
+  printf '%s' "$value"
+}
+
+env_assignment_is_single_line() {
+  local line="$1"
+  local state="unquoted"
+  local index character
+  for ((index = 0; index < ${#line}; index++)); do
+    character="${line:index:1}"
+    case "$state:$character" in
+      unquoted:\\|double:\\)
+        index=$((index + 1))
+        ((index < ${#line})) || return 1
+        ;;
+      unquoted:\')
+        state="single"
+        ;;
+      single:\')
+        state="unquoted"
+        ;;
+      unquoted:\")
+        state="double"
+        ;;
+      double:\")
+        state="unquoted"
+        ;;
+    esac
+  done
+  [[ "$state" == "unquoted" ]]
+}
+
+load_existing_tunnel_settings() {
+  local need_window="$1"
+  local need_concurrency="$2"
+  local line name raw
+  local line_number=0
+  local window_seen="false"
+  local concurrency_seen="false"
+  local window_raw=""
+  local concurrency_raw=""
+  local -a lines=()
+
+  [[ -e "$ENV_FILE" || -L "$ENV_FILE" ]] || return 0
+  if [[ ! -f "$ENV_FILE" || ! -r "$ENV_FILE" ]]; then
+    fail "cannot safely read existing agent environment: ${ENV_FILE}"
+  fi
+  mapfile -t lines <"$ENV_FILE" \
+    || fail "could not read existing agent environment: ${ENV_FILE}"
+
+  for line in "${lines[@]}"; do
+    line_number=$((line_number + 1))
+    if [[ "$line" =~ ^[[:space:]]*$ || "$line" =~ ^[[:space:]]*# ]]; then
+      continue
+    fi
+    env_assignment_is_single_line "$line" \
+      || fail "unsupported multiline syntax in existing agent environment at line ${line_number}"
+    if [[ ! "$line" =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=(.*)$ ]]; then
+      fail "unsupported syntax in existing agent environment at line ${line_number}"
+    fi
+    name="${BASH_REMATCH[1]}"
+    raw="${BASH_REMATCH[2]}"
+    case "$name" in
+      TUNNEL_MAX_STREAM_WINDOW_BYTES)
+        if [[ "$need_window" == "true" ]]; then
+          window_seen="true"
+          window_raw="$raw"
+        fi
+        ;;
+      TUNNEL_MAX_CONCURRENT_REQUESTS)
+        if [[ "$need_concurrency" == "true" ]]; then
+          concurrency_seen="true"
+          concurrency_raw="$raw"
+        fi
+        ;;
+    esac
+  done
+
+  if [[ "$window_seen" == "true" ]]; then
+    TUNNEL_MAX_STREAM_WINDOW_BYTES="$(validate_tunnel_setting \
+      TUNNEL_MAX_STREAM_WINDOW_BYTES "$window_raw" \
+      "$MIN_TUNNEL_MAX_STREAM_WINDOW_BYTES" "$MAX_TUNNEL_MAX_STREAM_WINDOW_BYTES")"
+  fi
+  if [[ "$concurrency_seen" == "true" ]]; then
+    TUNNEL_MAX_CONCURRENT_REQUESTS="$(validate_tunnel_setting \
+      TUNNEL_MAX_CONCURRENT_REQUESTS "$concurrency_raw" \
+      "$MIN_TUNNEL_MAX_CONCURRENT_REQUESTS" "$MAX_TUNNEL_MAX_CONCURRENT_REQUESTS")"
+  fi
+}
+
+preflight_tunnel_settings() {
+  local need_window="false"
+  local need_concurrency="false"
+  local effective_window effective_concurrency
+
+  if [[ -n "${TUNNEL_MAX_STREAM_WINDOW_BYTES:-}" ]]; then
+    TUNNEL_MAX_STREAM_WINDOW_BYTES="$(validate_tunnel_setting \
+      TUNNEL_MAX_STREAM_WINDOW_BYTES "$TUNNEL_MAX_STREAM_WINDOW_BYTES" \
+      "$MIN_TUNNEL_MAX_STREAM_WINDOW_BYTES" "$MAX_TUNNEL_MAX_STREAM_WINDOW_BYTES")"
+  else
+    need_window="true"
+  fi
+  if [[ -n "${TUNNEL_MAX_CONCURRENT_REQUESTS:-}" ]]; then
+    TUNNEL_MAX_CONCURRENT_REQUESTS="$(validate_tunnel_setting \
+      TUNNEL_MAX_CONCURRENT_REQUESTS "$TUNNEL_MAX_CONCURRENT_REQUESTS" \
+      "$MIN_TUNNEL_MAX_CONCURRENT_REQUESTS" "$MAX_TUNNEL_MAX_CONCURRENT_REQUESTS")"
+  else
+    need_concurrency="true"
+  fi
+
+  if [[ "$need_window" == "true" || "$need_concurrency" == "true" ]]; then
+    load_existing_tunnel_settings "$need_window" "$need_concurrency"
+  fi
+
+  effective_window="${TUNNEL_MAX_STREAM_WINDOW_BYTES:-$DEFAULT_TUNNEL_MAX_STREAM_WINDOW_BYTES}"
+  effective_concurrency="${TUNNEL_MAX_CONCURRENT_REQUESTS:-$DEFAULT_TUNNEL_MAX_CONCURRENT_REQUESTS}"
+  if ((effective_window * effective_concurrency > MAX_TUNNEL_AGGREGATE_WINDOW_BYTES)); then
+    fail "TUNNEL_MAX_STREAM_WINDOW_BYTES times TUNNEL_MAX_CONCURRENT_REQUESTS must be at most ${MAX_TUNNEL_AGGREGATE_WINDOW_BYTES}"
+  fi
+}
+
 write_optional_agent_env() {
   local name="$1"
   local value="$2"
-  local line
   if [[ -n "$value" ]]; then
     printf '%s=%s\n' "$name" "$(systemd_env_value "$value")"
-    return
   fi
-  [[ -f "$ENV_FILE" ]] || return 0
-  while IFS= read -r line; do
-    case "$line" in
-      "${name}="*)
-        printf '%s\n' "$line"
-        return
-        ;;
-    esac
-  done <"$ENV_FILE"
-  return 0
 }
 
 write_agent_env() {
@@ -250,6 +420,7 @@ main() {
   require_env AGENT_TOKEN
   validate_management_url_inputs
   validate_tls_inputs
+  preflight_tunnel_settings
   ensure_service_user
 
   local repository="${P2PSTREAM_REPOSITORY:-$DEFAULT_REPOSITORY}"

--- a/scripts/install-agent.sh
+++ b/scripts/install-agent.sh
@@ -195,7 +195,7 @@ load_existing_tunnel_settings() {
     fi
     env_assignment_is_single_line "$line" \
       || fail "unsupported multiline syntax in existing agent environment at line ${line_number}"
-    if [[ ! "$line" =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=(.*)$ ]]; then
+    if [[ ! "$line" =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
       fail "unsupported syntax in existing agent environment at line ${line_number}"
     fi
     name="${BASH_REMATCH[1]}"

--- a/scripts/test-agent-lifecycle.sh
+++ b/scripts/test-agent-lifecycle.sh
@@ -328,6 +328,20 @@ test_ambiguous_tunnel_preservation_fails_before_mutation() {
   assert_absent "$INSTALL_PATH"
   assert_empty "$COMMAND_LOG"
 
+  printf 'TUNNEL_MAX_CONCURRENT_REQUESTS =32\n' >"${CONFIG_DIR}/agent.env"
+  if run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    TUNNEL_MAX_STREAM_WINDOW_BYTES="4194304" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="new-token" \
+    >/dev/null 2>"${TEST_DIR}/spaced-assignment.err"; then
+    fail "unsupported whitespace in a tunnel setting assignment should fail"
+  fi
+  assert_contains "${TEST_DIR}/spaced-assignment.err" "unsupported syntax in existing agent environment at line 1"
+  assert_contains "${CONFIG_DIR}/agent.env" "TUNNEL_MAX_CONCURRENT_REQUESTS =32"
+  assert_absent "$INSTALL_PATH"
+  assert_empty "$COMMAND_LOG"
+
   run_installer \
     MANAGEMENT_URL="https://mgmt.example.test:8081" \
     TUNNEL_MAX_STREAM_WINDOW_BYTES="4194304" \

--- a/scripts/test-agent-lifecycle.sh
+++ b/scripts/test-agent-lifecycle.sh
@@ -38,6 +38,20 @@ assert_not_contains() {
   fi
 }
 
+assert_line_count() {
+  local path="$1"
+  local text="$2"
+  local expected="$3"
+  local actual
+  actual="$(grep -Fxc -- "$text" "$path" || true)"
+  [[ "$actual" == "$expected" ]] \
+    || fail "expected ${path} to contain ${expected} exact lines matching ${text}, found ${actual}"
+}
+
+assert_empty() {
+  [[ ! -s "$1" ]] || fail "expected path to be empty: $1"
+}
+
 assert_systemctl_enable_before_restart() {
   local enable_line restart_line
   enable_line="$(grep -n '^enable p2pstream-agent$' "$SYSTEMCTL_LOG" | tail -n 1 | cut -d: -f1)"
@@ -260,6 +274,96 @@ test_reinstall_overwrites_token_and_ca() {
   assert_not_contains "$SYSTEMCTL_LOG" "enable --now"
 }
 
+test_reinstall_preserves_effective_tunnel_limits() {
+  setup_fixture
+  {
+    printf 'TUNNEL_MAX_STREAM_WINDOW_BYTES="1048576"\n'
+    printf 'TUNNEL_MAX_CONCURRENT_REQUESTS=8\n'
+    printf '   TUNNEL_MAX_STREAM_WINDOW_BYTES=0004194304\n'
+    printf '\tTUNNEL_MAX_CONCURRENT_REQUESTS=\04700032\047'
+  } >"${CONFIG_DIR}/agent.env"
+
+  run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="new-token"
+
+  assert_line_count "${CONFIG_DIR}/agent.env" 'TUNNEL_MAX_STREAM_WINDOW_BYTES="4194304"' 1
+  assert_line_count "${CONFIG_DIR}/agent.env" 'TUNNEL_MAX_CONCURRENT_REQUESTS="32"' 1
+  assert_not_contains "${CONFIG_DIR}/agent.env" '1048576'
+  assert_not_contains "${CONFIG_DIR}/agent.env" 'TUNNEL_MAX_CONCURRENT_REQUESTS="8"'
+}
+
+test_explicit_tunnel_setting_bypasses_replaced_value() {
+  setup_fixture
+  {
+    printf 'TUNNEL_MAX_STREAM_WINDOW_BYTES=not-a-number\n'
+    printf 'TUNNEL_MAX_CONCURRENT_REQUESTS="00032"\n'
+  } >"${CONFIG_DIR}/agent.env"
+
+  run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    TUNNEL_MAX_STREAM_WINDOW_BYTES="4194304" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="new-token"
+
+  assert_line_count "${CONFIG_DIR}/agent.env" 'TUNNEL_MAX_STREAM_WINDOW_BYTES="4194304"' 1
+  assert_line_count "${CONFIG_DIR}/agent.env" 'TUNNEL_MAX_CONCURRENT_REQUESTS="32"' 1
+  assert_not_contains "${CONFIG_DIR}/agent.env" 'not-a-number'
+}
+
+test_ambiguous_tunnel_preservation_fails_before_mutation() {
+  setup_fixture
+  printf 'UNRELATED=continued\\\nTUNNEL_MAX_CONCURRENT_REQUESTS=32\n' >"${CONFIG_DIR}/agent.env"
+
+  if run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    TUNNEL_MAX_STREAM_WINDOW_BYTES="4194304" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="new-token" \
+    >/dev/null 2>"${TEST_DIR}/ambiguous.err"; then
+    fail "ambiguous existing agent environment should fail"
+  fi
+  assert_contains "${TEST_DIR}/ambiguous.err" "unsupported multiline syntax in existing agent environment at line 1"
+  assert_absent "$INSTALL_PATH"
+  assert_empty "$COMMAND_LOG"
+
+  run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    TUNNEL_MAX_STREAM_WINDOW_BYTES="4194304" \
+    TUNNEL_MAX_CONCURRENT_REQUESTS="16" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="new-token"
+  assert_line_count "${CONFIG_DIR}/agent.env" 'TUNNEL_MAX_STREAM_WINDOW_BYTES="4194304"' 1
+  assert_line_count "${CONFIG_DIR}/agent.env" 'TUNNEL_MAX_CONCURRENT_REQUESTS="16"' 1
+}
+
+test_unreadable_tunnel_settings_require_explicit_replacement() {
+  setup_fixture
+  printf 'TUNNEL_MAX_STREAM_WINDOW_BYTES="4194304"\n' >"${CONFIG_DIR}/agent.env"
+  chmod 0200 "${CONFIG_DIR}/agent.env"
+
+  if run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="new-token" \
+    >/dev/null 2>"${TEST_DIR}/unreadable.err"; then
+    fail "unreadable existing agent environment should fail"
+  fi
+  assert_contains "${TEST_DIR}/unreadable.err" "cannot safely read existing agent environment"
+  assert_absent "$INSTALL_PATH"
+  assert_empty "$COMMAND_LOG"
+
+  run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    TUNNEL_MAX_STREAM_WINDOW_BYTES="4194304" \
+    TUNNEL_MAX_CONCURRENT_REQUESTS="16" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="new-token"
+  assert_line_count "${CONFIG_DIR}/agent.env" 'TUNNEL_MAX_STREAM_WINDOW_BYTES="4194304"' 1
+  assert_line_count "${CONFIG_DIR}/agent.env" 'TUNNEL_MAX_CONCURRENT_REQUESTS="16"' 1
+}
+
 test_reinstall_without_ca_removes_stale_managed_ca() {
   setup_fixture
   printf 'stale CA\n' >"${CONFIG_DIR}/management-ca.pem"
@@ -307,6 +411,16 @@ test_validation_failures() {
     fail "unsupported P2PSTREAM_VERSION should fail"
   fi
   assert_contains "${TEST_DIR}/version.err" "P2PSTREAM_VERSION must be latest, staging, or vX.Y.Z"
+
+  if run_installer MANAGEMENT_URL="https://mgmt.example.test:8081" TUNNEL_MAX_STREAM_WINDOW_BYTES="262143" AGENT_ID="agent-one" AGENT_TOKEN="token-one" >/dev/null 2>"${TEST_DIR}/window.err"; then
+    fail "undersized TUNNEL_MAX_STREAM_WINDOW_BYTES should fail"
+  fi
+  assert_contains "${TEST_DIR}/window.err" "TUNNEL_MAX_STREAM_WINDOW_BYTES must be at least 262144"
+
+  if run_installer MANAGEMENT_URL="https://mgmt.example.test:8081" TUNNEL_MAX_STREAM_WINDOW_BYTES="67108864" TUNNEL_MAX_CONCURRENT_REQUESTS="9" AGENT_ID="agent-one" AGENT_TOKEN="token-one" >/dev/null 2>"${TEST_DIR}/aggregate.err"; then
+    fail "oversized aggregate tunnel window should fail"
+  fi
+  assert_contains "${TEST_DIR}/aggregate.err" "TUNNEL_MAX_STREAM_WINDOW_BYTES times TUNNEL_MAX_CONCURRENT_REQUESTS must be at most 536870912"
 }
 
 test_uninstall_full_purge() {
@@ -363,6 +477,10 @@ run_test() {
 
 run_test "first install" test_first_install
 run_test "reinstall overwrites token and CA" test_reinstall_overwrites_token_and_ca
+run_test "reinstall preserves effective tunnel limits" test_reinstall_preserves_effective_tunnel_limits
+run_test "explicit tunnel setting bypasses replaced value" test_explicit_tunnel_setting_bypasses_replaced_value
+run_test "ambiguous tunnel preservation fails before mutation" test_ambiguous_tunnel_preservation_fails_before_mutation
+run_test "unreadable tunnel settings require explicit replacement" test_unreadable_tunnel_settings_require_explicit_replacement
 run_test "reinstall without CA removes stale managed CA" test_reinstall_without_ca_removes_stale_managed_ca
 run_test "staging version downloads staging asset" test_staging_version_downloads_staging_asset
 run_test "validation failures" test_validation_failures

--- a/scripts/test-agent-lifecycle.sh
+++ b/scripts/test-agent-lifecycle.sh
@@ -212,6 +212,8 @@ test_first_install() {
   run_installer \
     MANAGEMENT_URL="https://mgmt.example.test:8081" \
     MANAGEMENT_CA_PEM_BASE64="$(base64_value "CA-one")" \
+    TUNNEL_MAX_STREAM_WINDOW_BYTES="4194304" \
+    TUNNEL_MAX_CONCURRENT_REQUESTS="32" \
     AGENT_ID="agent-one" \
     AGENT_TOKEN="token-one"
 
@@ -221,6 +223,8 @@ test_first_install() {
   assert_exists "${SYSTEMD_DIR}/p2pstream-agent.service"
   assert_contains "${CONFIG_DIR}/agent.env" "MANAGEMENT_URL=\"https://mgmt.example.test:8081\""
   assert_contains "${CONFIG_DIR}/agent.env" "MANAGEMENT_CA_FILE=\"${CONFIG_DIR}/management-ca.pem\""
+  assert_contains "${CONFIG_DIR}/agent.env" "TUNNEL_MAX_STREAM_WINDOW_BYTES=\"4194304\""
+  assert_contains "${CONFIG_DIR}/agent.env" "TUNNEL_MAX_CONCURRENT_REQUESTS=\"32\""
   assert_contains "${CONFIG_DIR}/agent.env" "AGENT_ID=\"agent-one\""
   assert_contains "${CONFIG_DIR}/agent.env" "AGENT_TOKEN=\"token-one\""
   assert_contains "${CONFIG_DIR}/management-ca.pem" "CA-one"
@@ -234,6 +238,8 @@ test_reinstall_overwrites_token_and_ca() {
   run_installer \
     MANAGEMENT_URL="https://mgmt.example.test:8081" \
     MANAGEMENT_CA_PEM_BASE64="$(base64_value "old CA")" \
+    TUNNEL_MAX_STREAM_WINDOW_BYTES="4194304" \
+    TUNNEL_MAX_CONCURRENT_REQUESTS="32" \
     AGENT_ID="agent-one" \
     AGENT_TOKEN="old-token"
   : >"$SYSTEMCTL_LOG"
@@ -246,6 +252,8 @@ test_reinstall_overwrites_token_and_ca() {
 
   assert_contains "${CONFIG_DIR}/agent.env" "AGENT_TOKEN=\"new-token\""
   assert_not_contains "${CONFIG_DIR}/agent.env" "old-token"
+  assert_contains "${CONFIG_DIR}/agent.env" "TUNNEL_MAX_STREAM_WINDOW_BYTES=\"4194304\""
+  assert_contains "${CONFIG_DIR}/agent.env" "TUNNEL_MAX_CONCURRENT_REQUESTS=\"32\""
   assert_contains "${CONFIG_DIR}/management-ca.pem" "new CA"
   assert_not_contains "${CONFIG_DIR}/management-ca.pem" "old CA"
   assert_systemctl_enable_before_restart


### PR DESCRIPTION
## Summary
- raise the default Yamux per-stream receive window from 256 KiB to 2 MiB for better high-RTT throughput
- add `TUNNEL_MAX_STREAM_WINDOW_BYTES` and `TUNNEL_MAX_CONCURRENT_REQUESTS` configuration for both server and agent
- enforce a server public-request cap and a live-stream cap that includes pooled idle connections, health/environment dials, and Yamux half-close cleanup
- enforce the agent-side stream cap with an explicit `agent_capacity` response and recover capacity after close
- validate a 256 KiB to 64 MiB stream window, 1 to 2048 concurrent streams, and a maximum 512 MiB window-times-concurrency budget
- preserve installer tunnel settings with effective-last-assignment semantics and fail closed before mutation on unreadable or ambiguous environment files
- close delayed stream opens after cancellation so abandoned streams cannot escape accounting

Closes #114

## Security behavior
- defaults are 2 MiB times 64, or 128 MiB of aggregate receive-window budget per side
- overload returns `503 Service Unavailable` for public agent routes without marking the agent passively unhealthy
- stream capacity is retained through pooled idle use, peer FIN, or the bounded Yamux forced-close timeout

## Tests
- `make verify`
- `go test -race ./internal/agent ./internal/server ./internal/tunnel -count=1`
- focused stream lifetime, cancellation, pooling, capacity recovery, and installer regressions under repeated race runs
- full Linux agent lifecycle installer suite
- `git diff --check`