### PR TITLE
perf: pool reverse proxy copy buffers

### DIFF
--- a/internal/server/app_services.go
+++ b/internal/server/app_services.go
@@ -1,6 +1,10 @@
 package server
 
-import "p2pstream/internal/config"
+import (
+	"net/http/httputil"
+
+	"p2pstream/internal/config"
+)
 
 type appServices struct {
 	agentHub        *agentHub
@@ -17,6 +21,7 @@ type appServices struct {
 	observability   *observabilityRecorder
 	auth            *authService
 	agentTransports *agentTransportPool
+	reverseProxyBuf httputil.BufferPool
 	dashboardCache  *dashboardResponseCache
 	loginThrottle   *loginThrottle
 	agentAuthLocks  *agentAuthLockMap
@@ -33,6 +38,7 @@ func newAppServices(cfg *config.Config, app *App) appServices {
 		publicWAF:       newPublicWAF(),
 		publicCache:     newPublicProxyCache(cfg.PublicCacheDir),
 		agentTransports: newAgentTransportPool(),
+		reverseProxyBuf: newReverseProxyBufferPool(),
 		dashboardCache:  newDashboardResponseCache(),
 		loginThrottle:   newLoginThrottle(cfg.LoginThrottleMaxKeys),
 		agentAuthLocks:  newAgentAuthLockMap(),
@@ -65,6 +71,7 @@ func (a *App) applyServices(services appServices) {
 	a.observabilityRecorder = services.observability
 	a.auth = services.auth
 	a.AgentTransports = services.agentTransports
+	a.reverseProxyBuffers = services.reverseProxyBuf
 	a.DashboardCache = services.dashboardCache
 	a.LoginThrottle = services.loginThrottle
 	a.agentAuthLocks = services.agentAuthLocks

--- a/internal/server/public_routing.go
+++ b/internal/server/public_routing.go
@@ -605,7 +605,8 @@ func (a *App) proxyRouteTargetRequest(w http.ResponseWriter, r *http.Request, re
 				http.Error(w, "Bad Gateway", http.StatusBadGateway)
 			}
 		},
-		Transport: transport,
+		Transport:  transport,
+		BufferPool: a.reverseProxyBufferPool(),
 	}
 	proxy.ServeHTTP(w, r)
 }

--- a/internal/server/public_routing_test.go
+++ b/internal/server/public_routing_test.go
@@ -138,6 +138,59 @@ func TestApplyTrustedForwardedHeadersCanonicalizesHostAndPort(t *testing.T) {
 	}
 }
 
+func TestProxyRouteTargetRequestUsesAppReverseProxyBufferPool(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("proxied"))
+	}))
+	defer upstream.Close()
+
+	origin, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+	pool := &countingReverseProxyBufferPool{}
+	app := NewApp(nil, nil)
+	app.reverseProxyBuffers = pool
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://public.test/app", nil)
+
+	app.proxyDirectTargetRequest(rec, req, publicRouteResolution{
+		Listener: publicListenerConfig{Protocol: publicListenerProtocolHTTP},
+		Target: publicRouteTargetConfig{
+			ID:         20,
+			Name:       "buffered",
+			Enabled:    true,
+			TargetType: publicRouteTargetTypeProxy,
+			Transport:  publicRouteTargetTransportDirect,
+			ParsedURL:  origin,
+		},
+	}, nil, nil, nil, proxyRequestObservability{})
+
+	if rec.Code != http.StatusOK || rec.Body.String() != "proxied" {
+		t.Fatalf("response = status %d body %q, want 200 proxied", rec.Code, rec.Body.String())
+	}
+	if got := pool.gets.Load(); got == 0 {
+		t.Fatal("reverse proxy did not get a copy buffer from the app pool")
+	}
+	if got := pool.puts.Load(); got == 0 {
+		t.Fatal("reverse proxy did not return a copy buffer to the app pool")
+	}
+}
+
+type countingReverseProxyBufferPool struct {
+	gets atomic.Int64
+	puts atomic.Int64
+}
+
+func (p *countingReverseProxyBufferPool) Get() []byte {
+	p.gets.Add(1)
+	return make([]byte, reverseProxyCopyBufferSize)
+}
+
+func (p *countingReverseProxyBufferPool) Put([]byte) {
+	p.puts.Add(1)
+}
+
 func TestPublicProxyForwardsCanonicalHostAndConfiguredPort(t *testing.T) {
 	handler, captured := newTestForwardedHeaderProxy(t, publicListenerProtocolHTTP, 8080)
 	req := httptest.NewRequest(http.MethodGet, "http://app.example.:444/assets/app.txt", nil)

--- a/internal/server/reverse_proxy_buffer_pool.go
+++ b/internal/server/reverse_proxy_buffer_pool.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"net/http/httputil"
+	"sync"
+)
+
+const reverseProxyCopyBufferSize = 32 * 1024
+
+type reverseProxyCopyBuffer [reverseProxyCopyBufferSize]byte
+
+type reverseProxyBufferPool struct {
+	pool sync.Pool
+}
+
+func newReverseProxyBufferPool() *reverseProxyBufferPool {
+	return &reverseProxyBufferPool{
+		pool: sync.Pool{
+			New: func() any {
+				return new(reverseProxyCopyBuffer)
+			},
+		},
+	}
+}
+
+func (p *reverseProxyBufferPool) Get() []byte {
+	if p == nil {
+		return make([]byte, reverseProxyCopyBufferSize)
+	}
+	buf, _ := p.pool.Get().(*reverseProxyCopyBuffer)
+	if buf == nil {
+		return make([]byte, reverseProxyCopyBufferSize)
+	}
+	return buf[:]
+}
+
+func (p *reverseProxyBufferPool) Put(b []byte) {
+	if p == nil || cap(b) != reverseProxyCopyBufferSize {
+		return
+	}
+	b = b[:reverseProxyCopyBufferSize]
+	p.pool.Put((*reverseProxyCopyBuffer)(b))
+}
+
+var defaultReverseProxyBufferPool httputil.BufferPool = newReverseProxyBufferPool()
+
+func (a *App) reverseProxyBufferPool() httputil.BufferPool {
+	if a != nil && a.reverseProxyBuffers != nil {
+		return a.reverseProxyBuffers
+	}
+	return defaultReverseProxyBufferPool
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"net/http"
+	"net/http/httputil"
 	"strconv"
 	"strings"
 	"sync"
@@ -58,6 +59,7 @@ type App struct {
 	observabilityRecorder *observabilityRecorder
 	auth                  *authService
 	AgentTransports       *agentTransportPool
+	reverseProxyBuffers   httputil.BufferPool
 	DashboardCache        *dashboardResponseCache
 	LoginThrottle         *loginThrottle
 	agentAuthLocks        *agentAuthLockMap


### PR DESCRIPTION
## Summary
- add an app-scoped sync.Pool-backed httputil.BufferPool for 32 KiB reverse proxy copy buffers
- attach the pool to the public target ReverseProxy path used by direct and agent targets
- add a regression test that observes BufferPool Get/Put during a proxied response

## Tests
- go test ./internal/server -run TestProxyRouteTargetRequestUsesAppReverseProxyBufferPool -count=1
- go test ./internal/server -count=1
- go test ./... -count=1

Stacked on #131. Closes #117.