### PR TITLE
perf: reduce public proxy hot-path contention

### DIFF
--- a/internal/server/proxy_lifecycle.go
+++ b/internal/server/proxy_lifecycle.go
@@ -71,7 +71,7 @@ func (a *App) startProxy(ctx context.Context) (*p2pstreamv1.ProxyStatus, error) 
 	}
 
 	a.proxyMu.Lock()
-	a.publicSnapshot = snap
+	a.setPublicSnapshotLocked(snap)
 	a.proxyServiceActive = true
 	a.ensureListenerStatesLocked(snap)
 	a.proxyState = p2pstreamv1.ProxyState_PROXY_STATE_STARTING

--- a/internal/server/public_cache.go
+++ b/internal/server/public_cache.go
@@ -356,6 +356,10 @@ func (c *publicProxyCache) removeCacheBodies(rows []db.DeleteExpiredPublicCacheE
 }
 
 func (a *App) checkPublicCache(r *http.Request, resolution publicRouteResolution) publicCacheDecision {
+	return a.checkPublicCacheWithSnapshot(a.currentPublicSnapshot(), r, resolution)
+}
+
+func (a *App) checkPublicCacheWithSnapshot(snap *publicProxySnapshot, r *http.Request, resolution publicRouteResolution) publicCacheDecision {
 	startedAt := time.Now()
 	if a == nil || a.PublicCache == nil || a.DB == nil {
 		return publicCacheDecision{Status: publicCacheStatusBypass, BypassReason: "cache_unavailable"}
@@ -363,9 +367,6 @@ func (a *App) checkPublicCache(r *http.Request, resolution publicRouteResolution
 	if resolution.Target.TargetType != publicRouteTargetTypeProxy {
 		return publicCacheDecision{Status: publicCacheStatusBypass, BypassReason: "target_not_proxy"}
 	}
-	a.proxyMu.Lock()
-	snap := a.publicSnapshot
-	a.proxyMu.Unlock()
 	if snap == nil || !snap.CacheSettings.Enabled || len(snap.CacheRules) == 0 {
 		return publicCacheDecision{Status: publicCacheStatusBypass, BypassReason: "cache_disabled"}
 	}
@@ -490,20 +491,22 @@ func selectPublicCacheRule(rules []publicCacheRuleConfig, listener publicListene
 	if len(rules) == 0 {
 		return publicCacheRuleConfig{}, false
 	}
-	ordered := append([]publicCacheRuleConfig(nil), rules...)
-	sort.SliceStable(ordered, func(i, j int) bool {
-		if ordered[i].Priority == ordered[j].Priority {
-			return ordered[i].ID < ordered[j].ID
-		}
-		return ordered[i].Priority < ordered[j].Priority
-	})
-	for _, rule := range ordered {
+	for _, rule := range rules {
 		if !rule.Enabled || !rule.matches(listener, r, resolution) {
 			continue
 		}
 		return rule, true
 	}
 	return publicCacheRuleConfig{}, false
+}
+
+func sortPublicCacheRules(rules []publicCacheRuleConfig) {
+	sort.SliceStable(rules, func(i, j int) bool {
+		if rules[i].Priority == rules[j].Priority {
+			return rules[i].ID < rules[j].ID
+		}
+		return rules[i].Priority < rules[j].Priority
+	})
 }
 
 func (rule publicCacheRuleConfig) matches(listener publicListenerConfig, r *http.Request, resolution publicRouteResolution) bool {

--- a/internal/server/public_cache_test.go
+++ b/internal/server/public_cache_test.go
@@ -881,13 +881,11 @@ func newTestPublicCacheApp(t *testing.T) (*App, publicRouteResolution, func()) {
 		CacheRuleID: rule.ID,
 	}
 	resolution.Route.Targets = []publicRouteTargetConfig{resolution.Target}
-	app.proxyMu.Lock()
-	app.publicSnapshot = &publicProxySnapshot{
+	setPublicSnapshotForTest(t, app, &publicProxySnapshot{
 		CacheSettings: defaultPublicCacheSettings(),
 		CacheRules:    []publicCacheRuleConfig{rule},
 		RouteTargets:  map[int64]publicRouteTargetConfig{resolution.Target.ID: resolution.Target},
-	}
-	app.proxyMu.Unlock()
+	})
 	app.PublicCache.reconcile(defaultPublicCacheSettings())
 
 	return app, resolution, func() { database.Close() }

--- a/internal/server/public_config_loader.go
+++ b/internal/server/public_config_loader.go
@@ -48,9 +48,21 @@ func (a *App) refreshPublicProxySnapshot(ctx context.Context) error {
 	return nil
 }
 
+func (a *App) currentPublicSnapshot() *publicProxySnapshot {
+	if a == nil {
+		return nil
+	}
+	return a.publicSnapshotPtr.Load()
+}
+
+func (a *App) setPublicSnapshotLocked(snap *publicProxySnapshot) {
+	a.publicSnapshot = snap
+	a.publicSnapshotPtr.Store(snap)
+}
+
 func (a *App) applyPublicProxySnapshot(snap *publicProxySnapshot) {
 	a.proxyMu.Lock()
-	a.publicSnapshot = snap
+	a.setPublicSnapshotLocked(snap)
 	a.ensureListenerStatesLocked(snap)
 	a.proxyStatusLocked()
 	active := a.proxyServiceActive
@@ -363,6 +375,7 @@ func snapshotFromPublicRows(rows publicConfigRows) (*publicProxySnapshot, error)
 		rule.Fingerprint = publicRateLimitRuleFingerprint(rule)
 		snap.RateLimitRules = append(snap.RateLimitRules, rule)
 	}
+	sortPublicRateLimitRules(snap.RateLimitRules)
 	for _, row := range rows.TrafficShaperRules {
 		rule, err := publicTrafficShaperRuleRowToConfig(row)
 		if err != nil {
@@ -370,6 +383,7 @@ func snapshotFromPublicRows(rows publicConfigRows) (*publicProxySnapshot, error)
 		}
 		snap.TrafficShaperRules = append(snap.TrafficShaperRules, rule)
 	}
+	sortPublicTrafficShaperRules(snap.TrafficShaperRules)
 	for _, row := range rows.WafCaptchaProviders {
 		provider := publicWafCaptchaProviderRowToConfig(row, true)
 		snap.WafCaptchaProviders[provider.ID] = provider
@@ -397,6 +411,7 @@ func snapshotFromPublicRows(rows publicConfigRows) (*publicProxySnapshot, error)
 		rule.Fingerprint = publicWafRuleFingerprint(rule)
 		snap.WafRules = append(snap.WafRules, rule)
 	}
+	sortPublicWafRules(snap.WafRules)
 	for _, row := range rows.CacheRules {
 		rule, err := publicCacheRuleRowToConfig(row)
 		if err != nil {
@@ -404,6 +419,7 @@ func snapshotFromPublicRows(rows publicConfigRows) (*publicProxySnapshot, error)
 		}
 		snap.CacheRules = append(snap.CacheRules, rule)
 	}
+	sortPublicCacheRules(snap.CacheRules)
 	return snap, nil
 }
 

--- a/internal/server/public_proxy_pipeline.go
+++ b/internal/server/public_proxy_pipeline.go
@@ -28,6 +28,7 @@ type publicProxyContext struct {
 	App        *App
 	ListenerID int64
 	StartedAt  time.Time
+	Snapshot   *publicProxySnapshot
 
 	Writer         http.ResponseWriter
 	ResponseWriter http.ResponseWriter
@@ -77,10 +78,15 @@ func newPublicProxyContext(app *App, listenerID int64, w http.ResponseWriter, r 
 	if trace != nil {
 		trace.emitReceived(listenerID)
 	}
+	var snap *publicProxySnapshot
+	if app != nil {
+		snap = app.currentPublicSnapshot()
+	}
 	return &publicProxyContext{
 		App:            app,
 		ListenerID:     listenerID,
 		StartedAt:      time.Now(),
+		Snapshot:       snap,
 		Writer:         w,
 		ResponseWriter: responseWriter,
 		Recorder:       recorder,
@@ -126,7 +132,7 @@ func routePathSecurityStage(ctx *publicProxyContext) publicProxyStageResult {
 		return publicProxyStageContinue
 	}
 	if !ctx.PathIssues.hasEncodedSeparator() {
-		match, err := ctx.App.matchPublicRoute(ctx.ListenerID, ctx.Request)
+		match, err := ctx.App.matchPublicRouteInSnapshot(ctx.Snapshot, ctx.ListenerID, ctx.Request)
 		if err != nil {
 			match.Err = err
 		}
@@ -134,7 +140,7 @@ func routePathSecurityStage(ctx *publicProxyContext) publicProxyStageResult {
 		ctx.HasRouteMatch = true
 		return publicProxyStageContinue
 	}
-	match, err := ctx.App.matchPublicRoute(ctx.ListenerID, ctx.Request)
+	match, err := ctx.App.matchPublicRouteInSnapshot(ctx.Snapshot, ctx.ListenerID, ctx.Request)
 	if err != nil {
 		match.Err = err
 		ctx.RouteMatch = match
@@ -289,7 +295,7 @@ func serveACMEChallengeStage(ctx *publicProxyContext) publicProxyStageResult {
 }
 
 func serveWAFReservedStage(ctx *publicProxyContext) publicProxyStageResult {
-	decision, handled := ctx.App.servePublicWAFReserved(ctx.ResponseWriter, ctx.Request, ctx.ListenerID)
+	decision, handled := ctx.App.servePublicWAFReservedWithSnapshot(ctx.Snapshot, ctx.ResponseWriter, ctx.Request, ctx.ListenerID)
 	if !handled {
 		return publicProxyStageContinue
 	}
@@ -337,7 +343,7 @@ func beginWAFPressureStage(ctx *publicProxyContext) publicProxyStageResult {
 }
 
 func wafPolicyStage(ctx *publicProxyContext) publicProxyStageResult {
-	decision, allowed := ctx.App.checkPublicWAF(ctx.ListenerID, ctx.Request)
+	decision, allowed := ctx.App.checkPublicWAFWithSnapshot(ctx.Snapshot, ctx.ListenerID, ctx.Request)
 	if allowed {
 		return publicProxyStageContinue
 	}
@@ -379,7 +385,7 @@ func wafPolicyStage(ctx *publicProxyContext) publicProxyStageResult {
 }
 
 func rateLimitStage(ctx *publicProxyContext) publicProxyStageResult {
-	decision, allowed := ctx.App.checkPublicRateLimits(ctx.ListenerID, ctx.Request)
+	decision, allowed := ctx.App.checkPublicRateLimitsWithSnapshot(ctx.Snapshot, ctx.ListenerID, ctx.Request)
 	if allowed {
 		return publicProxyStageContinue
 	}
@@ -423,7 +429,7 @@ func rateLimitStage(ctx *publicProxyContext) publicProxyStageResult {
 }
 
 func trafficShaperStage(ctx *publicProxyContext) publicProxyStageResult {
-	decision, ok := ctx.App.selectPublicTrafficShaper(ctx.ListenerID, ctx.Request)
+	decision, ok := ctx.App.selectPublicTrafficShaperWithSnapshot(ctx.Snapshot, ctx.ListenerID, ctx.Request)
 	if !ok {
 		return publicProxyStageContinue
 	}
@@ -465,7 +471,12 @@ func routeResolutionStage(ctx *publicProxyContext) publicProxyStageResult {
 	if ctx.HasRouteMatch {
 		resolution, err = ctx.App.resolvePublicRouteFromMatch(ctx.RouteMatch)
 	} else {
-		resolution, err = ctx.App.resolvePublicRoute(ctx.ListenerID, ctx.Request)
+		match, matchErr := ctx.App.matchPublicRouteInSnapshot(ctx.Snapshot, ctx.ListenerID, ctx.Request)
+		if matchErr != nil {
+			err = matchErr
+		} else {
+			resolution, err = ctx.App.resolvePublicRouteFromMatch(match)
+		}
 	}
 	if err != nil {
 		statusCode := http.StatusBadGateway
@@ -547,7 +558,7 @@ func cacheLookupStage(ctx *publicProxyContext) publicProxyStageResult {
 	if ctx.Resolution.Target.TargetType != publicRouteTargetTypeProxy {
 		return publicProxyStageContinue
 	}
-	decision := ctx.App.checkPublicCache(ctx.Request, ctx.Resolution)
+	decision := ctx.App.checkPublicCacheWithSnapshot(ctx.Snapshot, ctx.Request, ctx.Resolution)
 	applyCacheResolutionFields(&ctx.Resolution, decision)
 	if ctx.Trace != nil {
 		ctx.Trace.emit(

--- a/internal/server/public_routing.go
+++ b/internal/server/public_routing.go
@@ -774,10 +774,10 @@ func (a *App) selectTargetAgent(target publicRouteTargetConfig) *AgentConn {
 	if snap == nil {
 		return nil
 	}
-	return a.selectTargetAgentFromSnapshot(*snap, target)
+	return a.selectTargetAgentFromSnapshot(snap, target)
 }
 
-func (a *App) selectTargetAgentFromSnapshot(snap publicProxySnapshot, target publicRouteTargetConfig) *AgentConn {
+func (a *App) selectTargetAgentFromSnapshot(snap *publicProxySnapshot, target publicRouteTargetConfig) *AgentConn {
 	candidates := a.eligibleTargetAgentCandidatesFromSnapshot(snap, target)
 	if len(candidates) == 0 {
 		return nil
@@ -793,11 +793,11 @@ func (a *App) eligibleTargetAgentCandidates(target publicRouteTargetConfig) []ba
 	if snap == nil {
 		return nil
 	}
-	return a.eligibleTargetAgentCandidatesFromSnapshot(*snap, target)
+	return a.eligibleTargetAgentCandidatesFromSnapshot(snap, target)
 }
 
-func (a *App) eligibleTargetAgentCandidatesFromSnapshot(snap publicProxySnapshot, target publicRouteTargetConfig) []backendAgentCandidate {
-	if a == nil || a.AgentHub == nil {
+func (a *App) eligibleTargetAgentCandidatesFromSnapshot(snap *publicProxySnapshot, target publicRouteTargetConfig) []backendAgentCandidate {
+	if a == nil || a.AgentHub == nil || snap == nil {
 		return nil
 	}
 	candidates := make([]backendAgentCandidate, 0, len(snap.Agents))
@@ -854,7 +854,10 @@ func shouldMarkAgentPassiveFailure(requestCtx context.Context, err error) bool {
 	return !requestContextCanceled(requestCtx, err)
 }
 
-func (a *App) selectRouteTarget(snap publicProxySnapshot, route publicRouteConfig) (publicRouteTargetConfig, *AgentConn, bool) {
+func (a *App) selectRouteTarget(snap *publicProxySnapshot, route publicRouteConfig) (publicRouteTargetConfig, *AgentConn, bool) {
+	if snap == nil {
+		return publicRouteTargetConfig{}, nil, false
+	}
 	candidates := make([]routeTargetCandidate, 0, len(route.Targets))
 	lowestPriorityGroupSet := false
 	lowestPriorityGroup := int64(0)
@@ -904,7 +907,7 @@ func (a *App) selectRouteTarget(snap publicProxySnapshot, route publicRouteConfi
 	return selected.Target, agent, true
 }
 
-func (a *App) targetEligibleForRoute(snap publicProxySnapshot, target publicRouteTargetConfig) bool {
+func (a *App) targetEligibleForRoute(snap *publicProxySnapshot, target publicRouteTargetConfig) bool {
 	if !target.Enabled {
 		return false
 	}
@@ -923,8 +926,8 @@ func (a *App) targetEligibleForRoute(snap publicProxySnapshot, target publicRout
 	return true
 }
 
-func (a *App) targetHasEligibleAgent(snap publicProxySnapshot, target publicRouteTargetConfig) bool {
-	if a == nil || a.AgentHub == nil {
+func (a *App) targetHasEligibleAgent(snap *publicProxySnapshot, target publicRouteTargetConfig) bool {
+	if a == nil || a.AgentHub == nil || snap == nil {
 		return false
 	}
 	for agentID, agentConfig := range snap.Agents {
@@ -1133,7 +1136,7 @@ func (a *App) resolvePublicRouteFromMatch(match publicRouteMatch) (publicRouteRe
 			RouteID:      routeID,
 		}, nil
 	}
-	target, agent, ok := a.selectRouteTarget(*match.Snapshot, matchedRoute)
+	target, agent, ok := a.selectRouteTarget(match.Snapshot, matchedRoute)
 	if !ok {
 		return publicRouteResolution{}, errNoRouteTargetAvailable
 	}

--- a/internal/server/public_routing.go
+++ b/internal/server/public_routing.go
@@ -770,7 +770,15 @@ func redactAgentDialAddress(address string) string {
 }
 
 func (a *App) selectTargetAgent(target publicRouteTargetConfig) *AgentConn {
-	candidates := a.eligibleTargetAgentCandidates(target)
+	snap := a.currentPublicSnapshot()
+	if snap == nil {
+		return nil
+	}
+	return a.selectTargetAgentFromSnapshot(*snap, target)
+}
+
+func (a *App) selectTargetAgentFromSnapshot(snap publicProxySnapshot, target publicRouteTargetConfig) *AgentConn {
+	candidates := a.eligibleTargetAgentCandidatesFromSnapshot(snap, target)
 	if len(candidates) == 0 {
 		return nil
 	}
@@ -781,13 +789,15 @@ func (a *App) selectTargetAgent(target publicRouteTargetConfig) *AgentConn {
 }
 
 func (a *App) eligibleTargetAgentCandidates(target publicRouteTargetConfig) []backendAgentCandidate {
-	if a == nil || a.AgentHub == nil {
+	snap := a.currentPublicSnapshot()
+	if snap == nil {
 		return nil
 	}
-	a.proxyMu.Lock()
-	snap := a.publicSnapshot
-	a.proxyMu.Unlock()
-	if snap == nil {
+	return a.eligibleTargetAgentCandidatesFromSnapshot(*snap, target)
+}
+
+func (a *App) eligibleTargetAgentCandidatesFromSnapshot(snap publicProxySnapshot, target publicRouteTargetConfig) []backendAgentCandidate {
+	if a == nil || a.AgentHub == nil {
 		return nil
 	}
 	candidates := make([]backendAgentCandidate, 0, len(snap.Agents))
@@ -887,7 +897,7 @@ func (a *App) selectRouteTarget(snap publicProxySnapshot, route publicRouteConfi
 	if selected.Target.Transport != publicRouteTargetTransportAgent {
 		return selected.Target, nil, true
 	}
-	agent := a.selectTargetAgent(selected.Target)
+	agent := a.selectTargetAgentFromSnapshot(snap, selected.Target)
 	if agent == nil {
 		return publicRouteTargetConfig{}, nil, false
 	}
@@ -1049,11 +1059,12 @@ func (a *App) resolvePublicRoute(listenerID int64, r *http.Request) (publicRoute
 }
 
 func (a *App) matchPublicRoute(listenerID int64, r *http.Request) (publicRouteMatch, error) {
+	return a.matchPublicRouteInSnapshot(a.currentPublicSnapshot(), listenerID, r)
+}
+
+func (a *App) matchPublicRouteInSnapshot(snap *publicProxySnapshot, listenerID int64, r *http.Request) (publicRouteMatch, error) {
 	host := normalizeRequestHost(r.Host)
 
-	a.proxyMu.Lock()
-	snap := a.publicSnapshot
-	a.proxyMu.Unlock()
 	if snap == nil {
 		return publicRouteMatch{}, errors.New("public proxy config is not loaded")
 	}

--- a/internal/server/public_routing_test.go
+++ b/internal/server/public_routing_test.go
@@ -40,13 +40,13 @@ func TestDottedHostWithPortMatchesRouteAndPolicyKey(t *testing.T) {
 	target := publicRouteTargetConfig{ID: 20, RouteID: 10, Enabled: true, TargetType: publicRouteTargetTypeStatic}
 	route := publicRouteConfig{ID: 10, Enabled: true, HostPattern: "app.example", Targets: []publicRouteTargetConfig{target}}
 	app := NewApp(nil, nil)
-	app.publicSnapshot = &publicProxySnapshot{
+	setPublicSnapshotForTest(t, app, &publicProxySnapshot{
 		Listeners: map[int64]publicListenerConfig{1: {ID: 1, Protocol: publicListenerProtocolHTTP}},
 		RoutesByListener: map[int64][]publicRouteConfig{
 			1: {route},
 		},
 		RouteTargets: map[int64]publicRouteTargetConfig{20: target},
-	}
+	})
 
 	resolution, err := app.resolvePublicRoute(1, req)
 	if err != nil {
@@ -365,11 +365,11 @@ func TestPublicProxyPlainSafePathStillWorks(t *testing.T) {
 
 func TestPublicProxyNoRouteUsesStrictEncodedSeparatorPolicy(t *testing.T) {
 	app := NewApp(nil, nil)
-	app.publicSnapshot = &publicProxySnapshot{
+	setPublicSnapshotForTest(t, app, &publicProxySnapshot{
 		Listeners:        map[int64]publicListenerConfig{1: {ID: 1, Protocol: publicListenerProtocolHTTP, Enabled: true}},
 		RoutesByListener: map[int64][]publicRouteConfig{1: {}},
 		WafCookieSecret:  []byte("test-secret"),
-	}
+	})
 	handler := app.publicProxyHandler(1)
 
 	safe := httptest.NewRecorder()
@@ -424,7 +424,7 @@ func TestPublicProxyEarlyRoutePathMatchDoesNotAdvanceLoadBalancer(t *testing.T) 
 	wafRule.Match = mustPublicPolicyMatchCEL(t, `path_prefix(path, "/blocked")`)
 	wafRule.Fingerprint = publicWafRuleFingerprint(wafRule)
 	app := NewApp(nil, nil)
-	app.publicSnapshot = &publicProxySnapshot{
+	snap := &publicProxySnapshot{
 		Listeners: map[int64]publicListenerConfig{1: {ID: 1, Protocol: publicListenerProtocolHTTP, Enabled: true}},
 		RoutesByListener: map[int64][]publicRouteConfig{
 			1: {route},
@@ -436,7 +436,8 @@ func TestPublicProxyEarlyRoutePathMatchDoesNotAdvanceLoadBalancer(t *testing.T) 
 		WafRules:        []publicWafRuleConfig{wafRule},
 		WafCookieSecret: []byte("test-secret"),
 	}
-	app.PublicWAF.reconcile(app.publicSnapshot)
+	setPublicSnapshotForTest(t, app, snap)
+	app.PublicWAF.reconcile(snap)
 	handler := app.publicProxyHandler(1)
 
 	blocked := httptest.NewRecorder()
@@ -634,7 +635,7 @@ func newTestPublicPathProxyWithMode(t *testing.T, pathPrefix string, wafRules []
 		Targets:          []publicRouteTargetConfig{target},
 	}
 	app := NewApp(nil, nil)
-	app.publicSnapshot = &publicProxySnapshot{
+	setPublicSnapshotForTest(t, app, &publicProxySnapshot{
 		Listeners: map[int64]publicListenerConfig{1: {ID: 1, Protocol: publicListenerProtocolHTTP, Enabled: true}},
 		RoutesByListener: map[int64][]publicRouteConfig{
 			1: {route},
@@ -642,7 +643,7 @@ func newTestPublicPathProxyWithMode(t *testing.T, pathPrefix string, wafRules []
 		RouteTargets:    map[int64]publicRouteTargetConfig{target.ID: target},
 		WafRules:        wafRules,
 		WafCookieSecret: []byte("test-secret"),
-	}
+	})
 	return app, app.publicProxyHandler(1), &hits, &lastPath
 }
 
@@ -678,13 +679,13 @@ func newTestForwardedHeaderProxy(t *testing.T, listenerProtocol string, listener
 		Targets:          []publicRouteTargetConfig{target},
 	}
 	app := NewApp(nil, nil)
-	app.publicSnapshot = &publicProxySnapshot{
+	setPublicSnapshotForTest(t, app, &publicProxySnapshot{
 		Listeners: map[int64]publicListenerConfig{1: {ID: 1, Protocol: listenerProtocol, Port: listenerPort, Enabled: true}},
 		RoutesByListener: map[int64][]publicRouteConfig{
 			1: {route},
 		},
 		RouteTargets: map[int64]publicRouteTargetConfig{target.ID: target},
-	}
+	})
 	return app.publicProxyHandler(1), captured
 }
 

--- a/internal/server/public_routing_timeout_test.go
+++ b/internal/server/public_routing_timeout_test.go
@@ -343,9 +343,7 @@ func newAgentProxyTunnelTestApp(t *testing.T, agentID int64, upstreamURL string,
 		RouteTargets: map[int64]publicRouteTargetConfig{target.ID: target},
 		Agents:       map[int64]publicAgentConfig{agentID: {ID: agentID, PublicID: agent.PublicID, Enabled: true, Labels: map[string]string{agentIDSystemLabelKey: agent.PublicID}}},
 	}
-	app.proxyMu.Lock()
-	app.publicSnapshot = snap
-	app.proxyMu.Unlock()
+	setPublicSnapshotForTest(t, app, snap)
 	app.TargetHealth.reconcile(app, snap, false)
 	return app, target, agent, fake
 }

--- a/internal/server/public_rule_order_test.go
+++ b/internal/server/public_rule_order_test.go
@@ -1,0 +1,57 @@
+package server
+
+import "testing"
+
+func TestPublicSnapshotRuleSortsUsePriorityThenID(t *testing.T) {
+	t.Run("rate limit", func(t *testing.T) {
+		rules := []publicRateLimitRuleConfig{
+			{ID: 30, Priority: 20},
+			{ID: 20, Priority: 10},
+			{ID: 10, Priority: 10},
+		}
+		sortPublicRateLimitRules(rules)
+		assertRuleIDs(t, []int64{rules[0].ID, rules[1].ID, rules[2].ID}, []int64{10, 20, 30})
+	})
+
+	t.Run("traffic shaper", func(t *testing.T) {
+		rules := []publicTrafficShaperRuleConfig{
+			{ID: 30, Priority: 20},
+			{ID: 20, Priority: 10},
+			{ID: 10, Priority: 10},
+		}
+		sortPublicTrafficShaperRules(rules)
+		assertRuleIDs(t, []int64{rules[0].ID, rules[1].ID, rules[2].ID}, []int64{10, 20, 30})
+	})
+
+	t.Run("WAF", func(t *testing.T) {
+		rules := []publicWafRuleConfig{
+			{ID: 30, Priority: 20},
+			{ID: 20, Priority: 10},
+			{ID: 10, Priority: 10},
+		}
+		sortPublicWafRules(rules)
+		assertRuleIDs(t, []int64{rules[0].ID, rules[1].ID, rules[2].ID}, []int64{10, 20, 30})
+	})
+
+	t.Run("cache", func(t *testing.T) {
+		rules := []publicCacheRuleConfig{
+			{ID: 30, Priority: 20},
+			{ID: 20, Priority: 10},
+			{ID: 10, Priority: 10},
+		}
+		sortPublicCacheRules(rules)
+		assertRuleIDs(t, []int64{rules[0].ID, rules[1].ID, rules[2].ID}, []int64{10, 20, 30})
+	})
+}
+
+func assertRuleIDs(t testing.TB, got []int64, want []int64) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("rule IDs len = %d, want %d", len(got), len(want))
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("rule IDs = %v, want %v", got, want)
+		}
+	}
+}

--- a/internal/server/public_snapshot_test.go
+++ b/internal/server/public_snapshot_test.go
@@ -1,0 +1,10 @@
+package server
+
+import "testing"
+
+func setPublicSnapshotForTest(t testing.TB, app *App, snap *publicProxySnapshot) {
+	t.Helper()
+	app.proxyMu.Lock()
+	app.setPublicSnapshotLocked(snap)
+	app.proxyMu.Unlock()
+}

--- a/internal/server/public_target_health_test.go
+++ b/internal/server/public_target_health_test.go
@@ -362,9 +362,7 @@ func TestAgentPoolSelectionSkipsDisconnectedAssignments(t *testing.T) {
 	for i := int64(1); i <= 5; i++ {
 		snap.Agents[i] = publicAgentConfig{ID: i, PublicID: "agent-" + strconv.FormatInt(i, 10), Enabled: true, Labels: map[string]string{"pool": "health-test"}}
 	}
-	app.proxyMu.Lock()
-	app.publicSnapshot = snap
-	app.proxyMu.Unlock()
+	setPublicSnapshotForTest(t, app, snap)
 	app.TargetHealth.reconcile(app, snap, false)
 	for i := int64(1); i <= 4; i++ {
 		agent := testAgentConn(i, "agent-"+strconv.FormatInt(i, 10))
@@ -442,9 +440,7 @@ func TestDefaultBackendRequiresEligibleAgent(t *testing.T) {
 		Listeners:        map[int64]publicListenerConfig{10: {ID: 10, Enabled: true}},
 		RoutesByListener: map[int64][]publicRouteConfig{10: {route}},
 	}
-	app.proxyMu.Lock()
-	app.publicSnapshot = snap
-	app.proxyMu.Unlock()
+	setPublicSnapshotForTest(t, app, snap)
 
 	req := httptest.NewRequest(http.MethodGet, "http://example.test/", nil)
 	_, err = app.resolvePublicRoute(10, req)
@@ -860,9 +856,7 @@ func testAgentPoolAppWithHealth(t *testing.T, healthEnabled bool) (*App, publicR
 		1: {ID: 1, PublicID: "agent-a", Enabled: true, Labels: map[string]string{"pool": "health-test"}},
 		2: {ID: 2, PublicID: "agent-b", Enabled: true, Labels: map[string]string{"pool": "health-test"}},
 	}
-	app.proxyMu.Lock()
-	app.publicSnapshot = snap
-	app.proxyMu.Unlock()
+	setPublicSnapshotForTest(t, app, snap)
 	app.TargetHealth.reconcile(app, snap, false)
 	for _, agent := range []*AgentConn{testAgentConn(1, "agent-a"), testAgentConn(2, "agent-b")} {
 		if err := app.AgentHub.connect(agent); err != nil {

--- a/internal/server/public_target_health_test.go
+++ b/internal/server/public_target_health_test.go
@@ -406,7 +406,7 @@ func TestAgentPoolHealthCheckAllAgentsUnhealthyMakesBackendUnavailable(t *testin
 			2: {ID: 2, PublicID: "agent-b", Enabled: true, Labels: map[string]string{"pool": "health-test"}},
 		},
 	}
-	if _, _, ok := app.selectRouteTarget(snap, route); ok {
+	if _, _, ok := app.selectRouteTarget(&snap, route); ok {
 		t.Fatal("route target should be unavailable when all agents are unhealthy")
 	}
 }
@@ -474,7 +474,7 @@ func TestRouteFallbackSelectedWhenPrimaryAgentPoolUnavailable(t *testing.T) {
 	app.TargetHealth.reconcile(app, &snap, false)
 	t.Cleanup(func() { app.TargetHealth.reconcile(app, nil, false) })
 
-	selected, _, ok := app.selectRouteTarget(snap, route)
+	selected, _, ok := app.selectRouteTarget(&snap, route)
 	if !ok || selected.ID != fallbackTarget.ID {
 		t.Fatalf("route target selection = target=%d ok=%v, want fallback %d", selected.ID, ok, fallbackTarget.ID)
 	}
@@ -514,7 +514,7 @@ func TestRouteTargetLeastActiveUsesTargetHealthCounters(t *testing.T) {
 	done := app.TargetHealth.beginRequest(busy.ID)
 	t.Cleanup(done)
 
-	selected, _, ok := app.selectRouteTarget(snap, route)
+	selected, _, ok := app.selectRouteTarget(&snap, route)
 	if !ok || selected.ID != idle.ID {
 		t.Fatalf("route target selection = target=%d ok=%v, want idle target %d", selected.ID, ok, idle.ID)
 	}
@@ -781,7 +781,7 @@ func TestRouteKeepsBackendEligibleAfterPassiveFailureWhenHealthDisabled(t *testi
 		Action:  publicRouteActionForward,
 		Targets: []publicRouteTargetConfig{target},
 	}
-	selected, _, ok := app.selectRouteTarget(snap, route)
+	selected, _, ok := app.selectRouteTarget(&snap, route)
 	if !ok || selected.ID != target.ID {
 		t.Fatalf("route target selection = target=%d ok=%v, want target %d", selected.ID, ok, target.ID)
 	}

--- a/internal/server/public_traffic_shaper.go
+++ b/internal/server/public_traffic_shaper.go
@@ -139,12 +139,13 @@ func (s *publicTrafficShaper) reconcile(snap *publicProxySnapshot) {
 }
 
 func (a *App) selectPublicTrafficShaper(listenerID int64, r *http.Request) (publicTrafficShaperDecision, bool) {
+	return a.selectPublicTrafficShaperWithSnapshot(a.currentPublicSnapshot(), listenerID, r)
+}
+
+func (a *App) selectPublicTrafficShaperWithSnapshot(snap *publicProxySnapshot, listenerID int64, r *http.Request) (publicTrafficShaperDecision, bool) {
 	if a == nil || a.TrafficShaper == nil {
 		return publicTrafficShaperDecision{}, false
 	}
-	a.proxyMu.Lock()
-	snap := a.publicSnapshot
-	a.proxyMu.Unlock()
 	if snap == nil || len(snap.TrafficShaperRules) == 0 {
 		return publicTrafficShaperDecision{}, false
 	}
@@ -159,20 +160,22 @@ func (s *publicTrafficShaper) evaluate(rules []publicTrafficShaperRuleConfig, li
 	if len(rules) == 0 {
 		return publicTrafficShaperDecision{}, false
 	}
-	ordered := append([]publicTrafficShaperRuleConfig(nil), rules...)
-	sort.SliceStable(ordered, func(i, j int) bool {
-		if ordered[i].Priority == ordered[j].Priority {
-			return ordered[i].ID < ordered[j].ID
-		}
-		return ordered[i].Priority < ordered[j].Priority
-	})
-	for _, rule := range ordered {
+	for _, rule := range rules {
 		if !rule.Enabled || !rule.matches(listener, r) {
 			continue
 		}
 		return s.decisionForRule(rule, listener, r, now), true
 	}
 	return publicTrafficShaperDecision{}, false
+}
+
+func sortPublicTrafficShaperRules(rules []publicTrafficShaperRuleConfig) {
+	sort.SliceStable(rules, func(i, j int) bool {
+		if rules[i].Priority == rules[j].Priority {
+			return rules[i].ID < rules[j].ID
+		}
+		return rules[i].Priority < rules[j].Priority
+	})
 }
 
 func (s *publicTrafficShaper) decisionForRule(rule publicTrafficShaperRuleConfig, listener publicListenerConfig, r *http.Request, now time.Time) publicTrafficShaperDecision {

--- a/internal/server/public_traffic_shaper_test.go
+++ b/internal/server/public_traffic_shaper_test.go
@@ -22,7 +22,9 @@ func TestPublicTrafficShaperSelectsFirstMatchingRule(t *testing.T) {
 
 	later := testTrafficShaperRule(1, "later", 100, publicTrafficShaperBudgetScopePerKey, 0, 1024)
 	first := testTrafficShaperRule(2, "first", 10, publicTrafficShaperBudgetScopePerKey, 0, 512)
-	decision, ok := shaper.evaluate([]publicTrafficShaperRuleConfig{later, first}, listener, req, time.Unix(1, 0))
+	rules := []publicTrafficShaperRuleConfig{later, first}
+	sortPublicTrafficShaperRules(rules)
+	decision, ok := shaper.evaluate(rules, listener, req, time.Unix(1, 0))
 	if !ok {
 		t.Fatal("expected matching shaper")
 	}

--- a/internal/server/public_waf.go
+++ b/internal/server/public_waf.go
@@ -285,12 +285,13 @@ func (w *publicWAF) reconcile(snap *publicProxySnapshot) {
 }
 
 func (a *App) checkPublicWAF(listenerID int64, r *http.Request) (publicWafDecision, bool) {
+	return a.checkPublicWAFWithSnapshot(a.currentPublicSnapshot(), listenerID, r)
+}
+
+func (a *App) checkPublicWAFWithSnapshot(snap *publicProxySnapshot, listenerID int64, r *http.Request) (publicWafDecision, bool) {
 	if a == nil || a.PublicWAF == nil {
 		return publicWafDecision{}, true
 	}
-	a.proxyMu.Lock()
-	snap := a.publicSnapshot
-	a.proxyMu.Unlock()
 	if snap == nil || len(snap.WafRules) == 0 {
 		return publicWafDecision{}, true
 	}
@@ -302,24 +303,16 @@ func (a *App) checkPublicWAF(listenerID int64, r *http.Request) (publicWafDecisi
 }
 
 func (w *publicWAF) evaluate(snap *publicProxySnapshot, listener publicListenerConfig, r *http.Request, now time.Time, app *App) (publicWafDecision, bool) {
-	ordered := append([]publicWafRuleConfig(nil), snap.WafRules...)
-	sort.SliceStable(ordered, func(i, j int) bool {
-		if ordered[i].Priority == ordered[j].Priority {
-			return ordered[i].ID < ordered[j].ID
-		}
-		return ordered[i].Priority < ordered[j].Priority
-	})
-
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	for _, rule := range ordered {
+	for _, rule := range snap.WafRules {
 		if !rule.Enabled || !rule.matches(listener, r) {
 			continue
 		}
-		runtime := w.runtimeLocked(rule)
 		automaticActive := false
 		if rule.ActivationMode == publicWafActivationAutomatic {
+			w.mu.Lock()
+			runtime := w.runtimeLocked(rule)
 			automaticActive = w.updateAutomaticActivationLocked(runtime, rule, snap, app, now)
+			w.mu.Unlock()
 			if !automaticActive {
 				continue
 			}
@@ -357,7 +350,10 @@ func (w *publicWAF) evaluate(snap *publicProxySnapshot, listener publicListenerC
 				CaptchaReturnTo:       returnTo,
 			}, false
 		case publicWafActionWaitingRoom:
+			w.mu.Lock()
+			runtime := w.runtimeLocked(rule)
 			decision, allowed := runtime.waitingRoom.evaluateLocked(w, rule, listener, r, now, automaticActive)
+			w.mu.Unlock()
 			return decision, allowed
 		default:
 			return publicWafDecision{
@@ -375,6 +371,15 @@ func (w *publicWAF) evaluate(snap *publicProxySnapshot, listener publicListenerC
 		}
 	}
 	return publicWafDecision{}, true
+}
+
+func sortPublicWafRules(rules []publicWafRuleConfig) {
+	sort.SliceStable(rules, func(i, j int) bool {
+		if rules[i].Priority == rules[j].Priority {
+			return rules[i].ID < rules[j].ID
+		}
+		return rules[i].Priority < rules[j].Priority
+	})
 }
 
 func (w *publicWAF) runtimeLocked(rule publicWafRuleConfig) *publicWafRuleRuntime {

--- a/internal/server/public_waf_captcha.go
+++ b/internal/server/public_waf_captcha.go
@@ -73,6 +73,10 @@ func isPublicWAFReservedPath(path string) bool {
 }
 
 func (a *App) servePublicWAFReserved(w http.ResponseWriter, r *http.Request, listenerID int64) (publicWafDecision, bool) {
+	return a.servePublicWAFReservedWithSnapshot(a.currentPublicSnapshot(), w, r, listenerID)
+}
+
+func (a *App) servePublicWAFReservedWithSnapshot(snap *publicProxySnapshot, w http.ResponseWriter, r *http.Request, listenerID int64) (publicWafDecision, bool) {
 	if !isPublicWAFReservedPath(r.URL.Path) {
 		return publicWafDecision{}, false
 	}
@@ -81,9 +85,9 @@ func (a *App) servePublicWAFReserved(w http.ResponseWriter, r *http.Request, lis
 	}
 	switch r.URL.Path {
 	case publicWafCaptchaVerifyPath:
-		return a.servePublicWAFCaptchaVerify(w, r, listenerID), true
+		return a.servePublicWAFCaptchaVerifyWithSnapshot(snap, w, r, listenerID), true
 	case publicWafWaitingRoomPath, publicWafWaitingRoomStatusPath:
-		return a.servePublicWAFWaitingRoomStatus(w, r, listenerID), true
+		return a.servePublicWAFWaitingRoomStatusWithSnapshot(snap, w, r, listenerID), true
 	default:
 		http.NotFound(w, r)
 		return publicWafDecision{StatusCode: http.StatusNotFound, ErrorKind: "waf_reserved_not_found"}, true
@@ -127,6 +131,10 @@ func publicWafReservedRateLimitDecision(listenerID int64, path string, retryAfte
 }
 
 func (a *App) servePublicWAFCaptchaVerify(w http.ResponseWriter, r *http.Request, listenerID int64) publicWafDecision {
+	return a.servePublicWAFCaptchaVerifyWithSnapshot(a.currentPublicSnapshot(), w, r, listenerID)
+}
+
+func (a *App) servePublicWAFCaptchaVerifyWithSnapshot(snap *publicProxySnapshot, w http.ResponseWriter, r *http.Request, listenerID int64) publicWafDecision {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -161,7 +169,7 @@ func (a *App) servePublicWAFCaptchaVerify(w http.ResponseWriter, r *http.Request
 	if token == "" {
 		token = strings.TrimSpace(r.Form.Get("g-recaptcha-response"))
 	}
-	decision, rule, provider, ok := a.wafRuleAndProvider(ruleID, listenerID)
+	decision, rule, provider, ok := a.wafRuleAndProviderFromSnapshot(snap, ruleID, listenerID)
 	if !ok {
 		http.Error(w, "captcha rule unavailable", http.StatusServiceUnavailable)
 		return decision
@@ -224,9 +232,10 @@ func (a *App) servePublicWAFCaptchaVerify(w http.ResponseWriter, r *http.Request
 }
 
 func (a *App) wafRuleAndProvider(ruleID int64, listenerID int64) (publicWafDecision, publicWafRuleConfig, publicWafCaptchaProviderConfig, bool) {
-	a.proxyMu.Lock()
-	snap := a.publicSnapshot
-	a.proxyMu.Unlock()
+	return a.wafRuleAndProviderFromSnapshot(a.currentPublicSnapshot(), ruleID, listenerID)
+}
+
+func (a *App) wafRuleAndProviderFromSnapshot(snap *publicProxySnapshot, ruleID int64, listenerID int64) (publicWafDecision, publicWafRuleConfig, publicWafCaptchaProviderConfig, bool) {
 	decision := publicWafDecision{
 		Listener:   publicListenerConfig{ID: listenerID},
 		Action:     publicWafActionCaptcha,

--- a/internal/server/public_waf_test.go
+++ b/internal/server/public_waf_test.go
@@ -547,9 +547,7 @@ func TestPublicWafReservedWaitingRoomStatusRateLimited(t *testing.T) {
 	app := NewApp(nil, nil)
 	rule := testWafRule(1, publicWafActionWaitingRoom)
 	snap := testWafSnapshot(rule, nil)
-	app.proxyMu.Lock()
-	app.publicSnapshot = snap
-	app.proxyMu.Unlock()
+	setPublicSnapshotForTest(t, app, snap)
 	app.PublicWAF.reconcile(snap)
 	handler := app.publicProxyHandler(1)
 
@@ -717,9 +715,7 @@ func TestPublicWafWaitingRoomStatusSanitizesUnsafeReturnRedirect(t *testing.T) {
 	app := NewApp(nil, nil)
 	rule := testWafRule(1, publicWafActionWaitingRoom)
 	snap := testWafSnapshot(rule, nil)
-	app.proxyMu.Lock()
-	app.publicSnapshot = snap
-	app.proxyMu.Unlock()
+	setPublicSnapshotForTest(t, app, snap)
 	app.PublicWAF.reconcile(snap)
 
 	req := httptest.NewRequest(http.MethodGet, "http://example.com"+publicWafWaitingRoomStatusPath+"?rule_id=1&return_to=%2F%2Fevil.example%2Fprivate", nil)
@@ -932,9 +928,7 @@ func TestPublicProxyCaptchaPassStillHitsRateLimit(t *testing.T) {
 		WafCookieSecret: []byte("test-secret"),
 		RateLimitRules:  []publicRateLimitRuleConfig{rateLimitRule},
 	}
-	app.proxyMu.Lock()
-	app.publicSnapshot = snap
-	app.proxyMu.Unlock()
+	setPublicSnapshotForTest(t, app, snap)
 	app.PublicWAF.reconcile(snap)
 	app.RateLimiter.reconcile(snap)
 	handler := app.publicProxyHandler(1)
@@ -1450,9 +1444,7 @@ func newTestCaptchaVerifyApp(t *testing.T, provider http.HandlerFunc) (*App, htt
 			Enabled:      true,
 		},
 	})
-	app.proxyMu.Lock()
-	app.publicSnapshot = snap
-	app.proxyMu.Unlock()
+	setPublicSnapshotForTest(t, app, snap)
 	app.PublicWAF.reconcile(snap)
 	return app, app.publicProxyHandler(1), rule, &calls
 }

--- a/internal/server/public_waf_test.go
+++ b/internal/server/public_waf_test.go
@@ -1054,6 +1054,48 @@ func TestPublicWafCookieSecretConcurrentReconcileAndSigning(t *testing.T) {
 	}
 }
 
+func TestPublicWaitingRoomRuntimeMaintainsPositionIndex(t *testing.T) {
+	rt := newPublicWaitingRoomRuntime()
+	now := time.Unix(100, 0)
+
+	rt.enqueueLocked("a", now)
+	rt.enqueueLocked("b", now.Add(time.Second))
+	rt.enqueueLocked("c", now.Add(2*time.Second))
+
+	if got := rt.positionLocked("a"); got != 1 {
+		t.Fatalf("position a = %d, want 1", got)
+	}
+	if got := rt.positionLocked("c"); got != 3 {
+		t.Fatalf("position c = %d, want 3", got)
+	}
+
+	delete(rt.queued, "a")
+	rt.removeFromQueueLocked("a")
+	if _, ok := rt.queueIndex["a"]; ok {
+		t.Fatal("removed session still present in queue index")
+	}
+	if got := rt.positionLocked("b"); got != 1 {
+		t.Fatalf("position b after head removal = %d, want 1", got)
+	}
+	if got := rt.positionLocked("c"); got != 2 {
+		t.Fatalf("position c after head removal = %d, want 2", got)
+	}
+
+	rt.pruneLocked(now.Add(63*time.Second), 61*time.Second)
+	if _, ok := rt.queued["b"]; ok {
+		t.Fatal("expired session still present in queued map")
+	}
+	if _, ok := rt.queueIndex["b"]; ok {
+		t.Fatal("expired session still present in queue index")
+	}
+	if got := rt.positionLocked("c"); got != 1 {
+		t.Fatalf("position c after prune = %d, want 1", got)
+	}
+	if rt.queueHead != 0 || len(rt.queue) != 1 || rt.queue[0] != "c" {
+		t.Fatalf("queue after compaction = head %d queue %#v, want head 0 queue [c]", rt.queueHead, rt.queue)
+	}
+}
+
 func TestPublicWafWaitingRoomFIFOAdmission(t *testing.T) {
 	waf := newPublicWAF()
 	rule := testWafRule(1, publicWafActionWaitingRoom)

--- a/internal/server/public_waf_waiting_room.go
+++ b/internal/server/public_waf_waiting_room.go
@@ -13,6 +13,8 @@ import (
 
 type publicWaitingRoomRuntime struct {
 	queue           []string
+	queueHead       int
+	queueIndex      map[string]int
 	queued          map[string]time.Time
 	admitted        map[string]time.Time
 	admissionTokens float64
@@ -21,8 +23,9 @@ type publicWaitingRoomRuntime struct {
 
 func newPublicWaitingRoomRuntime() *publicWaitingRoomRuntime {
 	return &publicWaitingRoomRuntime{
-		queued:   make(map[string]time.Time),
-		admitted: make(map[string]time.Time),
+		queueIndex: make(map[string]int),
+		queued:     make(map[string]time.Time),
+		admitted:   make(map[string]time.Time),
 	}
 }
 
@@ -60,11 +63,10 @@ func (rt *publicWaitingRoomRuntime) evaluateLocked(w *publicWAF, rule publicWafR
 				RetryAfter:      retryAfter,
 				AutomaticActive: automaticActive,
 				ChallengeKind:   publicWafActionWaitingRoom,
-				QueuePosition:   int64(len(rt.queue) + 1),
+				QueuePosition:   int64(rt.queueLenLocked() + 1),
 			}, false
 		}
-		rt.queued[sessionID] = now
-		rt.queue = append(rt.queue, sessionID)
+		rt.enqueueLocked(sessionID, now)
 	}
 	position := rt.positionLocked(sessionID)
 	queueCookie := w.signedRuleCookie(rule, listener, r, publicWafQueueCookieKind, sessionID, queueTimeout, now)
@@ -115,23 +117,29 @@ func (rt *publicWaitingRoomRuntime) pruneLocked(now time.Time, queueTimeout time
 	if queueTimeout <= 0 {
 		queueTimeout = defaultWafWaitingRoomQueueTimeout
 	}
-	keep := rt.queue[:0]
-	for _, sessionID := range rt.queue {
+	// Enqueue times are FIFO, so a non-expired head means later sessions are not expired.
+	for rt.queueHead < len(rt.queue) {
+		sessionID := rt.queue[rt.queueHead]
 		enqueuedAt, ok := rt.queued[sessionID]
 		if !ok {
+			delete(rt.queueIndex, sessionID)
+			rt.queue[rt.queueHead] = ""
+			rt.queueHead++
 			continue
 		}
-		if now.Sub(enqueuedAt) > queueTimeout {
-			delete(rt.queued, sessionID)
-			continue
+		if now.Sub(enqueuedAt) <= queueTimeout {
+			break
 		}
-		keep = append(keep, sessionID)
+		delete(rt.queued, sessionID)
+		delete(rt.queueIndex, sessionID)
+		rt.queue[rt.queueHead] = ""
+		rt.queueHead++
 	}
-	rt.queue = keep
+	rt.compactQueueLocked()
 }
 
 func (rt *publicWaitingRoomRuntime) canAdmitLocked(rule publicWafRuleConfig, now time.Time, sessionID string) bool {
-	if len(rt.queue) == 0 || rt.queue[0] != sessionID {
+	if rt.queueLenLocked() == 0 || rt.queue[rt.queueHead] != sessionID {
 		return false
 	}
 	maxAdmitted := rule.WaitingRoom.MaxAdmittedSessions
@@ -165,21 +173,67 @@ func (rt *publicWaitingRoomRuntime) canAdmitLocked(rule publicWafRuleConfig, now
 }
 
 func (rt *publicWaitingRoomRuntime) positionLocked(sessionID string) int64 {
-	for idx, queuedID := range rt.queue {
-		if queuedID == sessionID {
-			return int64(idx + 1)
-		}
+	idx, ok := rt.queueIndex[sessionID]
+	if ok && idx >= rt.queueHead && idx < len(rt.queue) {
+		return int64(idx - rt.queueHead + 1)
 	}
-	return int64(len(rt.queue) + 1)
+	return int64(rt.queueLenLocked() + 1)
 }
 
 func (rt *publicWaitingRoomRuntime) removeFromQueueLocked(sessionID string) {
-	for idx, queuedID := range rt.queue {
-		if queuedID == sessionID {
-			copy(rt.queue[idx:], rt.queue[idx+1:])
-			rt.queue = rt.queue[:len(rt.queue)-1]
-			return
-		}
+	idx, ok := rt.queueIndex[sessionID]
+	if !ok || idx < rt.queueHead || idx >= len(rt.queue) {
+		return
+	}
+	delete(rt.queueIndex, sessionID)
+	if idx == rt.queueHead {
+		rt.queue[idx] = ""
+		rt.queueHead++
+		rt.compactQueueLocked()
+		return
+	}
+	copy(rt.queue[idx:], rt.queue[idx+1:])
+	rt.queue[len(rt.queue)-1] = ""
+	rt.queue = rt.queue[:len(rt.queue)-1]
+	for shiftedIdx := idx; shiftedIdx < len(rt.queue); shiftedIdx++ {
+		rt.queueIndex[rt.queue[shiftedIdx]] = shiftedIdx
+	}
+}
+
+func (rt *publicWaitingRoomRuntime) enqueueLocked(sessionID string, now time.Time) {
+	if rt.queueIndex == nil {
+		rt.queueIndex = make(map[string]int)
+	}
+	rt.queued[sessionID] = now
+	rt.queueIndex[sessionID] = len(rt.queue)
+	rt.queue = append(rt.queue, sessionID)
+}
+
+func (rt *publicWaitingRoomRuntime) queueLenLocked() int {
+	return len(rt.queue) - rt.queueHead
+}
+
+func (rt *publicWaitingRoomRuntime) compactQueueLocked() {
+	if rt.queueHead == 0 {
+		return
+	}
+	if rt.queueHead == len(rt.queue) {
+		clear(rt.queueIndex)
+		rt.queue = rt.queue[:0]
+		rt.queueHead = 0
+		return
+	}
+	if rt.queueHead < 1024 && rt.queueHead*2 < len(rt.queue) {
+		return
+	}
+	active := copy(rt.queue, rt.queue[rt.queueHead:])
+	for idx := active; idx < len(rt.queue); idx++ {
+		rt.queue[idx] = ""
+	}
+	rt.queue = rt.queue[:active]
+	rt.queueHead = 0
+	for idx, sessionID := range rt.queue {
+		rt.queueIndex[sessionID] = idx
 	}
 }
 

--- a/internal/server/public_waf_waiting_room.go
+++ b/internal/server/public_waf_waiting_room.go
@@ -261,10 +261,11 @@ func writeWaitingRoomPage(w http.ResponseWriter, r *http.Request, decision publi
 }
 
 func (a *App) servePublicWAFWaitingRoomStatus(w http.ResponseWriter, r *http.Request, listenerID int64) publicWafDecision {
+	return a.servePublicWAFWaitingRoomStatusWithSnapshot(a.currentPublicSnapshot(), w, r, listenerID)
+}
+
+func (a *App) servePublicWAFWaitingRoomStatusWithSnapshot(snap *publicProxySnapshot, w http.ResponseWriter, r *http.Request, listenerID int64) publicWafDecision {
 	ruleID, _ := strconv.ParseInt(r.URL.Query().Get("rule_id"), 10, 64)
-	a.proxyMu.Lock()
-	snap := a.publicSnapshot
-	a.proxyMu.Unlock()
 	if snap == nil || a.PublicWAF == nil || ruleID <= 0 {
 		http.NotFound(w, r)
 		return publicWafDecision{Action: publicWafActionWaitingRoom, StatusCode: http.StatusNotFound, ErrorKind: "waf_waiting_room_not_found"}

--- a/internal/server/rate_limiter.go
+++ b/internal/server/rate_limiter.go
@@ -179,12 +179,13 @@ func (l *publicRateLimiter) reconcile(snap *publicProxySnapshot) {
 }
 
 func (a *App) checkPublicRateLimits(listenerID int64, r *http.Request) (publicRateLimitDecision, bool) {
+	return a.checkPublicRateLimitsWithSnapshot(a.currentPublicSnapshot(), listenerID, r)
+}
+
+func (a *App) checkPublicRateLimitsWithSnapshot(snap *publicProxySnapshot, listenerID int64, r *http.Request) (publicRateLimitDecision, bool) {
 	if a == nil || a.RateLimiter == nil {
 		return publicRateLimitDecision{}, true
 	}
-	a.proxyMu.Lock()
-	snap := a.publicSnapshot
-	a.proxyMu.Unlock()
 	if snap == nil || len(snap.RateLimitRules) == 0 {
 		return publicRateLimitDecision{}, true
 	}
@@ -199,16 +200,8 @@ func (l *publicRateLimiter) evaluate(rules []publicRateLimitRuleConfig, listener
 	if len(rules) == 0 {
 		return publicRateLimitDecision{}, true
 	}
-	ordered := append([]publicRateLimitRuleConfig(nil), rules...)
-	sort.SliceStable(ordered, func(i, j int) bool {
-		if ordered[i].Priority == ordered[j].Priority {
-			return ordered[i].ID < ordered[j].ID
-		}
-		return ordered[i].Priority < ordered[j].Priority
-	})
-
-	candidates := make([]publicRateLimitEvaluationCandidate, 0, len(ordered))
-	for _, rule := range ordered {
+	candidates := make([]publicRateLimitEvaluationCandidate, 0, len(rules))
+	for _, rule := range rules {
 		if !rule.Enabled || !rule.matches(listener, r) {
 			continue
 		}
@@ -256,6 +249,15 @@ func (l *publicRateLimiter) evaluate(rules []publicRateLimitRuleConfig, listener
 		}
 	}
 	return publicRateLimitDecision{}, true
+}
+
+func sortPublicRateLimitRules(rules []publicRateLimitRuleConfig) {
+	sort.SliceStable(rules, func(i, j int) bool {
+		if rules[i].Priority == rules[j].Priority {
+			return rules[i].ID < rules[j].ID
+		}
+		return rules[i].Priority < rules[j].Priority
+	})
 }
 
 func (l *publicRateLimiter) pruneLocked(now time.Time) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -75,6 +75,7 @@ type App struct {
 	proxyState          p2pstreamv1.ProxyState
 	proxyLastError      string
 	publicSnapshot      *publicProxySnapshot
+	publicSnapshotPtr   atomic.Pointer[publicProxySnapshot]
 	publicListenerState map[int64]*publicListenerRuntime
 
 	publicConfigCacheMu sync.RWMutex


### PR DESCRIPTION
## Summary
- publish public proxy snapshots through an atomic pointer and capture one snapshot per public request
- thread that request snapshot through route matching, WAF, rate limits, traffic shaping, reserved WAF endpoints, cache lookup, and agent target selection without copying the snapshot struct on the hot path
- move WAF/rate-limit/traffic-shaper/cache rule sorting to snapshot construction and narrow WAF locking to mutable runtime state
- index waiting-room queue positions so queue polling no longer scans the whole queue while holding the WAF mutex

## Why the waiting-room index is in this PR
Issue #115 tracks reducing public proxy hot-path contention, including narrowing `publicWAF.mu`. The waiting-room status/poll path still runs under that mutex, and the previous `positionLocked` implementation did an O(queue length) scan while holding it. The queue index removes that scan from the same WAF hot path this PR is optimizing, so it belongs with the mutex-contention fix rather than as unrelated feature work.

Closes #115

## Tests
- go test ./internal/server -run 'TestPublicWaitingRoomRuntimeMaintainsPositionIndex|TestPublicWafWaitingRoom' -count=1
- go test ./internal/server -run 'Test.*Route|Test.*Target|Test.*Agent|TestPublicWaitingRoomRuntimeMaintainsPositionIndex|TestPublicWafWaitingRoom' -count=1
- go test ./internal/server -count=1
- go test ./... -count=1
