### PR TITLE
fix: rotate public TLS certificates hitlessly

### DIFF
--- a/internal/server/proxy_lifecycle.go
+++ b/internal/server/proxy_lifecycle.go
@@ -160,8 +160,8 @@ func shutdownPublicHTTPServer(ctx context.Context, srv *http.Server, timeout tim
 	if err == nil {
 		return nil
 	}
-	if errors.Is(err, context.DeadlineExceeded) {
-		log.Warn().Dur("timeout", timeout).Msg("Public listener graceful shutdown timed out; forcing close")
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		log.Warn().Err(err).Dur("timeout", timeout).Msg("Public listener graceful shutdown interrupted; forcing close")
 		if closeErr := srv.Close(); closeErr != nil {
 			return errors.Join(err, closeErr)
 		}
@@ -177,24 +177,28 @@ func publicListenerShutdownContext(ctx context.Context, timeout time.Duration) (
 	if timeout <= 0 {
 		return context.WithCancel(ctx)
 	}
-	if _, ok := ctx.Deadline(); ok {
-		return context.WithCancel(ctx)
-	}
 	return context.WithTimeout(ctx, timeout)
 }
 
 type publicTLSSelectorRefresh struct {
 	listenerID   int64
 	listenerName string
+	generation   uint64
+	snapshot     *publicProxySnapshot
+	server       *http.Server
 	selector     *publicTLSSelectorStore
 }
 
-func (a *App) refreshRunningPublicTLSSelectors(snap *publicProxySnapshot) {
+func (a *App) refreshRunningPublicTLSSelectors(snap *publicProxySnapshot, generation uint64) {
 	if a == nil || snap == nil {
 		return
 	}
 	updates := make([]publicTLSSelectorRefresh, 0)
 	a.proxyMu.Lock()
+	if a.publicSnapshot != snap || a.publicSnapshotGeneration != generation {
+		a.proxyMu.Unlock()
+		return
+	}
 	for listenerID, listener := range snap.Listeners {
 		if listener.Protocol != publicListenerProtocolHTTPS {
 			continue
@@ -206,13 +210,20 @@ func (a *App) refreshRunningPublicTLSSelectors(snap *publicProxySnapshot) {
 		updates = append(updates, publicTLSSelectorRefresh{
 			listenerID:   listenerID,
 			listenerName: listener.Name,
+			generation:   generation,
+			snapshot:     snap,
+			server:       runtime.Server,
 			selector:     runtime.TLSSelector,
 		})
 	}
 	a.proxyMu.Unlock()
 
 	for _, update := range updates {
-		if err := update.selector.refresh(update.listenerID, snap, a.PublicACME); err != nil {
+		selector, err := update.selector.buildRefresh(update.listenerID, snap, a.PublicACME)
+		if hook := a.publicTLSSelectorRefreshBeforePublish; hook != nil {
+			hook(update.generation)
+		}
+		if err != nil {
 			log.Warn().
 				Err(err).
 				Int64("listener_id", update.listenerID).
@@ -221,29 +232,44 @@ func (a *App) refreshRunningPublicTLSSelectors(snap *publicProxySnapshot) {
 			a.markPublicTLSSelectorRefreshError(update, err)
 			continue
 		}
-		a.markPublicTLSSelectorRefreshSuccess(update)
+		a.publishPublicTLSSelectorRefresh(update, selector)
 	}
+}
+
+func (a *App) publicTLSSelectorRefreshCurrentLocked(update publicTLSSelectorRefresh) (*publicListenerRuntime, bool) {
+	if a.publicSnapshot != update.snapshot || a.publicSnapshotGeneration != update.generation {
+		return nil, false
+	}
+	runtime := a.publicListenerState[update.listenerID]
+	if runtime == nil || runtime.Server != update.server || runtime.TLSSelector != update.selector || runtime.Server == nil || runtime.State == p2pstreamv1.ProxyState_PROXY_STATE_STOPPING {
+		return nil, false
+	}
+	return runtime, true
 }
 
 func (a *App) markPublicTLSSelectorRefreshError(update publicTLSSelectorRefresh, err error) {
 	a.proxyMu.Lock()
 	defer a.proxyMu.Unlock()
-	runtime := a.publicListenerState[update.listenerID]
-	if runtime == nil || runtime.TLSSelector != update.selector || runtime.Server == nil || runtime.State == p2pstreamv1.ProxyState_PROXY_STATE_STOPPING {
+	runtime, ok := a.publicTLSSelectorRefreshCurrentLocked(update)
+	if !ok {
 		return
 	}
-	runtime.State = p2pstreamv1.ProxyState_PROXY_STATE_ERROR
+	// The listener is still serving with its last known-good selector. Keep it
+	// addressable so a retry cannot orphan the live server by starting a second
+	// listener on the same address.
+	runtime.State = p2pstreamv1.ProxyState_PROXY_STATE_RUNNING
 	runtime.LastError = "refresh TLS certificates: " + err.Error()
 	a.proxyStatusLocked()
 }
 
-func (a *App) markPublicTLSSelectorRefreshSuccess(update publicTLSSelectorRefresh) {
+func (a *App) publishPublicTLSSelectorRefresh(update publicTLSSelectorRefresh, selector *publicTLSSelector) {
 	a.proxyMu.Lock()
 	defer a.proxyMu.Unlock()
-	runtime := a.publicListenerState[update.listenerID]
-	if runtime == nil || runtime.TLSSelector != update.selector || runtime.Server == nil || runtime.State == p2pstreamv1.ProxyState_PROXY_STATE_STOPPING {
+	runtime, ok := a.publicTLSSelectorRefreshCurrentLocked(update)
+	if !ok {
 		return
 	}
+	update.selector.publish(selector)
 	runtime.State = p2pstreamv1.ProxyState_PROXY_STATE_RUNNING
 	runtime.LastError = ""
 	a.proxyStatusLocked()
@@ -279,7 +305,7 @@ func (a *App) startPublicListenerRuntime(ctx context.Context, listenerID int64, 
 		a.proxyMu.Unlock()
 		return status, connect.NewError(connect.CodeFailedPrecondition, errors.New("listener is disabled"))
 	}
-	if runtime.Server != nil && runtime.State == p2pstreamv1.ProxyState_PROXY_STATE_RUNNING {
+	if runtime.Server != nil {
 		status := a.publicListenerStatusLocked(listenerID)
 		a.proxyStatusLocked()
 		a.proxyMu.Unlock()

--- a/internal/server/proxy_lifecycle.go
+++ b/internal/server/proxy_lifecycle.go
@@ -16,12 +16,14 @@ import (
 )
 
 const (
-	publicListenerProtocolHTTP  = "http"
-	publicListenerProtocolHTTPS = "https"
+	publicListenerProtocolHTTP    = "http"
+	publicListenerProtocolHTTPS   = "https"
+	publicListenerShutdownTimeout = 10 * time.Second
 )
 
 type publicListenerRuntime struct {
 	Server       *http.Server
+	TLSSelector  *publicTLSSelectorStore
 	State        p2pstreamv1.ProxyState
 	LastError    string
 	StartedAt    time.Time
@@ -111,13 +113,14 @@ func (a *App) stopProxy(ctx context.Context) (*p2pstreamv1.ProxyStatus, error) {
 
 	var shutdownErr error
 	for _, stop := range stops {
-		err := stop.Server.Shutdown(ctx)
+		err := shutdownPublicHTTPServer(ctx, stop.Server, publicListenerShutdownTimeout)
 		if err != nil {
 			shutdownErr = errors.Join(shutdownErr, err)
 		}
 		a.proxyMu.Lock()
 		if runtime := a.publicListenerState[stop.ID]; runtime != nil && runtime.Server == stop.Server {
 			runtime.Server = nil
+			runtime.TLSSelector = nil
 			runtime.StoppedAt = time.Now()
 			if err != nil {
 				runtime.State = p2pstreamv1.ProxyState_PROXY_STATE_ERROR
@@ -145,6 +148,105 @@ func (a *App) stopProxy(ctx context.Context) (*p2pstreamv1.ProxyStatus, error) {
 type publicListenerStop struct {
 	ID     int64
 	Server *http.Server
+}
+
+func shutdownPublicHTTPServer(ctx context.Context, srv *http.Server, timeout time.Duration) error {
+	if srv == nil {
+		return nil
+	}
+	shutdownCtx, cancel := publicListenerShutdownContext(ctx, timeout)
+	defer cancel()
+	err := srv.Shutdown(shutdownCtx)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		log.Warn().Dur("timeout", timeout).Msg("Public listener graceful shutdown timed out; forcing close")
+		if closeErr := srv.Close(); closeErr != nil {
+			return errors.Join(err, closeErr)
+		}
+		return nil
+	}
+	return err
+}
+
+func publicListenerShutdownContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if timeout <= 0 {
+		return context.WithCancel(ctx)
+	}
+	if _, ok := ctx.Deadline(); ok {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
+type publicTLSSelectorRefresh struct {
+	listenerID   int64
+	listenerName string
+	selector     *publicTLSSelectorStore
+}
+
+func (a *App) refreshRunningPublicTLSSelectors(snap *publicProxySnapshot) {
+	if a == nil || snap == nil {
+		return
+	}
+	updates := make([]publicTLSSelectorRefresh, 0)
+	a.proxyMu.Lock()
+	for listenerID, listener := range snap.Listeners {
+		if listener.Protocol != publicListenerProtocolHTTPS {
+			continue
+		}
+		runtime := a.publicListenerState[listenerID]
+		if runtime == nil || runtime.Server == nil || runtime.TLSSelector == nil || runtime.State == p2pstreamv1.ProxyState_PROXY_STATE_STOPPING {
+			continue
+		}
+		updates = append(updates, publicTLSSelectorRefresh{
+			listenerID:   listenerID,
+			listenerName: listener.Name,
+			selector:     runtime.TLSSelector,
+		})
+	}
+	a.proxyMu.Unlock()
+
+	for _, update := range updates {
+		if err := update.selector.refresh(update.listenerID, snap, a.PublicACME); err != nil {
+			log.Warn().
+				Err(err).
+				Int64("listener_id", update.listenerID).
+				Str("listener", update.listenerName).
+				Msg("Failed to refresh public TLS certificate selector")
+			a.markPublicTLSSelectorRefreshError(update, err)
+			continue
+		}
+		a.markPublicTLSSelectorRefreshSuccess(update)
+	}
+}
+
+func (a *App) markPublicTLSSelectorRefreshError(update publicTLSSelectorRefresh, err error) {
+	a.proxyMu.Lock()
+	defer a.proxyMu.Unlock()
+	runtime := a.publicListenerState[update.listenerID]
+	if runtime == nil || runtime.TLSSelector != update.selector || runtime.Server == nil || runtime.State == p2pstreamv1.ProxyState_PROXY_STATE_STOPPING {
+		return
+	}
+	runtime.State = p2pstreamv1.ProxyState_PROXY_STATE_ERROR
+	runtime.LastError = "refresh TLS certificates: " + err.Error()
+	a.proxyStatusLocked()
+}
+
+func (a *App) markPublicTLSSelectorRefreshSuccess(update publicTLSSelectorRefresh) {
+	a.proxyMu.Lock()
+	defer a.proxyMu.Unlock()
+	runtime := a.publicListenerState[update.listenerID]
+	if runtime == nil || runtime.TLSSelector != update.selector || runtime.Server == nil || runtime.State == p2pstreamv1.ProxyState_PROXY_STATE_STOPPING {
+		return
+	}
+	runtime.State = p2pstreamv1.ProxyState_PROXY_STATE_RUNNING
+	runtime.LastError = ""
+	a.proxyStatusLocked()
 }
 
 func (a *App) startPublicListenerRuntime(ctx context.Context, listenerID int64, activateService bool) (*p2pstreamv1.PublicListenerStatus, error) {
@@ -200,12 +302,14 @@ func (a *App) startPublicListenerFromSnapshot(listener publicListenerConfig, sna
 
 	var srv *http.Server
 	var serve func(net.Listener) error
+	var tlsSelector *publicTLSSelectorStore
 	if listener.Protocol == publicListenerProtocolHTTPS {
-		tlsConfig, err := newPublicTLSConfig(listener.ID, snap, a.PublicACME)
+		tlsConfig, selector, err := newPublicTLSConfigWithSelectorStore(listener.ID, snap, a.PublicACME)
 		if err != nil {
 			a.setPublicListenerError(listener.ID, err)
 			return a.getPublicListenerStatus(listener.ID), nil
 		}
+		tlsSelector = selector
 		srv = &http.Server{Addr: addr, Handler: mux, TLSConfig: tlsConfig}
 		configurePublicHTTPServer(srv)
 		serve = func(ln net.Listener) error {
@@ -227,6 +331,7 @@ func (a *App) startPublicListenerFromSnapshot(listener publicListenerConfig, sna
 	a.proxyMu.Lock()
 	runtime := a.ensureListenerStateLocked(listener.ID)
 	runtime.Server = srv
+	runtime.TLSSelector = tlsSelector
 	runtime.State = p2pstreamv1.ProxyState_PROXY_STATE_RUNNING
 	runtime.LastError = ""
 	runtime.StartedAt = time.Now()
@@ -248,6 +353,7 @@ func (a *App) startPublicListenerFromSnapshot(listener publicListenerConfig, sna
 			a.proxyMu.Lock()
 			if runtime := a.publicListenerState[listener.ID]; runtime != nil && runtime.Server == srv {
 				runtime.Server = nil
+				runtime.TLSSelector = nil
 				runtime.State = p2pstreamv1.ProxyState_PROXY_STATE_ERROR
 				runtime.LastError = errMsg
 				runtime.StoppedAt = time.Now()
@@ -271,6 +377,7 @@ func (a *App) stopPublicListenerRuntime(ctx context.Context, listenerID int64) (
 	}
 	runtime := a.ensureListenerStateLocked(listenerID)
 	if runtime.Server == nil {
+		runtime.TLSSelector = nil
 		runtime.State = p2pstreamv1.ProxyState_PROXY_STATE_STOPPED
 		status := a.publicListenerStatusLocked(listenerID)
 		a.proxyStatusLocked()
@@ -282,12 +389,13 @@ func (a *App) stopPublicListenerRuntime(ctx context.Context, listenerID int64) (
 	a.proxyStatusLocked()
 	a.proxyMu.Unlock()
 
-	err := srv.Shutdown(ctx)
+	err := shutdownPublicHTTPServer(ctx, srv, publicListenerShutdownTimeout)
 
 	a.proxyMu.Lock()
 	runtime = a.ensureListenerStateLocked(listenerID)
 	if runtime.Server == srv {
 		runtime.Server = nil
+		runtime.TLSSelector = nil
 		runtime.StoppedAt = time.Now()
 		if err != nil {
 			runtime.State = p2pstreamv1.ProxyState_PROXY_STATE_ERROR
@@ -318,6 +426,7 @@ func (a *App) setPublicListenerError(listenerID int64, err error) {
 	a.proxyMu.Lock()
 	runtime := a.ensureListenerStateLocked(listenerID)
 	runtime.Server = nil
+	runtime.TLSSelector = nil
 	runtime.State = p2pstreamv1.ProxyState_PROXY_STATE_ERROR
 	runtime.LastError = err.Error()
 	runtime.StoppedAt = time.Now()

--- a/internal/server/proxy_lifecycle_test.go
+++ b/internal/server/proxy_lifecycle_test.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestShutdownPublicHTTPServerForcesCloseAfterTimeout(t *testing.T) {
+	requestStarted := make(chan struct{})
+	handlerDone := make(chan struct{})
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		_, _ = w.Write([]byte("started"))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-r.Context().Done()
+		close(handlerDone)
+	})}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	serveErr := make(chan error, 1)
+	go func() {
+		err := server.Serve(listener)
+		if err == http.ErrServerClosed {
+			err = nil
+		}
+		serveErr <- err
+	}()
+
+	resp, err := http.Get("http://" + listener.Addr().String())
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for active request")
+	}
+
+	started := time.Now()
+	if err := shutdownPublicHTTPServer(context.Background(), server, 25*time.Millisecond); err != nil {
+		t.Fatalf("shutdownPublicHTTPServer() error = %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("shutdown took %s, want forced close within one second", elapsed)
+	}
+	select {
+	case <-handlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("handler was not closed after shutdown timeout")
+	}
+	select {
+	case err := <-serveErr:
+		if err != nil {
+			t.Fatalf("Serve() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Serve to exit")
+	}
+}

--- a/internal/server/proxy_lifecycle_test.go
+++ b/internal/server/proxy_lifecycle_test.go
@@ -9,6 +9,63 @@ import (
 )
 
 func TestShutdownPublicHTTPServerForcesCloseAfterTimeout(t *testing.T) {
+	server, handlerDone, serveErr := startBlockingPublicHTTPServer(t)
+
+	started := time.Now()
+	if err := shutdownPublicHTTPServer(context.Background(), server, 25*time.Millisecond); err != nil {
+		t.Fatalf("shutdownPublicHTTPServer() error = %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("shutdown took %s, want forced close within one second", elapsed)
+	}
+	assertBlockingPublicHTTPServerClosed(t, handlerDone, serveErr)
+}
+
+func TestShutdownPublicHTTPServerForcesCloseWhenParentCanceled(t *testing.T) {
+	server, handlerDone, serveErr := startBlockingPublicHTTPServer(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := shutdownPublicHTTPServer(ctx, server, time.Hour); err != nil {
+		t.Fatalf("shutdownPublicHTTPServer() error = %v", err)
+	}
+	assertBlockingPublicHTTPServerClosed(t, handlerDone, serveErr)
+}
+
+func TestPublicListenerShutdownContextUsesEarlierDeadline(t *testing.T) {
+	t.Run("configured timeout is earlier", func(t *testing.T) {
+		parent, cancelParent := context.WithTimeout(context.Background(), time.Hour)
+		defer cancelParent()
+		started := time.Now()
+		ctx, cancel := publicListenerShutdownContext(parent, 50*time.Millisecond)
+		defer cancel()
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("shutdown context has no deadline")
+		}
+		if remaining := deadline.Sub(started); remaining < 25*time.Millisecond || remaining > 250*time.Millisecond {
+			t.Fatalf("configured shutdown deadline remaining = %s, want about 50ms", remaining)
+		}
+	})
+
+	t.Run("parent deadline is earlier", func(t *testing.T) {
+		parentDeadline := time.Now().Add(50 * time.Millisecond)
+		parent, cancelParent := context.WithDeadline(context.Background(), parentDeadline)
+		defer cancelParent()
+		ctx, cancel := publicListenerShutdownContext(parent, time.Hour)
+		defer cancel()
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("shutdown context has no deadline")
+		}
+		if !deadline.Equal(parentDeadline) {
+			t.Fatalf("shutdown deadline = %s, want parent deadline %s", deadline, parentDeadline)
+		}
+	})
+}
+
+func startBlockingPublicHTTPServer(t *testing.T) (*http.Server, <-chan struct{}, <-chan error) {
+	t.Helper()
 	requestStarted := make(chan struct{})
 	handlerDone := make(chan struct{})
 	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -24,6 +81,7 @@ func TestShutdownPublicHTTPServerForcesCloseAfterTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
+	t.Cleanup(func() { _ = listener.Close() })
 	serveErr := make(chan error, 1)
 	go func() {
 		err := server.Serve(listener)
@@ -37,20 +95,17 @@ func TestShutdownPublicHTTPServerForcesCloseAfterTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
-	defer resp.Body.Close()
+	t.Cleanup(func() { _ = resp.Body.Close() })
 	select {
 	case <-requestStarted:
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for active request")
 	}
+	return server, handlerDone, serveErr
+}
 
-	started := time.Now()
-	if err := shutdownPublicHTTPServer(context.Background(), server, 25*time.Millisecond); err != nil {
-		t.Fatalf("shutdownPublicHTTPServer() error = %v", err)
-	}
-	if elapsed := time.Since(started); elapsed > time.Second {
-		t.Fatalf("shutdown took %s, want forced close within one second", elapsed)
-	}
+func assertBlockingPublicHTTPServerClosed(t *testing.T, handlerDone <-chan struct{}, serveErr <-chan error) {
+	t.Helper()
 	select {
 	case <-handlerDone:
 	case <-time.After(time.Second):

--- a/internal/server/public_acme.go
+++ b/internal/server/public_acme.go
@@ -502,7 +502,6 @@ func (m *publicACMEManager) issueCertificate(ctx context.Context, certID int64, 
 			Time("attempt_at", attemptAt).
 			Msg("Failed to refresh public proxy after ACME issue")
 	}
-	_, _ = m.app.restartTLSListenerIfActive(ctx, updated.ListenerID)
 }
 
 func (m *publicACMEManager) beginIssue(certID int64) bool {

--- a/internal/server/public_config_loader.go
+++ b/internal/server/public_config_loader.go
@@ -67,6 +67,7 @@ func (a *App) applyPublicProxySnapshot(snap *publicProxySnapshot) {
 	a.proxyStatusLocked()
 	active := a.proxyServiceActive
 	a.proxyMu.Unlock()
+	a.refreshRunningPublicTLSSelectors(snap)
 	a.LoadBalancers.reconcile(snap)
 	if a.TargetHealth != nil {
 		a.TargetHealth.reconcile(a, snap, active)
@@ -444,15 +445,4 @@ func (a *App) reconcilePublicListenerAfterMutation(ctx context.Context, listener
 		return a.restartPublicListenerRuntime(ctx, listenerID)
 	}
 	return a.getPublicListenerStatus(listenerID), nil
-}
-
-func (a *App) restartTLSListenerIfActive(ctx context.Context, listenerID int64) (*p2pstreamv1.PublicListenerStatus, error) {
-	a.proxyMu.Lock()
-	runtime := a.publicListenerState[listenerID]
-	running := runtime != nil && runtime.Server != nil
-	a.proxyMu.Unlock()
-	if !running {
-		return a.getPublicListenerStatus(listenerID), nil
-	}
-	return a.restartPublicListenerRuntime(ctx, listenerID)
 }

--- a/internal/server/public_config_loader.go
+++ b/internal/server/public_config_loader.go
@@ -58,16 +58,18 @@ func (a *App) currentPublicSnapshot() *publicProxySnapshot {
 func (a *App) setPublicSnapshotLocked(snap *publicProxySnapshot) {
 	a.publicSnapshot = snap
 	a.publicSnapshotPtr.Store(snap)
+	a.publicSnapshotGeneration++
 }
 
 func (a *App) applyPublicProxySnapshot(snap *publicProxySnapshot) {
 	a.proxyMu.Lock()
 	a.setPublicSnapshotLocked(snap)
+	generation := a.publicSnapshotGeneration
 	a.ensureListenerStatesLocked(snap)
 	a.proxyStatusLocked()
 	active := a.proxyServiceActive
 	a.proxyMu.Unlock()
-	a.refreshRunningPublicTLSSelectors(snap)
+	a.refreshRunningPublicTLSSelectors(snap, generation)
 	a.LoadBalancers.reconcile(snap)
 	if a.TargetHealth != nil {
 		a.TargetHealth.reconcile(a, snap, active)

--- a/internal/server/public_tls.go
+++ b/internal/server/public_tls.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/crypto/acme"
@@ -32,6 +33,71 @@ type publicWildcardCertificate struct {
 }
 
 func newPublicTLSConfig(listenerID int64, snap *publicProxySnapshot, acmeManager *publicACMEManager) (*tls.Config, error) {
+	tlsConfig, _, err := newPublicTLSConfigWithSelectorStore(listenerID, snap, acmeManager)
+	return tlsConfig, err
+}
+
+func newPublicTLSConfigWithSelectorStore(listenerID int64, snap *publicProxySnapshot, acmeManager *publicACMEManager) (*tls.Config, *publicTLSSelectorStore, error) {
+	selector, err := newPublicTLSSelector(listenerID, snap, acmeManager, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	store := newPublicTLSSelectorStore(selector)
+	return &tls.Config{
+		MinVersion:     tls.VersionTLS12,
+		NextProtos:     []string{acme.ALPNProto, "h2", "http/1.1"},
+		GetCertificate: store.GetCertificate,
+	}, store, nil
+}
+
+type publicTLSSelectorStore struct {
+	selector atomic.Pointer[publicTLSSelector]
+}
+
+func newPublicTLSSelectorStore(selector *publicTLSSelector) *publicTLSSelectorStore {
+	store := &publicTLSSelectorStore{}
+	store.selector.Store(selector)
+	return store
+}
+
+func (s *publicTLSSelectorStore) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	if s == nil {
+		return nil, errors.New("public TLS selector store is not initialized")
+	}
+	selector := s.selector.Load()
+	if selector == nil {
+		return nil, errors.New("public TLS selector is not initialized")
+	}
+	return selector.GetCertificate(hello)
+}
+
+func (s *publicTLSSelectorStore) refresh(listenerID int64, snap *publicProxySnapshot, acmeManager *publicACMEManager) error {
+	if s == nil {
+		return errors.New("public TLS selector store is not initialized")
+	}
+	selector, err := newPublicTLSSelector(listenerID, snap, acmeManager, s.fallbackCertificate())
+	if err != nil {
+		return err
+	}
+	s.selector.Store(selector)
+	return nil
+}
+
+func (s *publicTLSSelectorStore) fallbackCertificate() *tls.Certificate {
+	if s == nil {
+		return nil
+	}
+	selector := s.selector.Load()
+	if selector == nil {
+		return nil
+	}
+	return selector.fallback
+}
+
+func newPublicTLSSelector(listenerID int64, snap *publicProxySnapshot, acmeManager *publicACMEManager, fallback *tls.Certificate) (*publicTLSSelector, error) {
+	if snap == nil {
+		return nil, errors.New("public proxy snapshot is required")
+	}
 	selector := &publicTLSSelector{
 		exact: make(map[string]*tls.Certificate),
 		acme:  acmeManager,
@@ -64,17 +130,16 @@ func newPublicTLSConfig(listenerID int64, snap *publicProxySnapshot, acmeManager
 		return len(selector.wildcard[i].suffix) > len(selector.wildcard[j].suffix)
 	})
 
-	fallback, err := generateFallbackCertificate()
-	if err != nil {
-		return nil, err
+	if fallback == nil {
+		var err error
+		fallback, err = generateFallbackCertificate()
+		if err != nil {
+			return nil, err
+		}
 	}
 	selector.fallback = fallback
 
-	return &tls.Config{
-		MinVersion:     tls.VersionTLS12,
-		NextProtos:     []string{acme.ALPNProto, "h2", "http/1.1"},
-		GetCertificate: selector.GetCertificate,
-	}, nil
+	return selector, nil
 }
 
 func (s *publicTLSSelector) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {

--- a/internal/server/public_tls.go
+++ b/internal/server/public_tls.go
@@ -72,15 +72,30 @@ func (s *publicTLSSelectorStore) GetCertificate(hello *tls.ClientHelloInfo) (*tl
 }
 
 func (s *publicTLSSelectorStore) refresh(listenerID int64, snap *publicProxySnapshot, acmeManager *publicACMEManager) error {
-	if s == nil {
-		return errors.New("public TLS selector store is not initialized")
-	}
-	selector, err := newPublicTLSSelector(listenerID, snap, acmeManager, s.fallbackCertificate())
+	selector, err := s.buildRefresh(listenerID, snap, acmeManager)
 	if err != nil {
 		return err
 	}
-	s.selector.Store(selector)
+	s.publish(selector)
 	return nil
+}
+
+func (s *publicTLSSelectorStore) buildRefresh(listenerID int64, snap *publicProxySnapshot, acmeManager *publicACMEManager) (*publicTLSSelector, error) {
+	if s == nil {
+		return nil, errors.New("public TLS selector store is not initialized")
+	}
+	selector, err := newPublicTLSSelector(listenerID, snap, acmeManager, s.fallbackCertificate())
+	if err != nil {
+		return nil, err
+	}
+	return selector, nil
+}
+
+func (s *publicTLSSelectorStore) publish(selector *publicTLSSelector) {
+	if s == nil || selector == nil {
+		return
+	}
+	s.selector.Store(selector)
 }
 
 func (s *publicTLSSelectorStore) fallbackCertificate() *tls.Certificate {

--- a/internal/server/public_tls_config.go
+++ b/internal/server/public_tls_config.go
@@ -184,7 +184,6 @@ func (s *publicConfigService) createPublicTlsCertificate(
 	if err := a.refreshPublicProxySnapshot(ctx); err != nil {
 		return nil, err
 	}
-	_, _ = a.restartTLSListenerIfActive(ctx, cert.ListenerID)
 	a.queuePublicACMECertificateIssue(cert, publicACMETriggerConfigChange)
 	return connect.NewResponse(&p2pstreamv1.CreatePublicTlsCertificateResponse{TlsCertificate: publicTLSCertificateToProto(cert)}), nil
 }
@@ -252,10 +251,6 @@ func (s *publicConfigService) updatePublicTlsCertificate(
 	if err := a.refreshPublicProxySnapshot(ctx); err != nil {
 		return nil, err
 	}
-	if existing.ListenerID != cert.ListenerID {
-		_, _ = a.restartTLSListenerIfActive(ctx, existing.ListenerID)
-	}
-	_, _ = a.restartTLSListenerIfActive(ctx, cert.ListenerID)
 	a.queuePublicACMECertificateIssue(cert, publicACMETriggerConfigChange)
 	return connect.NewResponse(&p2pstreamv1.UpdatePublicTlsCertificateResponse{TlsCertificate: publicTLSCertificateToProto(cert)}), nil
 }
@@ -275,8 +270,7 @@ func (s *publicConfigService) deletePublicTlsCertificate(
 	req *connect.Request[p2pstreamv1.DeletePublicTlsCertificateRequest],
 ) (*connect.Response[p2pstreamv1.DeletePublicTlsCertificateResponse], error) {
 	a := s.app
-	cert, err := s.db.GetPublicTlsCertificate(ctx, req.Msg.Id)
-	if err != nil {
+	if _, err := s.db.GetPublicTlsCertificate(ctx, req.Msg.Id); err != nil {
 		return nil, publicDBError(err)
 	}
 	if err := s.db.DeletePublicTlsCertificate(ctx, req.Msg.Id); err != nil {
@@ -285,7 +279,6 @@ func (s *publicConfigService) deletePublicTlsCertificate(
 	if err := a.refreshPublicProxySnapshot(ctx); err != nil {
 		return nil, err
 	}
-	_, _ = a.restartTLSListenerIfActive(ctx, cert.ListenerID)
 	return connect.NewResponse(&p2pstreamv1.DeletePublicTlsCertificateResponse{}), nil
 }
 

--- a/internal/server/public_tls_test.go
+++ b/internal/server/public_tls_test.go
@@ -2,10 +2,13 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -47,6 +50,122 @@ func TestPublicTLSSelectorRefreshesRunningListenerWithoutRestart(t *testing.T) {
 	}
 	if runtime.State != p2pstreamv1.ProxyState_PROXY_STATE_RUNNING || runtime.LastError != "" {
 		t.Fatalf("runtime after selector refresh = state %v error %q, want running with no error", runtime.State, runtime.LastError)
+	}
+}
+
+func TestPublicTLSSelectorRefreshFailureKeepsLiveServerRegistered(t *testing.T) {
+	const hostname = "rotate-failure.example.com"
+	firstSnap, firstDER := testPublicTLSSnapshot(t, 1, hostname, "first")
+	invalidSnap, _ := testPublicTLSSnapshot(t, 1, hostname, "invalid")
+	invalidSnap.CertsByListener[1][0].CertPath = filepath.Join(t.TempDir(), "missing.crt.pem")
+
+	tlsConfig, selector, err := newPublicTLSConfigWithSelectorStore(1, firstSnap, nil)
+	if err != nil {
+		t.Fatalf("newPublicTLSConfigWithSelectorStore() error = %v", err)
+	}
+	server := &http.Server{}
+	app := NewApp(nil, nil)
+	app.proxyMu.Lock()
+	app.setPublicSnapshotLocked(firstSnap)
+	app.publicListenerState = map[int64]*publicListenerRuntime{
+		1: {
+			Server:      server,
+			TLSSelector: selector,
+			State:       p2pstreamv1.ProxyState_PROXY_STATE_RUNNING,
+		},
+	}
+	app.proxyMu.Unlock()
+
+	app.applyPublicProxySnapshot(invalidSnap)
+	assertPublicTLSCertificateDER(t, tlsConfig, hostname, firstDER)
+
+	app.proxyMu.Lock()
+	runtime := app.publicListenerState[1]
+	app.proxyMu.Unlock()
+	if runtime == nil || runtime.Server != server || runtime.TLSSelector != selector {
+		t.Fatalf("live runtime was orphaned after selector failure: %+v", runtime)
+	}
+	if runtime.State != p2pstreamv1.ProxyState_PROXY_STATE_RUNNING || !strings.Contains(runtime.LastError, "refresh TLS certificates") {
+		t.Fatalf("runtime after selector failure = state %v error %q, want running with refresh error", runtime.State, runtime.LastError)
+	}
+
+	if _, err := app.startPublicListenerRuntime(context.Background(), 1, false); err != nil {
+		t.Fatalf("startPublicListenerRuntime() with live degraded listener error = %v", err)
+	}
+	app.proxyMu.Lock()
+	runtime = app.publicListenerState[1]
+	app.proxyMu.Unlock()
+	if runtime == nil || runtime.Server != server || runtime.TLSSelector != selector {
+		t.Fatalf("start retry orphaned live runtime after selector failure: %+v", runtime)
+	}
+}
+
+func TestPublicTLSSelectorConcurrentRefreshPublishesNewestSnapshot(t *testing.T) {
+	const hostname = "rotate-concurrent.example.com"
+	firstSnap, _ := testPublicTLSSnapshot(t, 1, hostname, "first")
+	secondSnap, _ := testPublicTLSSnapshot(t, 1, hostname, "second")
+	thirdSnap, thirdDER := testPublicTLSSnapshot(t, 1, hostname, "third")
+
+	tlsConfig, selector, err := newPublicTLSConfigWithSelectorStore(1, firstSnap, nil)
+	if err != nil {
+		t.Fatalf("newPublicTLSConfigWithSelectorStore() error = %v", err)
+	}
+	app := NewApp(nil, nil)
+	server := &http.Server{}
+	app.proxyMu.Lock()
+	app.setPublicSnapshotLocked(firstSnap)
+	blockedGeneration := app.publicSnapshotGeneration + 1
+	app.publicListenerState = map[int64]*publicListenerRuntime{
+		1: {
+			Server:      server,
+			TLSSelector: selector,
+			State:       p2pstreamv1.ProxyState_PROXY_STATE_RUNNING,
+		},
+	}
+	app.proxyMu.Unlock()
+
+	firstBuilt := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var blockOnce sync.Once
+	app.publicTLSSelectorRefreshBeforePublish = func(generation uint64) {
+		if generation != blockedGeneration {
+			return
+		}
+		blockOnce.Do(func() {
+			close(firstBuilt)
+			<-releaseFirst
+		})
+	}
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		app.applyPublicProxySnapshot(secondSnap)
+	}()
+	select {
+	case <-firstBuilt:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first selector refresh build")
+	}
+
+	app.applyPublicProxySnapshot(thirdSnap)
+	close(releaseFirst)
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stale selector refresh")
+	}
+
+	assertPublicTLSCertificateDER(t, tlsConfig, hostname, thirdDER)
+	app.proxyMu.Lock()
+	runtime := app.publicListenerState[1]
+	currentSnap := app.publicSnapshot
+	app.proxyMu.Unlock()
+	if currentSnap != thirdSnap {
+		t.Fatal("concurrent refresh replaced the newest public snapshot")
+	}
+	if runtime == nil || runtime.Server != server || runtime.State != p2pstreamv1.ProxyState_PROXY_STATE_RUNNING || runtime.LastError != "" {
+		t.Fatalf("runtime after concurrent selector refresh = %+v", runtime)
 	}
 }
 

--- a/internal/server/public_tls_test.go
+++ b/internal/server/public_tls_test.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"bytes"
+	"crypto/tls"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	p2pstreamv1 "p2pstream/gen/proto/p2pstream/v1"
+)
+
+func TestPublicTLSSelectorRefreshesRunningListenerWithoutRestart(t *testing.T) {
+	const hostname = "rotate.example.com"
+	firstSnap, firstDER := testPublicTLSSnapshot(t, 1, hostname, "first")
+	secondSnap, secondDER := testPublicTLSSnapshot(t, 1, hostname, "second")
+
+	tlsConfig, selector, err := newPublicTLSConfigWithSelectorStore(1, firstSnap, nil)
+	if err != nil {
+		t.Fatalf("newPublicTLSConfigWithSelectorStore() error = %v", err)
+	}
+	assertPublicTLSCertificateDER(t, tlsConfig, hostname, firstDER)
+
+	app := NewApp(nil, nil)
+	server := &http.Server{}
+	app.proxyMu.Lock()
+	app.setPublicSnapshotLocked(firstSnap)
+	app.publicListenerState = map[int64]*publicListenerRuntime{
+		1: {
+			Server:      server,
+			TLSSelector: selector,
+			State:       p2pstreamv1.ProxyState_PROXY_STATE_RUNNING,
+		},
+	}
+	app.proxyMu.Unlock()
+
+	app.applyPublicProxySnapshot(secondSnap)
+
+	assertPublicTLSCertificateDER(t, tlsConfig, hostname, secondDER)
+	app.proxyMu.Lock()
+	runtime := app.publicListenerState[1]
+	app.proxyMu.Unlock()
+	if runtime == nil || runtime.Server != server {
+		t.Fatal("TLS selector refresh replaced the running listener server")
+	}
+	if runtime.State != p2pstreamv1.ProxyState_PROXY_STATE_RUNNING || runtime.LastError != "" {
+		t.Fatalf("runtime after selector refresh = state %v error %q, want running with no error", runtime.State, runtime.LastError)
+	}
+}
+
+func testPublicTLSSnapshot(t *testing.T, listenerID int64, hostname string, name string) (*publicProxySnapshot, []byte) {
+	t.Helper()
+	certPEM, keyPEM, leaf, err := generatePublicSelfSignedCertificatePEM(hostname, time.Hour)
+	if err != nil {
+		t.Fatalf("generate %s certificate: %v", name, err)
+	}
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, name+".crt.pem")
+	keyPath := filepath.Join(dir, name+".key.pem")
+	if err := os.WriteFile(certPath, certPEM, 0600); err != nil {
+		t.Fatalf("write %s certificate: %v", name, err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0600); err != nil {
+		t.Fatalf("write %s key: %v", name, err)
+	}
+	return &publicProxySnapshot{
+		Listeners: map[int64]publicListenerConfig{
+			listenerID: {
+				ID:       listenerID,
+				Name:     "https",
+				Protocol: publicListenerProtocolHTTPS,
+				Enabled:  true,
+			},
+		},
+		RouteTargets:     map[int64]publicRouteTargetConfig{},
+		RoutesByListener: map[int64][]publicRouteConfig{},
+		CertsByListener: map[int64][]publicTLSCertificateConfig{
+			listenerID: {{
+				ID:              10,
+				ListenerID:      listenerID,
+				HostnamePattern: hostname,
+				CertPath:        certPath,
+				KeyPath:         keyPath,
+				Enabled:         true,
+				Source:          publicTLSCertificateSourceManual,
+				Status:          publicTLSCertificateStatusReady,
+			}},
+		},
+	}, leaf.Raw
+}
+
+func assertPublicTLSCertificateDER(t *testing.T, tlsConfig *tls.Config, hostname string, want []byte) {
+	t.Helper()
+	got, err := tlsConfig.GetCertificate(&tls.ClientHelloInfo{ServerName: hostname})
+	if err != nil {
+		t.Fatalf("GetCertificate(%q) error = %v", hostname, err)
+	}
+	if got == nil || len(got.Certificate) == 0 {
+		t.Fatalf("GetCertificate(%q) returned no certificate", hostname)
+	}
+	if !bytes.Equal(got.Certificate[0], want) {
+		t.Fatalf("GetCertificate(%q) returned unexpected certificate", hostname)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -72,13 +72,14 @@ type App struct {
 	generatedSetupToken string
 	setupTokenLogOnce   sync.Once
 
-	proxyMu             sync.Mutex
-	proxyServiceActive  bool
-	proxyState          p2pstreamv1.ProxyState
-	proxyLastError      string
-	publicSnapshot      *publicProxySnapshot
-	publicSnapshotPtr   atomic.Pointer[publicProxySnapshot]
-	publicListenerState map[int64]*publicListenerRuntime
+	proxyMu                  sync.Mutex
+	proxyServiceActive       bool
+	proxyState               p2pstreamv1.ProxyState
+	proxyLastError           string
+	publicSnapshot           *publicProxySnapshot
+	publicSnapshotPtr        atomic.Pointer[publicProxySnapshot]
+	publicSnapshotGeneration uint64
+	publicListenerState      map[int64]*publicListenerRuntime
 
 	publicConfigCacheMu sync.RWMutex
 	publicConfigCache   cachedPublicConfig
@@ -86,7 +87,8 @@ type App struct {
 	observabilityMu          sync.Mutex
 	observabilityLastCleanup time.Time
 
-	agentTunnelBeforeFinalAuth func(db.Agent)
+	agentTunnelBeforeFinalAuth            func(db.Agent)
+	publicTLSSelectorRefreshBeforePublish func(uint64)
 }
 
 type agentAuthLockMap struct {


### PR DESCRIPTION
## Summary
- keep public HTTPS listeners on a stable GetCertificate callback backed by an atomic selector store
- refresh running TLS selectors on public snapshot updates instead of restarting HTTPS listeners for cert create/update/delete or ACME success
- bound public listener shutdown and force close active streams after the timeout for real listener restarts/stops

## Tests
- go test ./internal/server -run TestPublicTLSSelectorRefreshesRunningListenerWithoutRestart -count=1
- go test ./internal/server -run TestShutdownPublicHTTPServerForcesCloseAfterTimeout -count=1
- go test ./internal/server -count=1
- go test ./... -count=1

Stacked on #132. Closes #118.