### PR TITLE
fix: replace stale agent tunnel connections

### DIFF
--- a/internal/server/agent_hub.go
+++ b/internal/server/agent_hub.go
@@ -24,6 +24,9 @@ func newAgentHub() *agentHub {
 func (h *agentHub) connect(conn *AgentConn) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if _, ok := h.byID[conn.AgentID]; ok {
+		return errors.New("agent is already connected")
+	}
 	if _, ok := h.byPublicID[conn.PublicID]; ok {
 		return errors.New("agent is already connected")
 	}
@@ -32,9 +35,36 @@ func (h *agentHub) connect(conn *AgentConn) error {
 	return nil
 }
 
-func (h *agentHub) disconnect(conn *AgentConn) {
+func (h *agentHub) replace(conn *AgentConn) ([]*AgentConn, error) {
 	if h == nil || conn == nil {
-		return
+		return nil, errors.New("agent connection is required")
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	displacedByID := h.byID[conn.AgentID]
+	displacedByPublicID := h.byPublicID[conn.PublicID]
+	if displacedByID == conn || displacedByPublicID == conn {
+		return nil, errors.New("agent connection is already registered")
+	}
+	displaced := make([]*AgentConn, 0, 2)
+	if displacedByID != nil {
+		displaced = append(displaced, displacedByID)
+	}
+	if displacedByPublicID != nil && displacedByPublicID != displacedByID {
+		displaced = append(displaced, displacedByPublicID)
+	}
+	for _, old := range displaced {
+		delete(h.byID, old.AgentID)
+		delete(h.byPublicID, old.PublicID)
+	}
+	h.byPublicID[conn.PublicID] = conn
+	h.byID[conn.AgentID] = conn
+	return displaced, nil
+}
+
+func (h *agentHub) disconnect(conn *AgentConn) bool {
+	if h == nil || conn == nil {
+		return false
 	}
 	h.mu.Lock()
 	disconnected := h.disconnectLocked(conn)
@@ -43,6 +73,7 @@ func (h *agentHub) disconnect(conn *AgentConn) {
 	if disconnected && onDisconnect != nil {
 		onDisconnect(conn)
 	}
+	return disconnected
 }
 
 func (h *agentHub) disconnectByID(agentID int64) *AgentConn {

--- a/internal/server/agent_hub.go
+++ b/internal/server/agent_hub.go
@@ -108,14 +108,7 @@ func (h *agentHub) disconnectLocked(conn *AgentConn) bool {
 		delete(h.byID, conn.AgentID)
 		disconnected = true
 	}
-	if conn.Done == nil {
-		return disconnected
-	}
-	select {
-	case <-conn.Done:
-	default:
-		close(conn.Done)
-	}
+	conn.signalDone()
 	return disconnected
 }
 

--- a/internal/server/agent_registry_test.go
+++ b/internal/server/agent_registry_test.go
@@ -478,7 +478,7 @@ func TestAgentTunnelRejectsWrongVersion(t *testing.T) {
 	}
 }
 
-func TestAgentTunnelRejectsDuplicateConnection(t *testing.T) {
+func TestAgentTunnelReplacesDuplicateConnection(t *testing.T) {
 	database := newAgentRegistryTestDB(t)
 	app := NewApp(&config.Config{ManagementUIDisabled: true}, database)
 	agent := createAgentRegistryTestAgent(t, database, "agent-tunnel-duplicate", "Duplicate Tunnel", "token")
@@ -494,16 +494,40 @@ func TestAgentTunnelRejectsDuplicateConnection(t *testing.T) {
 	defer firstConn.Close()
 	defer firstSession.Close()
 	waitForAgentHubConnection(t, app, agent.ID, true)
+	firstHubConn := app.AgentHub.connectedByID(agent.ID)
+	if firstHubConn == nil {
+		t.Fatal("first tunnel was not registered in the hub")
+	}
 
-	_, secondConn, err := dialAgentRegistryTestTunnel(server.URL, agent.PublicID, "token")
-	if secondConn != nil {
-		secondConn.Close()
+	secondSession, secondConn, err := dialAgentRegistryTestTunnel(server.URL, agent.PublicID, "token")
+	if err != nil {
+		t.Fatalf("dial second tunnel: %v", err)
 	}
-	if err == nil {
-		t.Fatal("second tunnel connected, want duplicate rejection")
+	defer secondConn.Close()
+	defer secondSession.Close()
+	waitForAgentHubConnectionReplaced(t, app, agent.ID, firstHubConn)
+	secondHubConn := app.AgentHub.connectedByID(agent.ID)
+	if secondHubConn == nil {
+		t.Fatal("second tunnel was not registered in the hub")
 	}
-	if !strings.Contains(err.Error(), "409") {
-		t.Fatalf("duplicate tunnel error = %v, want status 409", err)
+	if secondHubConn == firstHubConn {
+		t.Fatal("hub still points at first tunnel after replacement")
+	}
+	assertAgentDoneClosed(t, firstHubConn)
+	assertAgentDoneOpen(t, secondHubConn)
+	waitForYamuxSessionClosed(t, firstSession)
+	waitForConnectionDisconnected(t, database, firstHubConn.ConnectionDBID)
+	assertOnlyOpenAgentConnection(t, database, agent.ID, secondHubConn.ConnectionDBID)
+
+	connected, err := database.GetAgent(context.Background(), agent.ID)
+	if err != nil {
+		t.Fatalf("get agent after reconnect: %v", err)
+	}
+	if !connected.LastConnectedAt.Valid {
+		t.Fatal("agent last_connected_at is not set after reconnect")
+	}
+	if connected.LastDisconnectedAt.Valid && connected.LastDisconnectedAt.Time.After(secondHubConn.ConnectedAt) {
+		t.Fatalf("agent was marked disconnected after replacement: disconnected_at=%s second_connected_at=%s", connected.LastDisconnectedAt.Time, secondHubConn.ConnectedAt)
 	}
 }
 
@@ -650,6 +674,19 @@ func waitForAgentHubConnection(t *testing.T, app *App, agentID int64, wantConnec
 	t.Fatalf("agent connected state did not become %v", wantConnected)
 }
 
+func waitForAgentHubConnectionReplaced(t *testing.T, app *App, agentID int64, old *AgentConn) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		connected := app.AgentHub.connectedByID(agentID)
+		if connected != nil && connected != old {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("agent hub connection was not replaced")
+}
+
 func waitForConnectionDisconnected(t *testing.T, database *db.DB, connID int64) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
@@ -664,6 +701,38 @@ func waitForConnectionDisconnected(t *testing.T, database *db.DB, connID int64) 
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("connection %d disconnected_at was not set", connID)
+}
+
+func assertOnlyOpenAgentConnection(t *testing.T, database *db.DB, agentID int64, wantConnID int64) {
+	t.Helper()
+	rows, err := database.QueryContext(context.Background(), `SELECT id FROM connections WHERE agent_id = ? AND disconnected_at IS NULL`, agentID)
+	if err != nil {
+		t.Fatalf("list open agent connections: %v", err)
+	}
+	defer rows.Close()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan open connection id: %v", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate open connections: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != wantConnID {
+		t.Fatalf("open connection ids = %+v, want [%d]", ids, wantConnID)
+	}
+}
+
+func waitForYamuxSessionClosed(t *testing.T, session *yamux.Session) {
+	t.Helper()
+	select {
+	case <-session.CloseChan():
+	case <-time.After(2 * time.Second):
+		t.Fatal("yamux session did not close")
+	}
 }
 
 type failingHijackResponseWriter struct {

--- a/internal/server/agent_registry_test.go
+++ b/internal/server/agent_registry_test.go
@@ -531,6 +531,225 @@ func TestAgentTunnelReplacesDuplicateConnection(t *testing.T) {
 	}
 }
 
+func TestAgentConnSignalDoneIsConcurrentAndIdempotent(t *testing.T) {
+	conn := &AgentConn{Done: make(chan struct{})}
+	const callers = 64
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			conn.signalDone()
+		}()
+	}
+	close(start)
+	wg.Wait()
+	conn.signalDone()
+	assertAgentDoneClosed(t, conn)
+}
+
+func TestAgentReplacementSerializesPriorDisconnectSideEffects(t *testing.T) {
+	database := newAgentRegistryTestDB(t)
+	app := NewApp(nil, database)
+	agent := createAgentRegistryTestAgent(t, database, "agent-replace-serialized", "Serialized Replacement", "token")
+	old := agentRegistryTestConn(agent)
+	old.ConnectedAt = time.Now()
+	old.ConnectionDBID = insertAgentConnectionForTest(t, database, agent.ID)
+	if err := database.MarkAgentConnected(context.Background(), agent.ID); err != nil {
+		t.Fatalf("mark old agent connected: %v", err)
+	}
+	if err := app.AgentHub.connect(old); err != nil {
+		t.Fatalf("connect old agent: %v", err)
+	}
+	target := agentReplacementTransportTarget()
+	_ = app.agentTargetTransport(old, target)
+
+	hubRemoved := make(chan struct{})
+	releaseCleanup := make(chan struct{})
+	var hookOnce sync.Once
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(releaseCleanup) })
+	app.agentDisconnectAfterHubRemoval = func(conn *AgentConn, disconnected bool) {
+		if conn != old || !disconnected {
+			return
+		}
+		hookOnce.Do(func() {
+			close(hubRemoved)
+			<-releaseCleanup
+		})
+	}
+	cleanupDone := make(chan bool, 1)
+	go func() {
+		cleanupDone <- app.cleanupAgentConnection(old)
+	}()
+	select {
+	case <-hubRemoved:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for old connection to leave hub")
+	}
+
+	app.agentAuthLocks.mu.Lock()
+	lifecycleLock := app.agentAuthLocks.locks[agent.ID]
+	app.agentAuthLocks.mu.Unlock()
+	if lifecycleLock == nil {
+		t.Fatal("agent lifecycle lock was not created")
+	}
+	if lifecycleLock.TryLock() {
+		lifecycleLock.Unlock()
+		t.Fatal("disconnect side effects did not retain the agent lifecycle lock")
+	}
+
+	type replacementResult struct {
+		conn *AgentConn
+		err  error
+	}
+	replacementStarted := make(chan struct{})
+	replacementDone := make(chan replacementResult, 1)
+	go func() {
+		close(replacementStarted)
+		unlock := app.lockAgentAuth(agent.ID)
+		defer unlock()
+		newConn := agentRegistryTestConn(agent)
+		newConn.ConnectedAt = time.Now()
+		connectionID, err := insertAgentConnection(database, agent.ID)
+		if err != nil {
+			replacementDone <- replacementResult{err: err}
+			return
+		}
+		newConn.ConnectionDBID = connectionID
+		if err := database.MarkAgentConnected(context.Background(), agent.ID); err != nil {
+			replacementDone <- replacementResult{err: err}
+			return
+		}
+		displaced, err := app.AgentHub.replace(newConn)
+		if err != nil {
+			replacementDone <- replacementResult{err: err}
+			return
+		}
+		if len(displaced) != 0 {
+			replacementDone <- replacementResult{err: fmt.Errorf("unexpected displaced connections: %d", len(displaced))}
+			return
+		}
+		_ = app.agentTargetTransport(newConn, target)
+		replacementDone <- replacementResult{conn: newConn}
+	}()
+	<-replacementStarted
+	releaseOnce.Do(func() { close(releaseCleanup) })
+
+	if disconnected := <-cleanupDone; !disconnected {
+		t.Fatal("old current connection was not disconnected")
+	}
+	var result replacementResult
+	select {
+	case result = <-replacementDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for serialized replacement")
+	}
+	if result.err != nil {
+		t.Fatalf("replace agent after disconnect: %v", result.err)
+	}
+	if got := app.AgentHub.connectedByID(agent.ID); got != result.conn {
+		t.Fatalf("hub connection = %#v, want replacement %#v", got, result.conn)
+	}
+	assertAgentTransportPoolConnection(t, app.AgentTransports, result.conn)
+	assertOnlyOpenAgentConnection(t, database, agent.ID, result.conn.ConnectionDBID)
+	row, err := database.GetAgent(context.Background(), agent.ID)
+	if err != nil {
+		t.Fatalf("get agent after serialized replacement: %v", err)
+	}
+	if row.LastDisconnectedAt.Valid && row.LastConnectedAt.Valid && row.LastDisconnectedAt.Time.After(row.LastConnectedAt.Time) {
+		t.Fatalf("agent disconnect timestamp %s is after replacement connect timestamp %s", row.LastDisconnectedAt.Time, row.LastConnectedAt.Time)
+	}
+}
+
+func TestStaleAgentCleanupCannotAffectReplacementSideEffects(t *testing.T) {
+	database := newAgentRegistryTestDB(t)
+	app := NewApp(nil, database)
+	agent := createAgentRegistryTestAgent(t, database, "agent-replace-stale-cleanup", "Stale Cleanup", "token")
+	old := agentRegistryTestConn(agent)
+	old.ConnectionDBID = insertAgentConnectionForTest(t, database, agent.ID)
+	if err := app.AgentHub.connect(old); err != nil {
+		t.Fatalf("connect old agent: %v", err)
+	}
+	target := agentReplacementTransportTarget()
+	_ = app.agentTargetTransport(old, target)
+
+	newConn := agentRegistryTestConn(agent)
+	newConn.ConnectedAt = time.Now()
+	newConn.ConnectionDBID = insertAgentConnectionForTest(t, database, agent.ID)
+	if err := database.MarkAgentConnected(context.Background(), agent.ID); err != nil {
+		t.Fatalf("mark replacement connected: %v", err)
+	}
+	unlock := app.lockAgentAuth(agent.ID)
+	displaced, err := app.AgentHub.replace(newConn)
+	if err != nil {
+		unlock()
+		t.Fatalf("replace agent: %v", err)
+	}
+	for _, conn := range displaced {
+		app.retireDisplacedAgentConnection(conn)
+	}
+	_ = app.agentTargetTransport(newConn, target)
+	unlock()
+
+	if disconnected := app.cleanupAgentConnection(old); disconnected {
+		t.Fatal("stale cleanup disconnected the replacement")
+	}
+	if got := app.AgentHub.connectedByID(agent.ID); got != newConn {
+		t.Fatalf("hub connection = %#v, want replacement %#v", got, newConn)
+	}
+	assertAgentTransportPoolConnection(t, app.AgentTransports, newConn)
+	assertOnlyOpenAgentConnection(t, database, agent.ID, newConn.ConnectionDBID)
+	row, err := database.GetAgent(context.Background(), agent.ID)
+	if err != nil {
+		t.Fatalf("get agent after stale cleanup: %v", err)
+	}
+	if row.LastDisconnectedAt.Valid {
+		t.Fatalf("stale cleanup marked replacement disconnected at %s", row.LastDisconnectedAt.Time)
+	}
+}
+
+func insertAgentConnectionForTest(t *testing.T, database *db.DB, agentID int64) int64 {
+	t.Helper()
+	id, err := insertAgentConnection(database, agentID)
+	if err != nil {
+		t.Fatalf("insert agent connection: %v", err)
+	}
+	return id
+}
+
+func insertAgentConnection(database *db.DB, agentID int64) (int64, error) {
+	id, err := database.InsertConnection(context.Background(), sql.NullInt64{Int64: agentID, Valid: true})
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+func agentReplacementTransportTarget() publicRouteTargetConfig {
+	return publicRouteTargetConfig{
+		ID:                            900,
+		URL:                           "http://replacement.test:9000",
+		UpstreamResponseHeaderTimeout: time.Second,
+	}
+}
+
+func assertAgentTransportPoolConnection(t *testing.T, pool *agentTransportPool, want *AgentConn) {
+	t.Helper()
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
+	if len(pool.entries) != 1 {
+		t.Fatalf("agent transport entries = %d, want 1", len(pool.entries))
+	}
+	for _, entry := range pool.entries {
+		if entry == nil || entry.agent != want {
+			t.Fatalf("pooled transport agent = %#v, want %#v", entry, want)
+		}
+	}
+}
+
 func newAgentRegistryTestDB(t *testing.T) *db.DB {
 	t.Helper()
 	database, err := db.Open(filepath.Join(t.TempDir(), "agent-registry-test.db"))

--- a/internal/server/agent_transport_pool.go
+++ b/internal/server/agent_transport_pool.go
@@ -160,6 +160,15 @@ func (p *agentTransportPool) closeAgent(agentID int64) {
 	})
 }
 
+func (p *agentTransportPool) closeAgentConnection(agent *AgentConn) {
+	if agent == nil {
+		return
+	}
+	p.closeEntriesWhere(func(_ agentTransportKey, entry *pooledAgentTransport) bool {
+		return entry != nil && entry.agent == agent
+	})
+}
+
 func (p *agentTransportPool) closeRouteTarget(targetID int64) {
 	p.closeWhere(func(key agentTransportKey) bool {
 		return key.Kind == agentTransportKindRouteTarget && key.RouteTargetID == targetID
@@ -186,13 +195,19 @@ func (p *agentTransportPool) len() int {
 }
 
 func (p *agentTransportPool) closeWhere(match func(agentTransportKey) bool) {
+	p.closeEntriesWhere(func(key agentTransportKey, _ *pooledAgentTransport) bool {
+		return match(key)
+	})
+}
+
+func (p *agentTransportPool) closeEntriesWhere(match func(agentTransportKey, *pooledAgentTransport) bool) {
 	if p == nil {
 		return
 	}
 	var transports []*http.Transport
 	p.mu.Lock()
 	for key, entry := range p.entries {
-		if !match(key) {
+		if !match(key, entry) {
 			continue
 		}
 		if entry.transport != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -352,12 +352,6 @@ func (a *App) agentTunnelHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	agentRow = finalAgentRow
 
-	if existing := a.AgentHub.connectedByID(agentRow.ID); existing != nil {
-		log.Warn().Str("agent", agentRow.PublicID).Msg("Rejecting duplicate agent connection")
-		http.Error(w, "agent is already connected", http.StatusConflict)
-		return
-	}
-
 	agent := &AgentConn{
 		AgentID:     agentRow.ID,
 		PublicID:    agentRow.PublicID,
@@ -407,7 +401,8 @@ func (a *App) agentTunnelHandler(w http.ResponseWriter, r *http.Request) {
 			log.Warn().Err(err).Msg("Failed to insert connection into DB")
 		}
 	}
-	if err := a.AgentHub.connect(agent); err != nil {
+	displaced, err := a.AgentHub.replace(agent)
+	if err != nil {
 		_ = session.Close()
 		if a.DB != nil && agent.ConnectionDBID > 0 {
 			if err := a.DB.UpdateConnectionDisconnected(context.Background(), agent.ConnectionDBID); err != nil {
@@ -417,16 +412,20 @@ func (a *App) agentTunnelHandler(w http.ResponseWriter, r *http.Request) {
 				log.Warn().Err(err).Str("agent", agent.PublicID).Msg("Failed to update rejected agent disconnected timestamp")
 			}
 		}
-		log.Warn().Err(err).Str("agent", agent.PublicID).Msg("Rejecting duplicate agent connection")
+		log.Warn().Err(err).Str("agent", agent.PublicID).Msg("Failed to register agent tunnel")
 		return
+	}
+	for _, old := range displaced {
+		a.retireDisplacedAgentConnection(old)
 	}
 	unlockAgentAuth()
 
-	cleanupAgent := func() {
-		a.AgentHub.disconnect(agent)
-		if a.TargetHealth != nil {
+	cleanupAgent := func() bool {
+		disconnected := a.AgentHub.disconnect(agent)
+		if disconnected && a.TargetHealth != nil {
 			a.TargetHealth.recordAgentDisconnectedForAll(agent.AgentID)
 		}
+		return disconnected
 	}
 	if a.TargetHealth != nil {
 		a.TargetHealth.recordAgentConnectedForAll(agent.AgentID, agent.PublicID)
@@ -444,7 +443,7 @@ func (a *App) agentTunnelHandler(w http.ResponseWriter, r *http.Request) {
 			_ = session.Close()
 		case <-session.CloseChan():
 		}
-		cleanupAgent()
+		disconnected := cleanupAgent()
 		log.Info().
 			Str("agent", agent.PublicID).
 			Int64("duration_ms", time.Since(agent.ConnectedAt).Milliseconds()).
@@ -454,11 +453,38 @@ func (a *App) agentTunnelHandler(w http.ResponseWriter, r *http.Request) {
 			if err := a.DB.UpdateConnectionDisconnected(context.Background(), agent.ConnectionDBID); err != nil {
 				log.Warn().Err(err).Msg("Failed to update disconnection time")
 			}
-			if err := a.DB.MarkAgentDisconnected(context.Background(), agent.AgentID); err != nil {
-				log.Warn().Err(err).Str("agent", agent.PublicID).Msg("Failed to update agent disconnected timestamp")
+			if disconnected {
+				if err := a.DB.MarkAgentDisconnected(context.Background(), agent.AgentID); err != nil {
+					log.Warn().Err(err).Str("agent", agent.PublicID).Msg("Failed to update agent disconnected timestamp")
+				}
 			}
 		}
 	}()
+}
+
+func (a *App) retireDisplacedAgentConnection(agent *AgentConn) {
+	if agent == nil {
+		return
+	}
+	log.Warn().
+		Str("agent", agent.PublicID).
+		Int64("active_requests", agent.ActiveRequests.Load()).
+		Msg("Replacing existing agent tunnel with newer authenticated connection")
+	if a.AgentTransports != nil {
+		a.AgentTransports.closeAgentConnection(agent)
+	}
+	if agent.Done != nil {
+		select {
+		case <-agent.Done:
+		default:
+			close(agent.Done)
+		}
+	}
+	if agent.Session != nil {
+		if err := agent.Session.Close(); err != nil {
+			log.Warn().Err(err).Str("agent", agent.PublicID).Msg("Failed to close displaced agent tunnel session")
+		}
+	}
 }
 
 func headerHasToken(header http.Header, name string, want string) bool {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,9 +30,25 @@ type AgentConn struct {
 	Name           string
 	Session        *yamux.Session
 	Done           chan struct{}
+	doneOnce       sync.Once
 	ActiveRequests atomic.Int64
 	ConnectedAt    time.Time
 	ConnectionDBID int64
+}
+
+func (c *AgentConn) signalDone() {
+	if c == nil || c.Done == nil {
+		return
+	}
+	c.doneOnce.Do(func() {
+		select {
+		case <-c.Done:
+			// Keep compatibility with test and embedded callers that supplied an
+			// already-closed channel without going through signalDone.
+		default:
+			close(c.Done)
+		}
+	})
 }
 
 type App struct {
@@ -88,6 +104,7 @@ type App struct {
 	observabilityLastCleanup time.Time
 
 	agentTunnelBeforeFinalAuth            func(db.Agent)
+	agentDisconnectAfterHubRemoval        func(*AgentConn, bool)
 	publicTLSSelectorRefreshBeforePublish func(uint64)
 }
 
@@ -420,18 +437,10 @@ func (a *App) agentTunnelHandler(w http.ResponseWriter, r *http.Request) {
 	for _, old := range displaced {
 		a.retireDisplacedAgentConnection(old)
 	}
-	unlockAgentAuth()
-
-	cleanupAgent := func() bool {
-		disconnected := a.AgentHub.disconnect(agent)
-		if disconnected && a.TargetHealth != nil {
-			a.TargetHealth.recordAgentDisconnectedForAll(agent.AgentID)
-		}
-		return disconnected
-	}
 	if a.TargetHealth != nil {
 		a.TargetHealth.recordAgentConnectedForAll(agent.AgentID, agent.PublicID)
 	}
+	unlockAgentAuth()
 
 	log.Info().
 		Str("remote_addr", r.RemoteAddr).
@@ -445,23 +454,43 @@ func (a *App) agentTunnelHandler(w http.ResponseWriter, r *http.Request) {
 			_ = session.Close()
 		case <-session.CloseChan():
 		}
-		disconnected := cleanupAgent()
+		a.cleanupAgentConnection(agent)
 		log.Info().
 			Str("agent", agent.PublicID).
 			Int64("duration_ms", time.Since(agent.ConnectedAt).Milliseconds()).
 			Int64("active_requests", agent.ActiveRequests.Load()).
 			Msg("Agent tunnel disconnected")
-		if a.DB != nil && agent.ConnectionDBID > 0 {
-			if err := a.DB.UpdateConnectionDisconnected(context.Background(), agent.ConnectionDBID); err != nil {
-				log.Warn().Err(err).Msg("Failed to update disconnection time")
-			}
-			if disconnected {
-				if err := a.DB.MarkAgentDisconnected(context.Background(), agent.AgentID); err != nil {
-					log.Warn().Err(err).Str("agent", agent.PublicID).Msg("Failed to update agent disconnected timestamp")
-				}
+	}()
+}
+
+func (a *App) cleanupAgentConnection(agent *AgentConn) bool {
+	if a == nil || agent == nil {
+		return false
+	}
+	unlock := a.lockAgentAuth(agent.AgentID)
+	defer unlock()
+
+	disconnected := false
+	if a.AgentHub != nil {
+		disconnected = a.AgentHub.disconnect(agent)
+	}
+	if hook := a.agentDisconnectAfterHubRemoval; hook != nil {
+		hook(agent, disconnected)
+	}
+	if disconnected && a.TargetHealth != nil {
+		a.TargetHealth.recordAgentDisconnectedForAll(agent.AgentID)
+	}
+	if a.DB != nil && agent.ConnectionDBID > 0 {
+		if err := a.DB.UpdateConnectionDisconnected(context.Background(), agent.ConnectionDBID); err != nil {
+			log.Warn().Err(err).Msg("Failed to update disconnection time")
+		}
+		if disconnected {
+			if err := a.DB.MarkAgentDisconnected(context.Background(), agent.AgentID); err != nil {
+				log.Warn().Err(err).Str("agent", agent.PublicID).Msg("Failed to update agent disconnected timestamp")
 			}
 		}
-	}()
+	}
+	return disconnected
 }
 
 func (a *App) retireDisplacedAgentConnection(agent *AgentConn) {
@@ -475,13 +504,7 @@ func (a *App) retireDisplacedAgentConnection(agent *AgentConn) {
 	if a.AgentTransports != nil {
 		a.AgentTransports.closeAgentConnection(agent)
 	}
-	if agent.Done != nil {
-		select {
-		case <-agent.Done:
-		default:
-			close(agent.Done)
-		}
-	}
+	agent.signalDone()
 	if agent.Session != nil {
 		if err := agent.Session.Close(); err != nil {
 			log.Warn().Err(err).Str("agent", agent.PublicID).Msg("Failed to close displaced agent tunnel session")

--- a/tests/integration/agent_websocket_test.go
+++ b/tests/integration/agent_websocket_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 
@@ -45,10 +46,15 @@ func TestRegisteredAgentTunnelAuthAndDuplicates(t *testing.T) {
 	}
 	defer sessionA.Close()
 
-	duplicate, _, err := dialAgentTunnel(context.Background(), mgmtSrv.URL, agentA.GetPublicId(), tokenA, nil)
-	if err == nil {
-		_ = duplicate.Close()
-		t.Fatal("expected duplicate agent connection to fail")
+	replacementA, _, err := dialAgentTunnel(context.Background(), mgmtSrv.URL, agentA.GetPublicId(), tokenA, nil)
+	if err != nil {
+		t.Fatalf("dial replacement agent A: %v", err)
+	}
+	defer replacementA.Close()
+	select {
+	case <-sessionA.CloseChan():
+	case <-time.After(2 * time.Second):
+		t.Fatal("original agent A tunnel did not close after replacement")
 	}
 
 	sessionB, _, err := dialAgentTunnel(context.Background(), mgmtSrv.URL, agentB.GetPublicId(), tokenB, nil)


### PR DESCRIPTION
## Summary
- replace the old duplicate tunnel 409 with authenticated newest-wins agent tunnel registration
- retire displaced sessions by closing their old session, Done channel, and only their pointer-specific pooled transports
- make stale tunnel cleanup idempotent so an old cleanup closes its connection row without marking the newly registered agent disconnected
- update server and integration coverage for reconnect replacement

## Tests
- go test ./internal/server -run TestAgentTunnelReplacesDuplicateConnection -count=10
- go test ./internal/server -run TestAgentTunnelReplacesDuplicateConnection -count=1
- go test ./internal/server -count=1
- go test ./tests/integration -run TestRegisteredAgentTunnelAuthAndDuplicates -count=1
- go test ./... -count=1

Stacked on #133. Closes #119.