### PR TITLE
perf: index public cache lookups in memory

### DIFF
--- a/internal/server/public_cache.go
+++ b/internal/server/public_cache.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"container/list"
 	"context"
 	"crypto/sha256"
 	"database/sql"
@@ -60,7 +61,11 @@ const (
 	maxPublicCacheCleanupIntervalMillis     = int64(3600000)
 	maxPublicCacheHeaderBytes               = 256 * 1024
 	maxPublicCacheListItems                 = 64
-	publicCacheKeyDigestVersion             = "v3"
+	// Miss keys are attacker-derived, so their in-memory budget remains bounded
+	// independently of the operator's potentially much larger disk-entry limit.
+	maxPublicCacheNegativeLookups = 4096
+	publicCacheNegativeLookupTTL  = 30 * time.Second
+	publicCacheKeyDigestVersion   = "v3"
 )
 
 var defaultPublicCacheStatusCodes = []int64{200, 203, 204, 301, 308}
@@ -120,36 +125,44 @@ type publicCacheRuleMutationInput struct {
 }
 
 type publicCacheDecision struct {
-	Rule           publicCacheRuleConfig
-	Status         string
-	KeyDigest      string
-	QueryKey       string
-	Host           string
-	Path           string
-	RouteID        sql.NullInt64
-	RouteTargetID  sql.NullInt64
-	Entry          *db.PublicCacheEntry
-	BypassReason   string
-	CookieRequest  bool
-	Cacheable      bool
-	StoredBytes    int64
-	LookupDuration time.Duration
-	HitBody        io.ReadCloser
+	Rule             publicCacheRuleConfig
+	Status           string
+	KeyDigest        string
+	QueryKey         string
+	Host             string
+	Path             string
+	RouteID          sql.NullInt64
+	RouteTargetID    sql.NullInt64
+	Entry            *db.PublicCacheEntry
+	BypassReason     string
+	CookieRequest    bool
+	Cacheable        bool
+	StoredBytes      int64
+	LookupDuration   time.Duration
+	HitBody          io.ReadCloser
+	cacheGeneration  uint64
+	cacheFingerprint string
+	cacheCurrent     bool
 }
 
 type publicProxyCache struct {
 	dir string
 
+	// storeGate lets cache writes run concurrently while making a configuration
+	// invalidation atomic with respect to the final database commit.
+	storeGate       sync.RWMutex
 	mu              sync.Mutex
 	settings        publicCacheSettingsConfig
 	lastCleanup     time.Time
 	memoryEntries   map[string]*publicCacheMemoryEntry
 	indexEntries    map[string]publicCacheIndexEntry
 	indexLookups    map[publicCacheLookupKey]map[string]struct{}
-	loadedLookups   map[publicCacheLookupKey]struct{}
+	negativeLookups map[publicCacheLookupDigest]*list.Element
+	negativeOrder   *list.List
 	pendingTouches  map[string]struct{}
 	memoryBytes     int64
 	lastFingerprint string
+	generation      uint64
 }
 
 type publicCacheMemoryEntry struct {
@@ -172,18 +185,26 @@ type publicCacheLookupKey struct {
 	RouteTargetID    int64
 }
 
+type publicCacheLookupDigest [sha256.Size]byte
+
+type publicCacheNegativeLookup struct {
+	digest    publicCacheLookupDigest
+	expiresAt time.Time
+}
+
 func newPublicProxyCache(cacheDir string) *publicProxyCache {
 	if strings.TrimSpace(cacheDir) == "" {
 		cacheDir = filepath.Join(config.DefaultConfigDir, "cache", "public")
 	}
 	return &publicProxyCache{
-		dir:            cacheDir,
-		settings:       defaultPublicCacheSettings(),
-		memoryEntries:  make(map[string]*publicCacheMemoryEntry),
-		indexEntries:   make(map[string]publicCacheIndexEntry),
-		indexLookups:   make(map[publicCacheLookupKey]map[string]struct{}),
-		loadedLookups:  make(map[publicCacheLookupKey]struct{}),
-		pendingTouches: make(map[string]struct{}),
+		dir:             cacheDir,
+		settings:        defaultPublicCacheSettings(),
+		memoryEntries:   make(map[string]*publicCacheMemoryEntry),
+		indexEntries:    make(map[string]publicCacheIndexEntry),
+		indexLookups:    make(map[publicCacheLookupKey]map[string]struct{}),
+		negativeLookups: make(map[publicCacheLookupDigest]*list.Element),
+		negativeOrder:   list.New(),
+		pendingTouches:  make(map[string]struct{}),
 	}
 }
 
@@ -206,10 +227,15 @@ func (c *publicProxyCache) reconcile(settings publicCacheSettingsConfig, rules [
 		return
 	}
 	fingerprint := publicCacheRuntimeFingerprint(settings, rules)
+	c.storeGate.Lock()
+	defer c.storeGate.Unlock()
 	c.mu.Lock()
-	configChanged := c.lastFingerprint != "" && c.lastFingerprint != fingerprint
+	configChanged := c.lastFingerprint != fingerprint
 	c.settings = settings
 	c.lastFingerprint = fingerprint
+	if configChanged {
+		c.generation++
+	}
 	if configChanged || !settings.Enabled {
 		c.clearIndexLocked()
 	}
@@ -220,6 +246,69 @@ func (c *publicProxyCache) reconcile(settings publicCacheSettingsConfig, rules [
 		c.pruneMemoryLocked()
 	}
 	c.mu.Unlock()
+}
+
+func (c *publicProxyCache) invalidateConfiguration() {
+	if c == nil {
+		return
+	}
+	c.storeGate.Lock()
+	c.mu.Lock()
+	c.generation++
+	c.lastFingerprint = ""
+	c.clearIndexLocked()
+	c.mu.Unlock()
+	c.storeGate.Unlock()
+}
+
+// invalidateEntries rejects requests that began before an explicit purge while
+// allowing requests that begin after the purge boundary to use the same config.
+func (c *publicProxyCache) invalidateEntries() {
+	if c == nil {
+		return
+	}
+	c.storeGate.Lock()
+	c.mu.Lock()
+	c.generation++
+	c.clearIndexLocked()
+	c.mu.Unlock()
+	c.storeGate.Unlock()
+}
+
+func (c *publicProxyCache) captureGeneration(fingerprint string) (uint64, bool) {
+	if c == nil || fingerprint == "" {
+		return 0, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.generation, c.settings.Enabled && c.lastFingerprint == fingerprint
+}
+
+func (c *publicProxyCache) generationMatches(generation uint64, fingerprint string) bool {
+	if c == nil || fingerprint == "" {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.settings.Enabled && c.generation == generation && c.lastFingerprint == fingerprint
+}
+
+func (c *publicProxyCache) acquireStoreGeneration(generation uint64, fingerprint string) bool {
+	if c == nil {
+		return false
+	}
+	c.storeGate.RLock()
+	if c.generationMatches(generation, fingerprint) {
+		return true
+	}
+	c.storeGate.RUnlock()
+	return false
+}
+
+func (c *publicProxyCache) releaseStoreGeneration() {
+	if c != nil {
+		c.storeGate.RUnlock()
+	}
 }
 
 func publicCacheRuntimeFingerprint(settings publicCacheSettingsConfig, rules []publicCacheRuleConfig) string {
@@ -260,6 +349,16 @@ func publicCacheRuntimeFingerprint(settings publicCacheSettingsConfig, rules []p
 	data, _ := json.Marshal(payload)
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:])
+}
+
+func publicCacheSnapshotFingerprint(snap *publicProxySnapshot) string {
+	if snap == nil {
+		return ""
+	}
+	if snap.CacheFingerprint != "" {
+		return snap.CacheFingerprint
+	}
+	return publicCacheRuntimeFingerprint(snap.CacheSettings, snap.CacheRules)
 }
 
 func (c *publicProxyCache) memoryHotObjectMaxBytesSnapshot() int64 {
@@ -370,7 +469,8 @@ func (c *publicProxyCache) deleteEntryLocked(key string) {
 func (c *publicProxyCache) clearIndexLocked() {
 	c.indexEntries = make(map[string]publicCacheIndexEntry)
 	c.indexLookups = make(map[publicCacheLookupKey]map[string]struct{})
-	c.loadedLookups = make(map[publicCacheLookupKey]struct{})
+	c.negativeLookups = make(map[publicCacheLookupDigest]*list.Element)
+	c.negativeOrder = list.New()
 	c.pendingTouches = make(map[string]struct{})
 }
 
@@ -381,27 +481,116 @@ func (c *publicProxyCache) ensureIndexLocked() {
 	if c.indexLookups == nil {
 		c.indexLookups = make(map[publicCacheLookupKey]map[string]struct{})
 	}
-	if c.loadedLookups == nil {
-		c.loadedLookups = make(map[publicCacheLookupKey]struct{})
+	if c.negativeLookups == nil {
+		c.negativeLookups = make(map[publicCacheLookupDigest]*list.Element)
+	}
+	if c.negativeOrder == nil {
+		c.negativeOrder = list.New()
 	}
 	if c.pendingTouches == nil {
 		c.pendingTouches = make(map[string]struct{})
 	}
 }
 
-func (c *publicProxyCache) lookupIndexedCandidates(lookupKey publicCacheLookupKey, now time.Time) ([]db.PublicCacheEntry, bool) {
+func publicCacheLookupKeyHash(lookupKey publicCacheLookupKey) publicCacheLookupDigest {
+	// Retain only a fixed-width digest: Host, Path, and QueryKey all originate
+	// from an untrusted public request and can otherwise consume unbounded heap.
+	data, _ := json.Marshal(lookupKey)
+	return sha256.Sum256(data)
+}
+
+func (c *publicProxyCache) negativeLookupLimitLocked() int {
+	maxEntries := c.settings.MaxEntries
+	if maxEntries <= 0 {
+		maxEntries = defaultPublicCacheMaxEntries
+	}
+	remaining := maxEntries - int64(len(c.indexEntries))
+	if remaining <= 0 {
+		return 0
+	}
+	if remaining > maxPublicCacheNegativeLookups {
+		return maxPublicCacheNegativeLookups
+	}
+	return int(remaining)
+}
+
+func (c *publicProxyCache) removeNegativeLookupDigestLocked(digest publicCacheLookupDigest) {
+	element := c.negativeLookups[digest]
+	if element == nil {
+		return
+	}
+	delete(c.negativeLookups, digest)
+	c.negativeOrder.Remove(element)
+}
+
+func (c *publicProxyCache) removeNegativeLookupLocked(lookupKey publicCacheLookupKey) {
+	c.removeNegativeLookupDigestLocked(publicCacheLookupKeyHash(lookupKey))
+}
+
+func (c *publicProxyCache) pruneNegativeLookupsLocked(now time.Time) {
+	for element := c.negativeOrder.Front(); element != nil; {
+		next := element.Next()
+		negative := element.Value.(publicCacheNegativeLookup)
+		if negative.expiresAt.After(now) {
+			break
+		}
+		c.removeNegativeLookupDigestLocked(negative.digest)
+		element = next
+	}
+	limit := c.negativeLookupLimitLocked()
+	for len(c.negativeLookups) > limit {
+		element := c.negativeOrder.Front()
+		if element == nil {
+			break
+		}
+		negative := element.Value.(publicCacheNegativeLookup)
+		c.removeNegativeLookupDigestLocked(negative.digest)
+	}
+}
+
+func (c *publicProxyCache) rememberNegativeLookupLocked(lookupKey publicCacheLookupKey, now time.Time) {
+	c.pruneNegativeLookupsLocked(now)
+	if c.negativeLookupLimitLocked() == 0 {
+		return
+	}
+	digest := publicCacheLookupKeyHash(lookupKey)
+	c.removeNegativeLookupDigestLocked(digest)
+	element := c.negativeOrder.PushBack(publicCacheNegativeLookup{
+		digest:    digest,
+		expiresAt: now.Add(publicCacheNegativeLookupTTL),
+	})
+	c.negativeLookups[digest] = element
+	c.pruneNegativeLookupsLocked(now)
+}
+
+func (c *publicProxyCache) negativeLookupLoadedLocked(lookupKey publicCacheLookupKey, now time.Time) bool {
+	digest := publicCacheLookupKeyHash(lookupKey)
+	element := c.negativeLookups[digest]
+	if element == nil {
+		return false
+	}
+	negative := element.Value.(publicCacheNegativeLookup)
+	if !negative.expiresAt.After(now) {
+		c.removeNegativeLookupDigestLocked(digest)
+		return false
+	}
+	return true
+}
+
+func (c *publicProxyCache) lookupIndexedCandidates(lookupKey publicCacheLookupKey, now time.Time, generation uint64, fingerprint string) ([]db.PublicCacheEntry, bool) {
 	if c == nil {
 		return nil, false
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.ensureIndexLocked()
-	if _, ok := c.loadedLookups[lookupKey]; !ok {
+	if !c.settings.Enabled || c.generation != generation || c.lastFingerprint != fingerprint {
 		return nil, false
 	}
 	digests := c.indexLookups[lookupKey]
 	if len(digests) == 0 {
-		return nil, true
+		delete(c.indexLookups, lookupKey)
+		return nil, c.negativeLookupLoadedLocked(lookupKey, now)
 	}
 	candidates := make([]db.PublicCacheEntry, 0, len(digests))
 	for key := range digests {
@@ -418,24 +607,32 @@ func (c *publicProxyCache) lookupIndexedCandidates(lookupKey publicCacheLookupKe
 	}
 	if len(digests) == 0 {
 		delete(c.indexLookups, lookupKey)
+		return nil, false
 	}
 	return candidates, true
 }
 
-func (c *publicProxyCache) storeIndexedCandidates(lookupKey publicCacheLookupKey, candidates []db.PublicCacheEntry, now time.Time) {
+func (c *publicProxyCache) storeIndexedCandidates(lookupKey publicCacheLookupKey, candidates []db.PublicCacheEntry, now time.Time, generation uint64, fingerprint string) {
 	if c == nil {
 		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.ensureIndexLocked()
-	c.loadedLookups[lookupKey] = struct{}{}
+	if !c.settings.Enabled || c.generation != generation || c.lastFingerprint != fingerprint {
+		return
+	}
+	stored := false
 	for _, entry := range candidates {
 		if !entry.ExpiresAt.After(now) {
 			c.deleteEntryLocked(entry.KeyDigest)
 			continue
 		}
 		c.putIndexEntryLocked(entry)
+		stored = true
+	}
+	if !stored {
+		c.rememberNegativeLookupLocked(lookupKey, now)
 	}
 }
 
@@ -469,7 +666,8 @@ func (c *publicProxyCache) putIndexEntryLocked(entry db.PublicCacheEntry) {
 		c.indexLookups[lookupKey] = digests
 	}
 	digests[entry.KeyDigest] = struct{}{}
-	c.loadedLookups[lookupKey] = struct{}{}
+	c.removeNegativeLookupLocked(lookupKey)
+	c.pruneNegativeLookupsLocked(time.Now())
 }
 
 func (c *publicProxyCache) touchEntry(key string, now time.Time) {
@@ -632,6 +830,8 @@ func (a *App) checkPublicCacheWithSnapshot(snap *publicProxySnapshot, r *http.Re
 		return decision
 	}
 	decision.Rule = rule
+	decision.cacheFingerprint = publicCacheSnapshotFingerprint(snap)
+	decision.cacheGeneration, decision.cacheCurrent = a.PublicCache.captureGeneration(decision.cacheFingerprint)
 	if rule.Scope == publicCacheScopeRoute {
 		decision.RouteTargetID = sql.NullInt64{}
 	}
@@ -647,7 +847,7 @@ func (a *App) checkPublicCacheWithSnapshot(snap *publicProxySnapshot, r *http.Re
 	a.PublicCache.maybeCleanup(context.Background(), a.DB)
 	now := time.Now()
 	lookupKey := publicCacheLookupKeyFromDecision(rule, resolution, decision, queryKey)
-	candidates, loaded := a.PublicCache.lookupIndexedCandidates(lookupKey, now)
+	candidates, loaded := a.PublicCache.lookupIndexedCandidates(lookupKey, now, decision.cacheGeneration, decision.cacheFingerprint)
 	if !loaded {
 		var err error
 		candidates, err = a.DB.ListPublicCacheEntryCandidates(context.Background(), db.ListPublicCacheEntryCandidatesParams{
@@ -665,7 +865,7 @@ func (a *App) checkPublicCacheWithSnapshot(snap *publicProxySnapshot, r *http.Re
 			decision.LookupDuration = time.Since(startedAt)
 			return decision
 		}
-		a.PublicCache.storeIndexedCandidates(lookupKey, candidates, now)
+		a.PublicCache.storeIndexedCandidates(lookupKey, candidates, now, decision.cacheGeneration, decision.cacheFingerprint)
 	}
 	for _, entry := range candidates {
 		varyHeaders := publicCacheStringListFromJSON(entry.VaryHeadersJson)
@@ -1012,6 +1212,9 @@ func (a *App) capturePublicCacheResponseBody(ctx context.Context, r *http.Reques
 		}
 		return nil
 	}
+	if !decision.cacheCurrent || !a.PublicCache.generationMatches(decision.cacheGeneration, decision.cacheFingerprint) {
+		return resp.Body
+	}
 	ttl, varyHeaders, ok := publicCacheResponseEligibility(decision.Rule, resp)
 	if !ok {
 		return resp.Body
@@ -1062,6 +1265,8 @@ func (a *App) capturePublicCacheResponseBody(ctx context.Context, r *http.Reques
 		expiresAt:               time.Now().Add(ttl),
 		memoryBuffer:            memoryBuffer,
 		memoryHotObjectMaxBytes: memoryHotObjectMaxBytes,
+		cacheGeneration:         decision.cacheGeneration,
+		cacheFingerprint:        decision.cacheFingerprint,
 	}
 }
 
@@ -1087,6 +1292,8 @@ type publicCacheStoreReadCloser struct {
 	expiresAt               time.Time
 	memoryBuffer            *bytes.Buffer
 	memoryHotObjectMaxBytes int64
+	cacheGeneration         uint64
+	cacheFingerprint        string
 	bytesWritten            int64
 	tooLarge                bool
 	committed               bool
@@ -1139,6 +1346,11 @@ func (r *publicCacheStoreReadCloser) commit() {
 		r.discard()
 		return
 	}
+	if r.app == nil || r.app.PublicCache == nil || !r.app.PublicCache.acquireStoreGeneration(r.cacheGeneration, r.cacheFingerprint) {
+		r.discard()
+		return
+	}
+	defer r.app.PublicCache.releaseStoreGeneration()
 	if err := r.tmp.Close(); err != nil {
 		r.markStoreFailed()
 		r.discard()
@@ -1765,6 +1977,7 @@ func (a *App) CreatePublicCacheRule(ctx context.Context, req *connect.Request[p2
 	if err != nil {
 		return nil, publicDBError(err)
 	}
+	a.PublicCache.invalidateConfiguration()
 	if err := a.refreshPublicProxySnapshot(ctx); err != nil {
 		return nil, err
 	}
@@ -1790,6 +2003,7 @@ func (a *App) UpdatePublicCacheRule(ctx context.Context, req *connect.Request[p2
 	if err != nil {
 		return nil, publicDBError(err)
 	}
+	a.PublicCache.invalidateConfiguration()
 	if err := a.purgePublicCacheEntriesByRuleID(ctx, req.Msg.Id); err != nil {
 		return nil, publicDBError(err)
 	}
@@ -1807,6 +2021,7 @@ func (a *App) DeletePublicCacheRule(ctx context.Context, req *connect.Request[p2
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
+	a.PublicCache.invalidateConfiguration()
 	if err := a.purgePublicCacheEntriesByRuleID(ctx, req.Msg.Id); err != nil {
 		return nil, publicDBError(err)
 	}
@@ -1846,6 +2061,7 @@ func (a *App) UpdatePublicCacheSettings(ctx context.Context, req *connect.Reques
 	if err != nil {
 		return nil, publicDBError(err)
 	}
+	a.PublicCache.invalidateConfiguration()
 	if err := a.refreshPublicProxySnapshot(ctx); err != nil {
 		return nil, err
 	}
@@ -1863,6 +2079,7 @@ func (a *App) PurgePublicCache(ctx context.Context, req *connect.Request[p2pstre
 	var purgedEntries int64
 	var purgedBytes int64
 	if req.Msg.All {
+		a.PublicCache.invalidateEntries()
 		var err error
 		rows, err = a.DB.PurgeAllPublicCacheEntries(ctx)
 		if err != nil {
@@ -1875,6 +2092,7 @@ func (a *App) PurgePublicCache(ctx context.Context, req *connect.Request[p2pstre
 			purgedBytes += row.SizeBytes
 		}
 	} else if req.Msg.RuleId > 0 {
+		a.PublicCache.invalidateEntries()
 		ruleRows, err := a.DB.PurgePublicCacheEntriesByRule(ctx, req.Msg.RuleId)
 		if err != nil {
 			return nil, publicDBError(err)
@@ -1894,6 +2112,7 @@ func (a *App) PurgePublicCache(ctx context.Context, req *connect.Request[p2pstre
 		if pathPrefix != "" && !strings.HasPrefix(pathPrefix, "/") {
 			return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("cache purge path prefix must start with /"))
 		}
+		a.PublicCache.invalidateEntries()
 		hostRows, err := a.DB.PurgePublicCacheEntriesByHostPath(ctx, db.PurgePublicCacheEntriesByHostPathParams{
 			Column1: host,
 			Host:    host,

--- a/internal/server/public_cache.go
+++ b/internal/server/public_cache.go
@@ -134,6 +134,7 @@ type publicCacheDecision struct {
 	Cacheable      bool
 	StoredBytes    int64
 	LookupDuration time.Duration
+	HitBody        io.ReadCloser
 }
 
 type publicProxyCache struct {
@@ -143,6 +144,10 @@ type publicProxyCache struct {
 	settings        publicCacheSettingsConfig
 	lastCleanup     time.Time
 	memoryEntries   map[string]*publicCacheMemoryEntry
+	indexEntries    map[string]publicCacheIndexEntry
+	indexLookups    map[publicCacheLookupKey]map[string]struct{}
+	loadedLookups   map[publicCacheLookupKey]struct{}
+	pendingTouches  map[string]struct{}
 	memoryBytes     int64
 	lastFingerprint string
 }
@@ -152,14 +157,33 @@ type publicCacheMemoryEntry struct {
 	lastAccessed time.Time
 }
 
+type publicCacheIndexEntry struct {
+	entry     db.PublicCacheEntry
+	lookupKey publicCacheLookupKey
+}
+
+type publicCacheLookupKey struct {
+	RuleID           int64
+	ListenerProtocol string
+	Host             string
+	Path             string
+	QueryKey         string
+	RouteID          int64
+	RouteTargetID    int64
+}
+
 func newPublicProxyCache(cacheDir string) *publicProxyCache {
 	if strings.TrimSpace(cacheDir) == "" {
 		cacheDir = filepath.Join(config.DefaultConfigDir, "cache", "public")
 	}
 	return &publicProxyCache{
-		dir:           cacheDir,
-		settings:      defaultPublicCacheSettings(),
-		memoryEntries: make(map[string]*publicCacheMemoryEntry),
+		dir:            cacheDir,
+		settings:       defaultPublicCacheSettings(),
+		memoryEntries:  make(map[string]*publicCacheMemoryEntry),
+		indexEntries:   make(map[string]publicCacheIndexEntry),
+		indexLookups:   make(map[publicCacheLookupKey]map[string]struct{}),
+		loadedLookups:  make(map[publicCacheLookupKey]struct{}),
+		pendingTouches: make(map[string]struct{}),
 	}
 }
 
@@ -177,12 +201,18 @@ func defaultPublicCacheSettings() publicCacheSettingsConfig {
 	}
 }
 
-func (c *publicProxyCache) reconcile(settings publicCacheSettingsConfig) {
+func (c *publicProxyCache) reconcile(settings publicCacheSettingsConfig, rules []publicCacheRuleConfig) {
 	if c == nil {
 		return
 	}
+	fingerprint := publicCacheRuntimeFingerprint(settings, rules)
 	c.mu.Lock()
+	configChanged := c.lastFingerprint != "" && c.lastFingerprint != fingerprint
 	c.settings = settings
+	c.lastFingerprint = fingerprint
+	if configChanged || !settings.Enabled {
+		c.clearIndexLocked()
+	}
 	if !settings.Enabled || settings.MaxMemoryBytes <= 0 {
 		c.memoryEntries = make(map[string]*publicCacheMemoryEntry)
 		c.memoryBytes = 0
@@ -190,6 +220,46 @@ func (c *publicProxyCache) reconcile(settings publicCacheSettingsConfig) {
 		c.pruneMemoryLocked()
 	}
 	c.mu.Unlock()
+}
+
+func publicCacheRuntimeFingerprint(settings publicCacheSettingsConfig, rules []publicCacheRuleConfig) string {
+	type settingsFingerprint struct {
+		Enabled                 bool
+		MaxDiskBytes            int64
+		MaxMemoryBytes          int64
+		MemoryHotObjectMaxBytes int64
+		MaxEntries              int64
+		CleanupInterval         time.Duration
+	}
+	type ruleFingerprint struct {
+		ID          int64
+		Fingerprint string
+		Enabled     bool
+	}
+	payload := struct {
+		Settings settingsFingerprint
+		Rules    []ruleFingerprint
+	}{
+		Settings: settingsFingerprint{
+			Enabled:                 settings.Enabled,
+			MaxDiskBytes:            settings.MaxDiskBytes,
+			MaxMemoryBytes:          settings.MaxMemoryBytes,
+			MemoryHotObjectMaxBytes: settings.MemoryHotObjectMaxBytes,
+			MaxEntries:              settings.MaxEntries,
+			CleanupInterval:         settings.CleanupInterval,
+		},
+		Rules: make([]ruleFingerprint, 0, len(rules)),
+	}
+	for _, rule := range rules {
+		payload.Rules = append(payload.Rules, ruleFingerprint{
+			ID:          rule.ID,
+			Fingerprint: rule.Fingerprint,
+			Enabled:     rule.Enabled,
+		})
+	}
+	data, _ := json.Marshal(payload)
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
 }
 
 func (c *publicProxyCache) memoryHotObjectMaxBytesSnapshot() int64 {
@@ -262,10 +332,178 @@ func (c *publicProxyCache) deleteMemory(key string) {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.deleteMemoryLocked(key)
+}
+
+func (c *publicProxyCache) deleteMemoryLocked(key string) {
 	if existing := c.memoryEntries[key]; existing != nil {
 		c.memoryBytes -= int64(len(existing.body))
 		delete(c.memoryEntries, key)
 	}
+}
+
+func (c *publicProxyCache) deleteEntry(key string) {
+	if c == nil || key == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.deleteEntryLocked(key)
+}
+
+func (c *publicProxyCache) deleteEntryLocked(key string) {
+	c.deleteMemoryLocked(key)
+	indexEntry, ok := c.indexEntries[key]
+	if !ok {
+		return
+	}
+	delete(c.indexEntries, key)
+	delete(c.pendingTouches, key)
+	if digests := c.indexLookups[indexEntry.lookupKey]; digests != nil {
+		delete(digests, key)
+		if len(digests) == 0 {
+			delete(c.indexLookups, indexEntry.lookupKey)
+		}
+	}
+}
+
+func (c *publicProxyCache) clearIndexLocked() {
+	c.indexEntries = make(map[string]publicCacheIndexEntry)
+	c.indexLookups = make(map[publicCacheLookupKey]map[string]struct{})
+	c.loadedLookups = make(map[publicCacheLookupKey]struct{})
+	c.pendingTouches = make(map[string]struct{})
+}
+
+func (c *publicProxyCache) ensureIndexLocked() {
+	if c.indexEntries == nil {
+		c.indexEntries = make(map[string]publicCacheIndexEntry)
+	}
+	if c.indexLookups == nil {
+		c.indexLookups = make(map[publicCacheLookupKey]map[string]struct{})
+	}
+	if c.loadedLookups == nil {
+		c.loadedLookups = make(map[publicCacheLookupKey]struct{})
+	}
+	if c.pendingTouches == nil {
+		c.pendingTouches = make(map[string]struct{})
+	}
+}
+
+func (c *publicProxyCache) lookupIndexedCandidates(lookupKey publicCacheLookupKey, now time.Time) ([]db.PublicCacheEntry, bool) {
+	if c == nil {
+		return nil, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ensureIndexLocked()
+	if _, ok := c.loadedLookups[lookupKey]; !ok {
+		return nil, false
+	}
+	digests := c.indexLookups[lookupKey]
+	if len(digests) == 0 {
+		return nil, true
+	}
+	candidates := make([]db.PublicCacheEntry, 0, len(digests))
+	for key := range digests {
+		indexEntry, ok := c.indexEntries[key]
+		if !ok {
+			delete(digests, key)
+			continue
+		}
+		if !indexEntry.entry.ExpiresAt.After(now) {
+			c.deleteEntryLocked(key)
+			continue
+		}
+		candidates = append(candidates, indexEntry.entry)
+	}
+	if len(digests) == 0 {
+		delete(c.indexLookups, lookupKey)
+	}
+	return candidates, true
+}
+
+func (c *publicProxyCache) storeIndexedCandidates(lookupKey publicCacheLookupKey, candidates []db.PublicCacheEntry, now time.Time) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ensureIndexLocked()
+	c.loadedLookups[lookupKey] = struct{}{}
+	for _, entry := range candidates {
+		if !entry.ExpiresAt.After(now) {
+			c.deleteEntryLocked(entry.KeyDigest)
+			continue
+		}
+		c.putIndexEntryLocked(entry)
+	}
+}
+
+func (c *publicProxyCache) putIndexEntry(entry db.PublicCacheEntry) {
+	if c == nil || entry.KeyDigest == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ensureIndexLocked()
+	c.putIndexEntryLocked(entry)
+}
+
+func (c *publicProxyCache) putIndexEntryLocked(entry db.PublicCacheEntry) {
+	if entry.KeyDigest == "" {
+		return
+	}
+	lookupKey := publicCacheLookupKeyFromEntry(entry)
+	if existing, ok := c.indexEntries[entry.KeyDigest]; ok && existing.lookupKey != lookupKey {
+		if digests := c.indexLookups[existing.lookupKey]; digests != nil {
+			delete(digests, entry.KeyDigest)
+			if len(digests) == 0 {
+				delete(c.indexLookups, existing.lookupKey)
+			}
+		}
+	}
+	c.indexEntries[entry.KeyDigest] = publicCacheIndexEntry{entry: entry, lookupKey: lookupKey}
+	digests := c.indexLookups[lookupKey]
+	if digests == nil {
+		digests = make(map[string]struct{})
+		c.indexLookups[lookupKey] = digests
+	}
+	digests[entry.KeyDigest] = struct{}{}
+	c.loadedLookups[lookupKey] = struct{}{}
+}
+
+func (c *publicProxyCache) touchEntry(key string, now time.Time) {
+	if c == nil || key == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ensureIndexLocked()
+	indexEntry, ok := c.indexEntries[key]
+	if !ok {
+		return
+	}
+	indexEntry.entry.LastAccessedAt = now
+	indexEntry.entry.HitCount++
+	c.indexEntries[key] = indexEntry
+	c.pendingTouches[key] = struct{}{}
+}
+
+func (c *publicProxyCache) drainPendingTouches() []string {
+	if c == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.pendingTouches) == 0 {
+		return nil
+	}
+	touches := make([]string, 0, len(c.pendingTouches))
+	for key := range c.pendingTouches {
+		touches = append(touches, key)
+	}
+	c.pendingTouches = make(map[string]struct{})
+	return touches
 }
 
 func (c *publicProxyCache) pruneMemoryLocked() {
@@ -317,6 +555,10 @@ func (c *publicProxyCache) maybeCleanup(ctx context.Context, q *db.DB) {
 	settings := c.settings
 	c.mu.Unlock()
 
+	for _, key := range c.drainPendingTouches() {
+		_ = q.TouchPublicCacheEntry(ctx, key)
+	}
+
 	rows, err := q.DeleteExpiredPublicCacheEntries(ctx, now)
 	if err == nil {
 		c.removeCacheBodies(rows)
@@ -337,7 +579,7 @@ func (c *publicProxyCache) maybeCleanup(ctx context.Context, q *db.DB) {
 			if err := q.DeletePublicCacheEntry(ctx, row.KeyDigest); err != nil {
 				continue
 			}
-			c.deleteMemory(row.KeyDigest)
+			c.deleteEntry(row.KeyDigest)
 			_ = os.Remove(row.BodyPath)
 			totalBytes -= row.SizeBytes
 			entryCount--
@@ -350,7 +592,7 @@ func (c *publicProxyCache) maybeCleanup(ctx context.Context, q *db.DB) {
 
 func (c *publicProxyCache) removeCacheBodies(rows []db.DeleteExpiredPublicCacheEntriesRow) {
 	for _, row := range rows {
-		c.deleteMemory(row.KeyDigest)
+		c.deleteEntry(row.KeyDigest)
 		_ = os.Remove(row.BodyPath)
 	}
 }
@@ -403,20 +645,27 @@ func (a *App) checkPublicCacheWithSnapshot(snap *publicProxySnapshot, r *http.Re
 	decision.QueryKey = queryKey
 
 	a.PublicCache.maybeCleanup(context.Background(), a.DB)
-	candidates, err := a.DB.ListPublicCacheEntryCandidates(context.Background(), db.ListPublicCacheEntryCandidatesParams{
-		RuleID:           rule.ID,
-		ListenerProtocol: resolution.Listener.Protocol,
-		Host:             decision.Host,
-		Path:             decision.Path,
-		QueryKey:         queryKey,
-		RouteID:          sql.NullInt64{Int64: nullInt64Value(decision.RouteID), Valid: true},
-		RouteTargetID:    sql.NullInt64{Int64: nullInt64Value(decision.RouteTargetID), Valid: true},
-		ExpiresAt:        time.Now(),
-	})
-	if err != nil {
-		decision.Status = publicCacheStatusMiss
-		decision.LookupDuration = time.Since(startedAt)
-		return decision
+	now := time.Now()
+	lookupKey := publicCacheLookupKeyFromDecision(rule, resolution, decision, queryKey)
+	candidates, loaded := a.PublicCache.lookupIndexedCandidates(lookupKey, now)
+	if !loaded {
+		var err error
+		candidates, err = a.DB.ListPublicCacheEntryCandidates(context.Background(), db.ListPublicCacheEntryCandidatesParams{
+			RuleID:           lookupKey.RuleID,
+			ListenerProtocol: lookupKey.ListenerProtocol,
+			Host:             lookupKey.Host,
+			Path:             lookupKey.Path,
+			QueryKey:         lookupKey.QueryKey,
+			RouteID:          sql.NullInt64{Int64: lookupKey.RouteID, Valid: true},
+			RouteTargetID:    sql.NullInt64{Int64: lookupKey.RouteTargetID, Valid: true},
+			ExpiresAt:        now,
+		})
+		if err != nil {
+			decision.Status = publicCacheStatusMiss
+			decision.LookupDuration = time.Since(startedAt)
+			return decision
+		}
+		a.PublicCache.storeIndexedCandidates(lookupKey, candidates, now)
 	}
 	for _, entry := range candidates {
 		varyHeaders := publicCacheStringListFromJSON(entry.VaryHeadersJson)
@@ -424,9 +673,9 @@ func (a *App) checkPublicCacheWithSnapshot(snap *publicProxySnapshot, r *http.Re
 		if keyDigest != entry.KeyDigest {
 			continue
 		}
-		if _, err := os.Stat(entry.BodyPath); err != nil {
+		if !entry.ExpiresAt.After(now) {
 			_ = a.DB.DeletePublicCacheEntry(context.Background(), entry.KeyDigest)
-			a.PublicCache.deleteMemory(entry.KeyDigest)
+			a.PublicCache.deleteEntry(entry.KeyDigest)
 			continue
 		}
 		decision.Status = publicCacheStatusHit
@@ -434,7 +683,7 @@ func (a *App) checkPublicCacheWithSnapshot(snap *publicProxySnapshot, r *http.Re
 		entryCopy := entry
 		decision.Entry = &entryCopy
 		decision.LookupDuration = time.Since(startedAt)
-		_ = a.DB.TouchPublicCacheEntry(context.Background(), entry.KeyDigest)
+		a.PublicCache.touchEntry(entry.KeyDigest, now)
 		return decision
 	}
 	decision.Status = publicCacheStatusMiss
@@ -462,6 +711,30 @@ func publicCacheBaseDecision(r *http.Request, resolution publicRouteResolution) 
 		RouteID:       routeID,
 		RouteTargetID: routeTargetID,
 		CookieRequest: r.Header.Get("Cookie") != "",
+	}
+}
+
+func publicCacheLookupKeyFromDecision(rule publicCacheRuleConfig, resolution publicRouteResolution, decision publicCacheDecision, queryKey string) publicCacheLookupKey {
+	return publicCacheLookupKey{
+		RuleID:           rule.ID,
+		ListenerProtocol: resolution.Listener.Protocol,
+		Host:             decision.Host,
+		Path:             decision.Path,
+		QueryKey:         queryKey,
+		RouteID:          nullInt64Value(decision.RouteID),
+		RouteTargetID:    nullInt64Value(decision.RouteTargetID),
+	}
+}
+
+func publicCacheLookupKeyFromEntry(entry db.PublicCacheEntry) publicCacheLookupKey {
+	return publicCacheLookupKey{
+		RuleID:           entry.RuleID,
+		ListenerProtocol: entry.ListenerProtocol,
+		Host:             entry.Host,
+		Path:             entry.Path,
+		QueryKey:         entry.QueryKey,
+		RouteID:          nullInt64Value(entry.RouteID),
+		RouteTargetID:    nullInt64Value(entry.RouteTargetID),
 	}
 }
 
@@ -611,6 +884,41 @@ func publicCacheKeyDigest(r *http.Request, resolution publicRouteResolution, rul
 	return hex.EncodeToString(sum[:])
 }
 
+func (a *App) preparePublicCacheHitBody(r *http.Request, decision *publicCacheDecision) bool {
+	if a == nil || a.PublicCache == nil || decision == nil || decision.Entry == nil {
+		return false
+	}
+	if r.Method == http.MethodHead || decision.Entry.SizeBytes == 0 {
+		return true
+	}
+	if body := a.PublicCache.getMemory(decision.Entry.KeyDigest); len(body) > 0 {
+		decision.HitBody = io.NopCloser(bytes.NewReader(body))
+		return true
+	}
+	file, err := os.Open(decision.Entry.BodyPath)
+	if err != nil {
+		a.invalidatePublicCacheEntry(*decision.Entry)
+		return false
+	}
+	decision.HitBody = file
+	return true
+}
+
+func (a *App) invalidatePublicCacheEntry(entry db.PublicCacheEntry) {
+	if a == nil {
+		return
+	}
+	if a.DB != nil && entry.KeyDigest != "" {
+		_ = a.DB.DeletePublicCacheEntry(context.Background(), entry.KeyDigest)
+	}
+	if a.PublicCache != nil {
+		a.PublicCache.deleteEntry(entry.KeyDigest)
+	}
+	if entry.BodyPath != "" {
+		_ = os.Remove(entry.BodyPath)
+	}
+}
+
 func (a *App) servePublicCacheHit(w http.ResponseWriter, r *http.Request, resolution publicRouteResolution, trace *trafficRequestTrace, shaper *publicTrafficShaperDecision, decision publicCacheDecision, observability proxyRequestObservability) {
 	startedAt := time.Now()
 	statusCode := http.StatusOK
@@ -634,7 +942,7 @@ func (a *App) servePublicCacheHit(w http.ResponseWriter, r *http.Request, resolu
 			sql.NullInt64{},
 			sql.NullInt64{Int64: decision.Rule.ID, Valid: decision.Rule.ID != 0},
 			publicCacheStatusHit,
-			uint64FromInt64(decision.Entry.SizeBytes),
+			cacheEntryBytes(decision.Entry),
 			observability.requestBytesValue(),
 			observability.responseBytesValue(),
 			proxyRequestContextFromHTTP(r),
@@ -645,6 +953,28 @@ func (a *App) servePublicCacheHit(w http.ResponseWriter, r *http.Request, resolu
 		errorKind = "cache_entry_missing"
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
+	}
+	var body io.ReadCloser
+	if r.Method != http.MethodHead && decision.Entry.SizeBytes > 0 {
+		if decision.HitBody != nil {
+			body = decision.HitBody
+		} else if memoryBody := a.PublicCache.getMemory(decision.Entry.KeyDigest); len(memoryBody) > 0 {
+			body = io.NopCloser(bytes.NewReader(memoryBody))
+		} else {
+			file, err := os.Open(decision.Entry.BodyPath)
+			if err != nil {
+				a.invalidatePublicCacheEntry(*decision.Entry)
+				statusCode = http.StatusInternalServerError
+				errorKind = "cache_body_missing"
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				return
+			}
+			body = file
+		}
+		if shaper != nil {
+			body = shaper.wrapDownloadBody(r.Context(), body)
+		}
+		defer body.Close()
 	}
 	headers := publicCacheHeadersFromJSON(decision.Entry.ResponseHeadersJson)
 	for key, values := range headers {
@@ -662,30 +992,17 @@ func (a *App) servePublicCacheHit(w http.ResponseWriter, r *http.Request, resolu
 	}
 	statusCode = int(decision.Entry.StatusCode)
 	w.WriteHeader(statusCode)
-	if r.Method == http.MethodHead || decision.Entry.SizeBytes == 0 {
+	if body == nil {
 		return
 	}
-	if body := a.PublicCache.getMemory(decision.Entry.KeyDigest); len(body) > 0 {
-		reader := io.NopCloser(bytes.NewReader(body))
-		if shaper != nil {
-			reader = shaper.wrapDownloadBody(r.Context(), reader)
-		}
-		defer reader.Close()
-		_, _ = io.Copy(w, reader)
-		return
-	}
-	file, err := os.Open(decision.Entry.BodyPath)
-	if err != nil {
-		statusCode = http.StatusInternalServerError
-		errorKind = "cache_body_missing"
-		return
-	}
-	var body io.ReadCloser = file
-	if shaper != nil {
-		body = shaper.wrapDownloadBody(r.Context(), body)
-	}
-	defer body.Close()
 	_, _ = io.Copy(w, body)
+}
+
+func cacheEntryBytes(entry *db.PublicCacheEntry) uint64 {
+	if entry == nil || entry.SizeBytes <= 0 {
+		return 0
+	}
+	return uint64FromInt64(entry.SizeBytes)
 }
 
 func (a *App) capturePublicCacheResponseBody(ctx context.Context, r *http.Request, resolution publicRouteResolution, decision *publicCacheDecision, resp *http.Response, trace *trafficRequestTrace) io.ReadCloser {
@@ -843,7 +1160,7 @@ func (r *publicCacheStoreReadCloser) commit() {
 			routeTargetID = sql.NullInt64{Int64: r.resolution.Target.ID, Valid: true}
 		}
 	}
-	_, err := r.app.DB.UpsertPublicCacheEntry(context.Background(), db.UpsertPublicCacheEntryParams{
+	entry, err := r.app.DB.UpsertPublicCacheEntry(context.Background(), db.UpsertPublicCacheEntryParams{
 		KeyDigest:           r.keyDigest,
 		RuleID:              r.rule.ID,
 		Scope:               r.rule.Scope,
@@ -863,10 +1180,12 @@ func (r *publicCacheStoreReadCloser) commit() {
 	})
 	if err != nil {
 		_ = os.Remove(r.finalPath)
+		r.app.PublicCache.deleteEntry(r.keyDigest)
 		r.markStoreFailed()
 		log.Warn().Err(err).Str("cache_key", r.keyDigest).Msg("Failed to store public cache entry")
 		return
 	}
+	r.app.PublicCache.putIndexEntry(entry)
 	if r.decision != nil {
 		r.decision.Status = publicCacheStatusStored
 		r.decision.KeyDigest = r.keyDigest
@@ -1471,6 +1790,9 @@ func (a *App) UpdatePublicCacheRule(ctx context.Context, req *connect.Request[p2
 	if err != nil {
 		return nil, publicDBError(err)
 	}
+	if err := a.purgePublicCacheEntriesByRuleID(ctx, req.Msg.Id); err != nil {
+		return nil, publicDBError(err)
+	}
 	if err := a.refreshPublicProxySnapshot(ctx); err != nil {
 		return nil, err
 	}
@@ -1485,6 +1807,9 @@ func (a *App) DeletePublicCacheRule(ctx context.Context, req *connect.Request[p2
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
+	if err := a.purgePublicCacheEntriesByRuleID(ctx, req.Msg.Id); err != nil {
+		return nil, publicDBError(err)
+	}
 	if err := a.DB.DeletePublicCacheRule(ctx, req.Msg.Id); err != nil {
 		return nil, publicDBError(err)
 	}
@@ -1492,6 +1817,21 @@ func (a *App) DeletePublicCacheRule(ctx context.Context, req *connect.Request[p2
 		return nil, err
 	}
 	return connect.NewResponse(&p2pstreamv1.DeletePublicCacheRuleResponse{}), nil
+}
+
+func (a *App) purgePublicCacheEntriesByRuleID(ctx context.Context, ruleID int64) error {
+	if a == nil || a.DB == nil || a.PublicCache == nil || ruleID <= 0 {
+		return nil
+	}
+	rows, err := a.DB.PurgePublicCacheEntriesByRule(ctx, ruleID)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		a.PublicCache.deleteEntry(row.KeyDigest)
+		_ = os.Remove(row.BodyPath)
+	}
+	return nil
 }
 
 func (a *App) UpdatePublicCacheSettings(ctx context.Context, req *connect.Request[p2pstreamv1.UpdatePublicCacheSettingsRequest]) (*connect.Response[p2pstreamv1.UpdatePublicCacheSettingsResponse], error) {
@@ -1529,7 +1869,7 @@ func (a *App) PurgePublicCache(ctx context.Context, req *connect.Request[p2pstre
 			return nil, publicDBError(err)
 		}
 		for _, row := range rows {
-			a.PublicCache.deleteMemory(row.KeyDigest)
+			a.PublicCache.deleteEntry(row.KeyDigest)
 			_ = os.Remove(row.BodyPath)
 			purgedEntries++
 			purgedBytes += row.SizeBytes
@@ -1540,7 +1880,7 @@ func (a *App) PurgePublicCache(ctx context.Context, req *connect.Request[p2pstre
 			return nil, publicDBError(err)
 		}
 		for _, row := range ruleRows {
-			a.PublicCache.deleteMemory(row.KeyDigest)
+			a.PublicCache.deleteEntry(row.KeyDigest)
 			_ = os.Remove(row.BodyPath)
 			purgedEntries++
 			purgedBytes += row.SizeBytes
@@ -1564,7 +1904,7 @@ func (a *App) PurgePublicCache(ctx context.Context, req *connect.Request[p2pstre
 			return nil, publicDBError(err)
 		}
 		for _, row := range hostRows {
-			a.PublicCache.deleteMemory(row.KeyDigest)
+			a.PublicCache.deleteEntry(row.KeyDigest)
 			_ = os.Remove(row.BodyPath)
 			purgedEntries++
 			purgedBytes += row.SizeBytes

--- a/internal/server/public_cache_test.go
+++ b/internal/server/public_cache_test.go
@@ -591,6 +591,136 @@ func TestPublicCacheDirectBackendMissStoresThenHit(t *testing.T) {
 	if originHits != 1 {
 		t.Fatalf("origin hits = %d, want 1", originHits)
 	}
+
+	if secondDecision.Entry == nil {
+		t.Fatal("second decision missing cache entry")
+	}
+	if err := app.DB.DeletePublicCacheEntry(context.Background(), secondDecision.Entry.KeyDigest); err != nil {
+		t.Fatalf("delete warmed cache DB row: %v", err)
+	}
+	if err := os.Remove(secondDecision.Entry.BodyPath); err != nil {
+		t.Fatalf("remove warmed cache body: %v", err)
+	}
+	thirdReq := httptest.NewRequest(http.MethodGet, "http://assets.example.test/assets/app.txt?v=1", nil)
+	thirdDecision := app.checkPublicCache(thirdReq, resolution)
+	if thirdDecision.Status != publicCacheStatusHit {
+		t.Fatalf("third warmed cache status = %q, want hit", thirdDecision.Status)
+	}
+	thirdRec := httptest.NewRecorder()
+	app.servePublicCacheHit(thirdRec, thirdReq, resolution, nil, nil, thirdDecision, proxyRequestObservability{})
+	if thirdRec.Code != http.StatusOK || thirdRec.Body.String() != "asset-v1" {
+		t.Fatalf("third warmed response = status %d body %q, want cached asset", thirdRec.Code, thirdRec.Body.String())
+	}
+}
+
+func TestPublicCacheStaleIndexedBodyFallsBackToMiss(t *testing.T) {
+	app, resolution, closeDB := newTestPublicCacheApp(t)
+	defer closeDB()
+
+	req := httptest.NewRequest(http.MethodGet, "http://assets.example.test/assets/stale.txt", nil)
+	app.proxyMu.Lock()
+	rule := app.publicSnapshot.CacheRules[0]
+	app.proxyMu.Unlock()
+	keyDigest := publicCacheKeyDigest(req, resolution, rule, "", nil)
+	bodyPath := app.PublicCache.bodyPath(keyDigest)
+	if err := os.MkdirAll(filepath.Dir(bodyPath), 0700); err != nil {
+		t.Fatalf("create cache body dir: %v", err)
+	}
+	if err := os.WriteFile(bodyPath, []byte("stale-body"), 0600); err != nil {
+		t.Fatalf("write cache body: %v", err)
+	}
+	if _, err := app.DB.UpsertPublicCacheEntry(context.Background(), db.UpsertPublicCacheEntryParams{
+		KeyDigest:           keyDigest,
+		RuleID:              resolution.CacheRuleID,
+		Scope:               publicCacheScopeSelectedBackend,
+		ListenerProtocol:    resolution.Listener.Protocol,
+		Host:                "assets.example.test",
+		Path:                "/assets/stale.txt",
+		QueryKey:            "",
+		RouteID:             sql.NullInt64{Int64: resolution.Route.ID, Valid: true},
+		RouteTargetID:       sql.NullInt64{Int64: resolution.Target.ID, Valid: true},
+		Method:              http.MethodGet,
+		VaryHeadersJson:     "[]",
+		ResponseHeadersJson: `{"Content-Type":["text/plain"]}`,
+		StatusCode:          http.StatusOK,
+		BodyPath:            bodyPath,
+		SizeBytes:           int64(len("stale-body")),
+		ExpiresAt:           time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("insert cache entry: %v", err)
+	}
+
+	firstDecision := app.checkPublicCache(req, resolution)
+	if firstDecision.Status != publicCacheStatusHit {
+		t.Fatalf("first cache status = %q, want hit", firstDecision.Status)
+	}
+	if err := os.Remove(bodyPath); err != nil {
+		t.Fatalf("remove cache body: %v", err)
+	}
+	secondDecision := app.checkPublicCache(req, resolution)
+	if secondDecision.Status != publicCacheStatusHit {
+		t.Fatalf("second indexed status = %q, want hit before body preparation", secondDecision.Status)
+	}
+	if ok := app.preparePublicCacheHitBody(req, &secondDecision); ok {
+		t.Fatal("prepare cache hit body succeeded after body file was removed")
+	}
+	thirdDecision := app.checkPublicCache(req, resolution)
+	if thirdDecision.Status != publicCacheStatusMiss {
+		t.Fatalf("third cache status = %q, want miss after stale entry invalidation", thirdDecision.Status)
+	}
+}
+
+func TestPublicCacheEmptyMissUsesWarmedIndex(t *testing.T) {
+	app, resolution, closeDB := newTestPublicCacheApp(t)
+	defer closeDB()
+
+	req := httptest.NewRequest(http.MethodGet, "http://assets.example.test/assets/later.txt", nil)
+	firstDecision := app.checkPublicCache(req, resolution)
+	if firstDecision.Status != publicCacheStatusMiss {
+		t.Fatalf("first cache status = %q, want miss", firstDecision.Status)
+	}
+	app.proxyMu.Lock()
+	rule := app.publicSnapshot.CacheRules[0]
+	app.proxyMu.Unlock()
+	keyDigest := publicCacheKeyDigest(req, resolution, rule, "", nil)
+	bodyPath := app.PublicCache.bodyPath(keyDigest)
+	if err := os.MkdirAll(filepath.Dir(bodyPath), 0700); err != nil {
+		t.Fatalf("create cache body dir: %v", err)
+	}
+	if err := os.WriteFile(bodyPath, []byte("later-body"), 0600); err != nil {
+		t.Fatalf("write cache body: %v", err)
+	}
+	entry, err := app.DB.UpsertPublicCacheEntry(context.Background(), db.UpsertPublicCacheEntryParams{
+		KeyDigest:           keyDigest,
+		RuleID:              resolution.CacheRuleID,
+		Scope:               publicCacheScopeSelectedBackend,
+		ListenerProtocol:    resolution.Listener.Protocol,
+		Host:                "assets.example.test",
+		Path:                "/assets/later.txt",
+		QueryKey:            "",
+		RouteID:             sql.NullInt64{Int64: resolution.Route.ID, Valid: true},
+		RouteTargetID:       sql.NullInt64{Int64: resolution.Target.ID, Valid: true},
+		Method:              http.MethodGet,
+		VaryHeadersJson:     "[]",
+		ResponseHeadersJson: `{"Content-Type":["text/plain"]}`,
+		StatusCode:          http.StatusOK,
+		BodyPath:            bodyPath,
+		SizeBytes:           int64(len("later-body")),
+		ExpiresAt:           time.Now().Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("insert cache entry: %v", err)
+	}
+
+	secondDecision := app.checkPublicCache(req, resolution)
+	if secondDecision.Status != publicCacheStatusMiss {
+		t.Fatalf("second warmed-empty cache status = %q, want miss", secondDecision.Status)
+	}
+	app.PublicCache.putIndexEntry(entry)
+	thirdDecision := app.checkPublicCache(req, resolution)
+	if thirdDecision.Status != publicCacheStatusHit {
+		t.Fatalf("third indexed cache status = %q, want hit", thirdDecision.Status)
+	}
 }
 
 func TestPublicCacheAgentBackendMissStoresThenHit(t *testing.T) {
@@ -740,7 +870,10 @@ func TestPublicCacheStoreReadCloserDoesNotRaceWithReconcile(t *testing.T) {
 			} else {
 				settings.MemoryHotObjectMaxBytes = defaultPublicCacheMemoryHotObjectBytes
 			}
-			app.PublicCache.reconcile(settings)
+			app.proxyMu.Lock()
+			rules := append([]publicCacheRuleConfig(nil), app.publicSnapshot.CacheRules...)
+			app.proxyMu.Unlock()
+			app.PublicCache.reconcile(settings, rules)
 		}
 	}()
 	defer func() {
@@ -886,7 +1019,7 @@ func newTestPublicCacheApp(t *testing.T) (*App, publicRouteResolution, func()) {
 		CacheRules:    []publicCacheRuleConfig{rule},
 		RouteTargets:  map[int64]publicRouteTargetConfig{resolution.Target.ID: resolution.Target},
 	})
-	app.PublicCache.reconcile(defaultPublicCacheSettings())
+	app.PublicCache.reconcile(defaultPublicCacheSettings(), []publicCacheRuleConfig{rule})
 
 	return app, resolution, func() { database.Close() }
 }

--- a/internal/server/public_cache_test.go
+++ b/internal/server/public_cache_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -723,6 +726,242 @@ func TestPublicCacheEmptyMissUsesWarmedIndex(t *testing.T) {
 	}
 }
 
+func TestPublicCacheNegativeLookupIndexIsBoundedAndExpires(t *testing.T) {
+	newCache := func(t *testing.T, maxEntries int64) (*publicProxyCache, uint64, string) {
+		t.Helper()
+		cache := newPublicProxyCache(t.TempDir())
+		settings := defaultPublicCacheSettings()
+		settings.MaxEntries = maxEntries
+		rules := []publicCacheRuleConfig{{ID: 1, Enabled: true, Fingerprint: "rule-v1"}}
+		fingerprint := publicCacheRuntimeFingerprint(settings, rules)
+		cache.reconcile(settings, rules)
+		generation, ok := cache.captureGeneration(fingerprint)
+		if !ok {
+			t.Fatal("cache generation was not current after reconcile")
+		}
+		return cache, generation, fingerprint
+	}
+
+	t.Run("configured max entries and ttl", func(t *testing.T) {
+		cache, generation, fingerprint := newCache(t, 3)
+		now := time.Unix(1_700_000_000, 0)
+		lookups := make([]publicCacheLookupKey, 5)
+		for i := range lookups {
+			lookups[i] = publicCacheLookupKey{
+				RuleID:           1,
+				ListenerProtocol: publicListenerProtocolHTTP,
+				Host:             "attacker.example",
+				Path:             "/uncached/" + strconv.Itoa(i),
+				QueryKey:         "nonce=" + strconv.Itoa(i),
+			}
+			cache.storeIndexedCandidates(lookups[i], nil, now, generation, fingerprint)
+		}
+
+		cache.mu.Lock()
+		negativeCount := len(cache.negativeLookups)
+		orderCount := cache.negativeOrder.Len()
+		cache.mu.Unlock()
+		if negativeCount != 3 || orderCount != 3 {
+			t.Fatalf("negative lookup cardinality = map %d/order %d, want 3/3", negativeCount, orderCount)
+		}
+		if _, loaded := cache.lookupIndexedCandidates(lookups[0], now, generation, fingerprint); loaded {
+			t.Fatal("oldest negative lookup was not evicted at MaxEntries")
+		}
+		if _, loaded := cache.lookupIndexedCandidates(lookups[len(lookups)-1], now, generation, fingerprint); !loaded {
+			t.Fatal("newest negative lookup was not cached")
+		}
+		if _, loaded := cache.lookupIndexedCandidates(lookups[len(lookups)-1], now.Add(publicCacheNegativeLookupTTL), generation, fingerprint); loaded {
+			t.Fatal("negative lookup remained loaded at its TTL boundary")
+		}
+	})
+
+	t.Run("hard safety cap", func(t *testing.T) {
+		cache, generation, fingerprint := newCache(t, defaultPublicCacheMaxEntries)
+		now := time.Unix(1_700_000_000, 0)
+		for i := 0; i < maxPublicCacheNegativeLookups+64; i++ {
+			cache.storeIndexedCandidates(publicCacheLookupKey{
+				RuleID:           1,
+				ListenerProtocol: publicListenerProtocolHTTP,
+				Host:             "attacker.example",
+				Path:             "/uncached/" + strconv.Itoa(i),
+			}, nil, now, generation, fingerprint)
+		}
+		cache.mu.Lock()
+		negativeCount := len(cache.negativeLookups)
+		cache.mu.Unlock()
+		if negativeCount != maxPublicCacheNegativeLookups {
+			t.Fatalf("negative lookup cardinality = %d, want hard cap %d", negativeCount, maxPublicCacheNegativeLookups)
+		}
+	})
+}
+
+func TestPublicCacheIndexMaintainsPositiveAndNegativeLookupConsistency(t *testing.T) {
+	cache := newPublicProxyCache(t.TempDir())
+	settings := defaultPublicCacheSettings()
+	settings.MaxEntries = 2
+	rules := []publicCacheRuleConfig{{ID: 1, Enabled: true, Fingerprint: "rule-v1"}}
+	fingerprint := publicCacheRuntimeFingerprint(settings, rules)
+	cache.reconcile(settings, rules)
+	generation, ok := cache.captureGeneration(fingerprint)
+	if !ok {
+		t.Fatal("cache generation was not current after reconcile")
+	}
+	now := time.Now()
+	lookupA := publicCacheLookupKey{RuleID: 1, ListenerProtocol: publicListenerProtocolHTTP, Host: "a.example", Path: "/asset"}
+	lookupB := publicCacheLookupKey{RuleID: 1, ListenerProtocol: publicListenerProtocolHTTP, Host: "b.example", Path: "/asset"}
+	lookupC := publicCacheLookupKey{RuleID: 1, ListenerProtocol: publicListenerProtocolHTTP, Host: "c.example", Path: "/asset"}
+	cache.storeIndexedCandidates(lookupA, nil, now, generation, fingerprint)
+	cache.storeIndexedCandidates(lookupB, nil, now, generation, fingerprint)
+
+	entry := db.PublicCacheEntry{
+		KeyDigest:        "digest",
+		RuleID:           lookupB.RuleID,
+		ListenerProtocol: lookupB.ListenerProtocol,
+		Host:             lookupB.Host,
+		Path:             lookupB.Path,
+		ExpiresAt:        now.Add(time.Hour),
+	}
+	cache.putIndexEntry(entry)
+	cache.mu.Lock()
+	if _, exists := cache.negativeLookups[publicCacheLookupKeyHash(lookupB)]; exists {
+		cache.mu.Unlock()
+		t.Fatal("positive insertion retained a contradictory negative lookup")
+	}
+	if got := len(cache.negativeLookups) + len(cache.indexEntries); got != 2 {
+		cache.mu.Unlock()
+		t.Fatalf("combined index cardinality = %d, want MaxEntries 2", got)
+	}
+	cache.mu.Unlock()
+
+	entry.Host = lookupC.Host
+	cache.putIndexEntry(entry)
+	cache.mu.Lock()
+	_, oldLookupPresent := cache.indexLookups[lookupB]
+	newDigests := cache.indexLookups[lookupC]
+	_, newDigestPresent := newDigests[entry.KeyDigest]
+	cache.mu.Unlock()
+	if oldLookupPresent || !newDigestPresent {
+		t.Fatalf("moved positive index consistency = old lookup %v/new digest %v, want false/true", oldLookupPresent, newDigestPresent)
+	}
+
+	cache.deleteEntry(entry.KeyDigest)
+	cache.mu.Lock()
+	_, entryPresent := cache.indexEntries[entry.KeyDigest]
+	_, lookupPresent := cache.indexLookups[lookupC]
+	cache.mu.Unlock()
+	if entryPresent || lookupPresent {
+		t.Fatalf("deleted positive index retained state = entry %v/lookup %v", entryPresent, lookupPresent)
+	}
+}
+
+func TestPublicCacheStaleConcurrentLookupLoadsCannotRepopulateAfterReconcile(t *testing.T) {
+	cache := newPublicProxyCache(t.TempDir())
+	settings := defaultPublicCacheSettings()
+	oldRules := []publicCacheRuleConfig{{ID: 1, Enabled: true, Fingerprint: "rule-v1"}}
+	oldFingerprint := publicCacheRuntimeFingerprint(settings, oldRules)
+	cache.reconcile(settings, oldRules)
+	oldGeneration, ok := cache.captureGeneration(oldFingerprint)
+	if !ok {
+		t.Fatal("old cache generation was not current after reconcile")
+	}
+	now := time.Now()
+	entry := db.PublicCacheEntry{
+		KeyDigest:        "stale-digest",
+		RuleID:           1,
+		ListenerProtocol: publicListenerProtocolHTTP,
+		Host:             "assets.example",
+		Path:             "/asset",
+		ExpiresAt:        now.Add(time.Hour),
+	}
+	lookup := publicCacheLookupKeyFromEntry(entry)
+
+	start := make(chan struct{})
+	var workers sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			<-start
+			for j := 0; j < 100; j++ {
+				cache.storeIndexedCandidates(lookup, []db.PublicCacheEntry{entry}, now, oldGeneration, oldFingerprint)
+			}
+		}()
+	}
+	workers.Add(1)
+	go func() {
+		defer workers.Done()
+		<-start
+		cache.reconcile(settings, []publicCacheRuleConfig{{ID: 1, Enabled: true, Fingerprint: "rule-v2"}})
+	}()
+	close(start)
+	workers.Wait()
+
+	cache.mu.Lock()
+	entryCount := len(cache.indexEntries)
+	lookupCount := len(cache.indexLookups)
+	negativeCount := len(cache.negativeLookups)
+	cache.mu.Unlock()
+	if entryCount != 0 || lookupCount != 0 || negativeCount != 0 {
+		t.Fatalf("stale lookup load repopulated index after reconcile: entries=%d lookups=%d negatives=%d", entryCount, lookupCount, negativeCount)
+	}
+}
+
+func TestPublicCacheInFlightOldRuleResponseIsDiscardedAfterReconcile(t *testing.T) {
+	app, resolution, closeDB := newTestPublicCacheApp(t)
+	defer closeDB()
+
+	req := httptest.NewRequest(http.MethodGet, "http://assets.example.test/assets/config-race.txt", nil)
+	decision := app.checkPublicCache(req, resolution)
+	if decision.Status != publicCacheStatusMiss {
+		t.Fatalf("cache status = %q, want miss", decision.Status)
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Cache-Control": []string{"max-age=300"},
+			"Content-Type":  []string{"text/plain"},
+			"Vary":          []string{"Accept-Encoding"},
+		},
+		Body: io.NopCloser(strings.NewReader("old-rule-body")),
+	}
+	body := app.capturePublicCacheResponseBody(context.Background(), req, resolution, &decision, resp, nil)
+	store, ok := body.(*publicCacheStoreReadCloser)
+	if !ok {
+		t.Fatalf("cache response body type = %T, want *publicCacheStoreReadCloser", body)
+	}
+
+	newRule := decision.Rule
+	newRule.Scope = publicCacheScopeRoute
+	newRule.TTL = 2 * time.Hour
+	newRule.VaryHeaders = []string{"Accept-Language"}
+	newRule.Fingerprint = publicCacheRuleFingerprint(newRule)
+	settings := defaultPublicCacheSettings()
+	newRules := []publicCacheRuleConfig{newRule}
+	newSnapshot := &publicProxySnapshot{
+		CacheSettings:    settings,
+		CacheRules:       newRules,
+		CacheFingerprint: publicCacheRuntimeFingerprint(settings, newRules),
+	}
+	setPublicSnapshotForTest(t, app, newSnapshot)
+	app.PublicCache.reconcile(settings, newRules)
+
+	if _, err := io.ReadAll(body); err != nil {
+		t.Fatalf("read old-rule response: %v", err)
+	}
+	if err := body.Close(); err != nil {
+		t.Fatalf("close old-rule response: %v", err)
+	}
+	if decision.Status != publicCacheStatusMiss {
+		t.Fatalf("stale response decision status = %q, want miss", decision.Status)
+	}
+	if _, err := app.DB.GetPublicCacheEntry(context.Background(), store.keyDigest); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("stale cache DB lookup error = %v, want sql.ErrNoRows", err)
+	}
+	if _, err := os.Stat(store.finalPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stale cache body stat error = %v, want os.ErrNotExist", err)
+	}
+}
+
 func TestPublicCacheAgentBackendMissStoresThenHit(t *testing.T) {
 	app, resolution, closeDB := newTestPublicCacheApp(t)
 	defer closeDB()
@@ -858,18 +1097,13 @@ func TestPublicCacheStoreReadCloserDoesNotRaceWithReconcile(t *testing.T) {
 	reconcileDone := make(chan struct{})
 	go func() {
 		defer close(reconcileDone)
-		for i := 0; ; i++ {
+		for {
 			select {
 			case <-stopReconcile:
 				return
 			default:
 			}
 			settings := defaultPublicCacheSettings()
-			if i%2 == 0 {
-				settings.MemoryHotObjectMaxBytes = 32
-			} else {
-				settings.MemoryHotObjectMaxBytes = defaultPublicCacheMemoryHotObjectBytes
-			}
 			app.proxyMu.Lock()
 			rules := append([]publicCacheRuleConfig(nil), app.publicSnapshot.CacheRules...)
 			app.proxyMu.Unlock()
@@ -1014,12 +1248,15 @@ func newTestPublicCacheApp(t *testing.T) (*App, publicRouteResolution, func()) {
 		CacheRuleID: rule.ID,
 	}
 	resolution.Route.Targets = []publicRouteTargetConfig{resolution.Target}
+	settings := defaultPublicCacheSettings()
+	rules := []publicCacheRuleConfig{rule}
 	setPublicSnapshotForTest(t, app, &publicProxySnapshot{
-		CacheSettings: defaultPublicCacheSettings(),
-		CacheRules:    []publicCacheRuleConfig{rule},
-		RouteTargets:  map[int64]publicRouteTargetConfig{resolution.Target.ID: resolution.Target},
+		CacheSettings:    settings,
+		CacheRules:       rules,
+		CacheFingerprint: publicCacheRuntimeFingerprint(settings, rules),
+		RouteTargets:     map[int64]publicRouteTargetConfig{resolution.Target.ID: resolution.Target},
 	})
-	app.PublicCache.reconcile(defaultPublicCacheSettings(), []publicCacheRuleConfig{rule})
+	app.PublicCache.reconcile(settings, rules)
 
 	return app, resolution, func() { database.Close() }
 }
@@ -1027,12 +1264,17 @@ func newTestPublicCacheApp(t *testing.T) (*App, publicRouteResolution, func()) {
 func setTestCacheRuleAllowCookieRequests(t *testing.T, app *App, allowed bool) {
 	t.Helper()
 	app.proxyMu.Lock()
-	defer app.proxyMu.Unlock()
 	if app.publicSnapshot == nil || len(app.publicSnapshot.CacheRules) == 0 {
+		app.proxyMu.Unlock()
 		t.Fatal("test cache snapshot missing rule")
 	}
 	app.publicSnapshot.CacheRules[0].AllowCookieRequests = allowed
 	app.publicSnapshot.CacheRules[0].Fingerprint = publicCacheRuleFingerprint(app.publicSnapshot.CacheRules[0])
+	settings := app.publicSnapshot.CacheSettings
+	rules := append([]publicCacheRuleConfig(nil), app.publicSnapshot.CacheRules...)
+	app.publicSnapshot.CacheFingerprint = publicCacheRuntimeFingerprint(settings, rules)
+	app.proxyMu.Unlock()
+	app.PublicCache.reconcile(settings, rules)
 }
 
 func createTestAdminSession(t *testing.T, app *App) http.Header {

--- a/internal/server/public_config_loader.go
+++ b/internal/server/public_config_loader.go
@@ -81,7 +81,7 @@ func (a *App) applyPublicProxySnapshot(snap *publicProxySnapshot) {
 		a.PublicWAF.reconcile(snap)
 	}
 	if a.PublicCache != nil {
-		a.PublicCache.reconcile(snap.CacheSettings)
+		a.PublicCache.reconcile(snap.CacheSettings, snap.CacheRules)
 	}
 }
 

--- a/internal/server/public_config_loader.go
+++ b/internal/server/public_config_loader.go
@@ -420,6 +420,7 @@ func snapshotFromPublicRows(rows publicConfigRows) (*publicProxySnapshot, error)
 		snap.CacheRules = append(snap.CacheRules, rule)
 	}
 	sortPublicCacheRules(snap.CacheRules)
+	snap.CacheFingerprint = publicCacheRuntimeFingerprint(snap.CacheSettings, snap.CacheRules)
 	return snap, nil
 }
 

--- a/internal/server/public_proxy_pipeline.go
+++ b/internal/server/public_proxy_pipeline.go
@@ -559,6 +559,11 @@ func cacheLookupStage(ctx *publicProxyContext) publicProxyStageResult {
 		return publicProxyStageContinue
 	}
 	decision := ctx.App.checkPublicCacheWithSnapshot(ctx.Snapshot, ctx.Request, ctx.Resolution)
+	if decision.Status == publicCacheStatusHit && !ctx.App.preparePublicCacheHitBody(ctx.Request, &decision) {
+		decision.Status = publicCacheStatusMiss
+		decision.Entry = nil
+		decision.HitBody = nil
+	}
 	applyCacheResolutionFields(&ctx.Resolution, decision)
 	if ctx.Trace != nil {
 		ctx.Trace.emit(

--- a/internal/server/public_routing.go
+++ b/internal/server/public_routing.go
@@ -177,6 +177,7 @@ type publicProxySnapshot struct {
 	WafCookieSecret     []byte
 	CacheSettings       publicCacheSettingsConfig
 	CacheRules          []publicCacheRuleConfig
+	CacheFingerprint    string
 	ResponseTemplates   map[int64]publicResponseTemplateConfig
 }
 


### PR DESCRIPTION
## Summary
- add an in-memory public cache metadata index keyed by lookup dimensions and cache digest
- warm the index from SQLite on cold lookups, update it on stores, and invalidate it on purge/cleanup/rule changes
- remove lookup-time body stat and synchronous per-hit cache touch writes; stale bodies are opened before response commit and fall back to miss

Stacked on #130. Closes #116.

## Tests
- go test ./internal/server -run "TestPublicCache(DirectBackendMissStoresThenHit|StaleIndexedBodyFallsBackToMiss|EmptyMissUsesWarmedIndex|AgentBackendMissStoresThenHit|HeadServedFromCachedGet|StoreReadCloserDoesNotRaceWithReconcile)" -count=1
- go test ./internal/server -count=1
- go test ./... -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved public cache lookups with faster in-memory indexing.
  - Reduced repeated database scans for cache hits and misses.
  - Added bounded, expiring tracking for repeated cache misses.

- **Bug Fixes**
  - Prevented stale or missing cache files from being served as valid hits.
  - Improved cache consistency when settings or rules change.
  - Ensured cache updates and purges immediately reflect current results.
  - Improved reliability during concurrent cache configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->