### PR TITLE
Pool direct health check transports

### DIFF
--- a/internal/server/direct_health_transport_pool.go
+++ b/internal/server/direct_health_transport_pool.go
@@ -1,0 +1,139 @@
+package server
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+type directHealthTransportKey struct {
+	RouteTargetID               int64
+	TargetOrigin                string
+	TLSSkipVerify               bool
+	ResponseHeaderTimeoutMillis int64
+}
+
+type pooledDirectHealthTransport struct {
+	key       directHealthTransportKey
+	transport *http.Transport
+	createdAt time.Time
+}
+
+type directHealthTransportPool struct {
+	mu      sync.Mutex
+	entries map[directHealthTransportKey]*pooledDirectHealthTransport
+}
+
+func newDirectHealthTransportPool() *directHealthTransportPool {
+	return &directHealthTransportPool{entries: make(map[directHealthTransportKey]*pooledDirectHealthTransport)}
+}
+
+func (p *directHealthTransportPool) transport(target publicRouteTargetHealthConfig, timeout time.Duration) http.RoundTripper {
+	if p == nil {
+		return newDirectProxyHTTPTransport(target.TLSSkipVerify, timeout)
+	}
+	key := directHealthTransportKeyForTarget(target, timeout)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if existing := p.entries[key]; existing != nil && existing.transport != nil {
+		return existing.transport
+	}
+	transport := newDirectProxyHTTPTransport(target.TLSSkipVerify, timeout)
+	p.entries[key] = &pooledDirectHealthTransport{
+		key:       key,
+		transport: transport,
+		createdAt: time.Now(),
+	}
+	return transport
+}
+
+func (p *directHealthTransportPool) closeTarget(targetID int64) {
+	p.closeWhere(func(key directHealthTransportKey) bool {
+		return key.RouteTargetID == targetID
+	})
+}
+
+func (p *directHealthTransportPool) closeStaleTargetTransports(target publicRouteTargetHealthConfig, timeout time.Duration) {
+	want := directHealthTransportKeyForTarget(target, timeout)
+	p.closeWhere(func(key directHealthTransportKey) bool {
+		return key.RouteTargetID == target.ID && key != want
+	})
+}
+
+func (p *directHealthTransportPool) closeAll() {
+	p.closeWhere(func(directHealthTransportKey) bool { return true })
+}
+
+func (p *directHealthTransportPool) len() int {
+	if p == nil {
+		return 0
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.entries)
+}
+
+func (p *directHealthTransportPool) closeWhere(match func(directHealthTransportKey) bool) {
+	if p == nil {
+		return
+	}
+	var transports []*http.Transport
+	p.mu.Lock()
+	for key, entry := range p.entries {
+		if !match(key) {
+			continue
+		}
+		if entry.transport != nil {
+			transports = append(transports, entry.transport)
+		}
+		delete(p.entries, key)
+	}
+	p.mu.Unlock()
+	for _, transport := range transports {
+		transport.CloseIdleConnections()
+	}
+}
+
+func directHealthTransportKeyForTarget(target publicRouteTargetHealthConfig, timeout time.Duration) directHealthTransportKey {
+	timeout = normalizeUpstreamResponseHeaderTimeout(timeout)
+	return directHealthTransportKey{
+		RouteTargetID:               target.ID,
+		TargetOrigin:                directHealthTransportOrigin(target),
+		TLSSkipVerify:               target.TLSSkipVerify,
+		ResponseHeaderTimeoutMillis: int64(timeout / time.Millisecond),
+	}
+}
+
+func directHealthTransportOrigin(target publicRouteTargetHealthConfig) string {
+	origin := target.ParsedOrigin
+	if origin == nil && target.TargetOrigin != "" {
+		parsed, err := url.Parse(target.TargetOrigin)
+		if err == nil {
+			origin = parsed
+		}
+	}
+	if origin == nil {
+		return target.TargetOrigin
+	}
+	return (&url.URL{Scheme: origin.Scheme, Host: origin.Host}).String()
+}
+
+func newDirectProxyHTTPTransport(tlsSkipVerify bool, responseHeaderTimeout time.Duration) *http.Transport {
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		base = &http.Transport{}
+	}
+	transport := base.Clone()
+	transport.ResponseHeaderTimeout = normalizeUpstreamResponseHeaderTimeout(responseHeaderTimeout)
+	if tlsSkipVerify {
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = &tls.Config{}
+		} else {
+			transport.TLSClientConfig = transport.TLSClientConfig.Clone()
+		}
+		transport.TLSClientConfig.InsecureSkipVerify = true
+	}
+	return transport
+}

--- a/internal/server/public_routing.go
+++ b/internal/server/public_routing.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"crypto/tls"
 	"database/sql"
 	"errors"
 	"io"
@@ -1311,21 +1310,7 @@ func mergeRedirectQuery(configuredQuery string, incomingQuery string, preserveIn
 }
 
 func directProxyTransport(tlsSkipVerify bool, responseHeaderTimeout time.Duration) http.RoundTripper {
-	base, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		return http.DefaultTransport
-	}
-	transport := base.Clone()
-	transport.ResponseHeaderTimeout = normalizeUpstreamResponseHeaderTimeout(responseHeaderTimeout)
-	if tlsSkipVerify {
-		if transport.TLSClientConfig == nil {
-			transport.TLSClientConfig = &tls.Config{}
-		} else {
-			transport.TLSClientConfig = transport.TLSClientConfig.Clone()
-		}
-		transport.TLSClientConfig.InsecureSkipVerify = true
-	}
-	return transport
+	return newDirectProxyHTTPTransport(tlsSkipVerify, responseHeaderTimeout)
 }
 
 func normalizeUpstreamResponseHeaderTimeout(timeout time.Duration) time.Duration {

--- a/internal/server/public_target_health.go
+++ b/internal/server/public_target_health.go
@@ -42,10 +42,11 @@ type publicRouteTargetAgentHealthSnapshot struct {
 }
 
 type publicRouteTargetHealthMonitor struct {
-	mu       sync.Mutex
-	app      *App
-	sequence uint64
-	states   map[int64]*publicRouteTargetHealthState
+	mu               sync.Mutex
+	app              *App
+	sequence         uint64
+	states           map[int64]*publicRouteTargetHealthState
+	directTransports *directHealthTransportPool
 }
 
 type publicRouteTargetHealthState struct {
@@ -105,7 +106,10 @@ type publicRouteTargetHealthTraceState struct {
 }
 
 func newPublicRouteTargetHealthMonitor() *publicRouteTargetHealthMonitor {
-	return &publicRouteTargetHealthMonitor{states: make(map[int64]*publicRouteTargetHealthState)}
+	return &publicRouteTargetHealthMonitor{
+		states:           make(map[int64]*publicRouteTargetHealthState),
+		directTransports: newDirectHealthTransportPool(),
+	}
 }
 
 func (m *publicRouteTargetHealthMonitor) reconcile(app *App, snap *publicProxySnapshot, active bool) {
@@ -121,6 +125,7 @@ func (m *publicRouteTargetHealthMonitor) reconcile(app *App, snap *publicProxySn
 			state.stopLocked()
 			delete(m.states, id)
 		}
+		m.closeDirectHealthTransports()
 		return
 	}
 	healthBackends := publicHealthTargetConfigsFromSnapshot(snap)
@@ -128,6 +133,7 @@ func (m *publicRouteTargetHealthMonitor) reconcile(app *App, snap *publicProxySn
 		if _, ok := healthBackends[id]; !ok {
 			state.stopLocked()
 			delete(m.states, id)
+			m.closeDirectHealthTransportsForTarget(id)
 		}
 	}
 	for _, target := range healthBackends {
@@ -150,8 +156,11 @@ func (m *publicRouteTargetHealthMonitor) reconcile(app *App, snap *publicProxySn
 			state.directCheckRunning = true
 			go m.directHealthLoop(ctx, target.ID)
 		}
-		if !shouldRunDirect {
+		if shouldRunDirect {
+			m.closeStaleDirectHealthTransports(target)
+		} else {
 			state.stopDirectLocked()
+			m.closeDirectHealthTransportsForTarget(target.ID)
 		}
 
 		shouldRunAgents := active &&
@@ -325,7 +334,7 @@ func (m *publicRouteTargetHealthMonitor) directHealthLoop(ctx context.Context, t
 		if !ok {
 			return
 		}
-		m.recordDirectExplicitCheck(targetID, runPublicRouteTargetHealthCheck(ctx, target))
+		m.recordDirectExplicitCheck(targetID, m.runPublicRouteTargetHealthCheck(ctx, target))
 		if !waitPublicTargetHealthInterval(ctx, target.HealthCheck.Interval) {
 			return
 		}
@@ -410,7 +419,27 @@ func checkPublicTargetHealth(parent context.Context, target publicRouteTargetHea
 }
 
 func runPublicRouteTargetHealthCheck(parent context.Context, target publicRouteTargetHealthConfig) publicRouteTargetHealthCheckAttempt {
+	return runPublicRouteTargetHealthCheckWithTransport(parent, target, nil, "")
+}
+
+func (m *publicRouteTargetHealthMonitor) runPublicRouteTargetHealthCheck(parent context.Context, target publicRouteTargetHealthConfig) publicRouteTargetHealthCheckAttempt {
+	timeout := publicRouteTargetHealthCheckTimeout(target)
+	transport := http.RoundTripper(nil)
+	if m != nil && m.directTransports != nil {
+		transport = m.directTransports.transport(target, timeout)
+	}
+	transportLabel := ""
+	if transport != nil {
+		transportLabel = "direct_pool"
+	}
+	return runPublicRouteTargetHealthCheckWithTransport(parent, target, transport, transportLabel)
+}
+
+func runPublicRouteTargetHealthCheckWithTransport(parent context.Context, target publicRouteTargetHealthConfig, transport http.RoundTripper, transportLabel string) publicRouteTargetHealthCheckAttempt {
 	attempt := newPublicRouteTargetHealthCheckAttempt(target)
+	if transportLabel != "" {
+		attempt.DebugAttributes["transport"] = transportLabel
+	}
 	defer finishPublicRouteTargetHealthCheckAttempt(&attempt)
 
 	checkURL, err := publicRouteTargetHealthCheckURL(target)
@@ -419,10 +448,7 @@ func runPublicRouteTargetHealthCheck(parent context.Context, target publicRouteT
 		return attempt
 	}
 	attempt.URL = redactSensitiveTraceURL(checkURL.String())
-	timeout := target.HealthCheck.Timeout
-	if timeout <= 0 {
-		timeout = time.Duration(defaultTargetHealthCheckTimeoutMillis) * time.Millisecond
-	}
+	timeout := publicRouteTargetHealthCheckTimeout(target)
 	ctx, cancel := context.WithTimeout(parent, timeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, target.HealthCheck.Method, checkURL.String(), nil)
@@ -431,7 +457,13 @@ func runPublicRouteTargetHealthCheck(parent context.Context, target publicRouteT
 		return attempt
 	}
 	applyUpstreamRequestConfig(req, target)
-	client := &http.Client{Transport: directProxyTransport(target.TLSSkipVerify, timeout)}
+	if transport == nil {
+		transport = directProxyTransport(target.TLSSkipVerify, timeout)
+		if directTransport, ok := transport.(*http.Transport); ok {
+			defer directTransport.CloseIdleConnections()
+		}
+	}
+	client := &http.Client{Transport: transport}
 	resp, err := client.Do(req)
 	if err != nil {
 		attempt.applyContextFailure(parent, ctx, "request_failed", err)
@@ -449,6 +481,35 @@ func runPublicRouteTargetHealthCheck(parent context.Context, target publicRouteT
 	}
 	attempt.ErrorKind = "success"
 	return attempt
+}
+
+func publicRouteTargetHealthCheckTimeout(target publicRouteTargetHealthConfig) time.Duration {
+	timeout := target.HealthCheck.Timeout
+	if timeout <= 0 {
+		timeout = time.Duration(defaultTargetHealthCheckTimeoutMillis) * time.Millisecond
+	}
+	return timeout
+}
+
+func (m *publicRouteTargetHealthMonitor) closeDirectHealthTransportsForTarget(targetID int64) {
+	if m == nil || m.directTransports == nil {
+		return
+	}
+	m.directTransports.closeTarget(targetID)
+}
+
+func (m *publicRouteTargetHealthMonitor) closeStaleDirectHealthTransports(target publicRouteTargetHealthConfig) {
+	if m == nil || m.directTransports == nil {
+		return
+	}
+	m.directTransports.closeStaleTargetTransports(target, publicRouteTargetHealthCheckTimeout(target))
+}
+
+func (m *publicRouteTargetHealthMonitor) closeDirectHealthTransports() {
+	if m == nil || m.directTransports == nil {
+		return
+	}
+	m.directTransports.closeAll()
 }
 
 func (a *App) checkPublicTargetHealthViaAgent(parent context.Context, target publicRouteTargetHealthConfig, agent *AgentConn) error {

--- a/internal/server/public_target_health.go
+++ b/internal/server/public_target_health.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"reflect"
 	"sort"
 	"strconv"
 	"sync"
@@ -53,6 +54,7 @@ type publicRouteTargetHealthState struct {
 	target             publicRouteTargetHealthConfig
 	directCancel       context.CancelFunc
 	directCheckRunning bool
+	directGeneration   uint64
 	direct             publicRouteTargetCheckState
 	directTraces       []*p2pstreamv1.PublicRouteTargetHealthTrace
 	agentStates        map[int64]*publicRouteTargetAgentHealthState
@@ -142,6 +144,11 @@ func (m *publicRouteTargetHealthMonitor) reconcile(app *App, snap *publicProxySn
 			state = newPublicRouteTargetHealthState(target)
 			m.states[target.ID] = state
 		}
+		directConfigChanged := !reflect.DeepEqual(state.target, target)
+		if directConfigChanged && state.directCheckRunning {
+			state.stopDirectLocked()
+			state.directGeneration++
+		}
 		state.target = target
 
 		shouldRunDirect := active &&
@@ -154,11 +161,16 @@ func (m *publicRouteTargetHealthMonitor) reconcile(app *App, snap *publicProxySn
 			ctx, cancel := context.WithCancel(context.Background())
 			state.directCancel = cancel
 			state.directCheckRunning = true
-			go m.directHealthLoop(ctx, target.ID)
+			state.directGeneration++
+			generation := state.directGeneration
+			go m.directHealthLoop(ctx, target.ID, generation)
 		}
 		if shouldRunDirect {
 			m.closeStaleDirectHealthTransports(target)
 		} else {
+			if state.directCheckRunning {
+				state.directGeneration++
+			}
 			state.stopDirectLocked()
 			m.closeDirectHealthTransportsForTarget(target.ID)
 		}
@@ -328,13 +340,18 @@ func (s *publicRouteTargetHealthState) clearHealthStateLocked() {
 	}
 }
 
-func (m *publicRouteTargetHealthMonitor) directHealthLoop(ctx context.Context, targetID int64) {
+func (m *publicRouteTargetHealthMonitor) directHealthLoop(ctx context.Context, targetID int64, generation uint64) {
 	for {
-		target, ok := m.targetForDirectCheck(targetID)
+		target, transport, ok := m.directCheckForGeneration(targetID, generation)
 		if !ok {
 			return
 		}
-		m.recordDirectExplicitCheck(targetID, m.runPublicRouteTargetHealthCheck(ctx, target))
+		transportLabel := ""
+		if transport != nil {
+			transportLabel = "direct_pool"
+		}
+		attempt := runPublicRouteTargetHealthCheckWithTransport(ctx, target, transport, transportLabel)
+		m.recordDirectExplicitCheckForGeneration(targetID, generation, attempt)
 		if !waitPublicTargetHealthInterval(ctx, target.HealthCheck.Interval) {
 			return
 		}
@@ -378,14 +395,19 @@ func waitPublicTargetHealthInterval(ctx context.Context, interval time.Duration)
 	}
 }
 
-func (m *publicRouteTargetHealthMonitor) targetForDirectCheck(targetID int64) (publicRouteTargetHealthConfig, bool) {
+func (m *publicRouteTargetHealthMonitor) directCheckForGeneration(targetID int64, generation uint64) (publicRouteTargetHealthConfig, http.RoundTripper, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	state := m.states[targetID]
-	if state == nil || !state.directCheckRunning {
-		return publicRouteTargetHealthConfig{}, false
+	if state == nil || !state.directCheckRunning || state.directGeneration != generation {
+		return publicRouteTargetHealthConfig{}, nil, false
 	}
-	return state.target, true
+	target := state.target
+	var transport http.RoundTripper
+	if m.directTransports != nil {
+		transport = m.directTransports.transport(target, publicRouteTargetHealthCheckTimeout(target))
+	}
+	return target, transport, true
 }
 
 func (m *publicRouteTargetHealthMonitor) backendForAgentCheck(targetID int64, agentID int64) (publicRouteTargetHealthConfig, bool) {
@@ -700,6 +722,20 @@ func (m *publicRouteTargetHealthMonitor) recordDirectExplicitCheck(targetID int6
 	if state == nil {
 		return
 	}
+	m.recordDirectExplicitCheckLocked(state, attempt)
+}
+
+func (m *publicRouteTargetHealthMonitor) recordDirectExplicitCheckForGeneration(targetID int64, generation uint64, attempt publicRouteTargetHealthCheckAttempt) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	state := m.states[targetID]
+	if state == nil || !state.directCheckRunning || state.directGeneration != generation {
+		return
+	}
+	m.recordDirectExplicitCheckLocked(state, attempt)
+}
+
+func (m *publicRouteTargetHealthMonitor) recordDirectExplicitCheckLocked(state *publicRouteTargetHealthState, attempt publicRouteTargetHealthCheckAttempt) {
 	now := time.Now()
 	before := publicRouteTargetHealthTraceStateFromCheck(state.direct, state.target.HealthCheck.Enabled, now)
 	if attempt.Skipped {

--- a/internal/server/public_target_health_test.go
+++ b/internal/server/public_target_health_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -59,6 +60,96 @@ func TestDirectTargetHealthStillChecksFromServer(t *testing.T) {
 	waitForHealthStatus(t, monitor, 1, p2pstreamv1.PublicRouteTargetHealthStatus_PUBLIC_ROUTE_TARGET_HEALTH_STATUS_HEALTHY)
 	if !monitor.available(backend) {
 		t.Fatal("backend should be available after explicit health recovery")
+	}
+}
+
+func TestDirectTargetHealthCheckReusesPooledTransportConnection(t *testing.T) {
+	var newConnections atomic.Int64
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			t.Fatalf("direct health path = %q, want /health", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			newConnections.Add(1)
+		}
+	}
+	srv.Start()
+	defer srv.Close()
+
+	backend := testHealthTarget(t, 2, publicRouteTargetTransportDirect, srv.URL+"/base?ignored=true")
+	monitor := newPublicRouteTargetHealthMonitor()
+	t.Cleanup(func() { monitor.closeDirectHealthTransports() })
+
+	for i := 0; i < 3; i++ {
+		attempt := monitor.runPublicRouteTargetHealthCheck(context.Background(), backend)
+		if attempt.Err != nil {
+			t.Fatalf("health check %d failed: kind=%s err=%v", i, attempt.ErrorKind, attempt.Err)
+		}
+		if attempt.DebugAttributes["transport"] != "direct_pool" {
+			t.Fatalf("health check %d transport = %q, want direct_pool", i, attempt.DebugAttributes["transport"])
+		}
+	}
+
+	if got := newConnections.Load(); got != 1 {
+		t.Fatalf("new upstream connections = %d, want 1", got)
+	}
+	if got := monitor.directTransports.len(); got != 1 {
+		t.Fatalf("direct health transport pool len = %d, want 1", got)
+	}
+}
+
+func TestDirectHealthTransportPoolEvictsStaleTargetKeys(t *testing.T) {
+	monitor := newPublicRouteTargetHealthMonitor()
+	t.Cleanup(func() { monitor.closeDirectHealthTransports() })
+	backend := testHealthTarget(t, 3, publicRouteTargetTransportDirect, "http://127.0.0.1:8080/base?token=secret")
+
+	first := monitor.directTransports.transport(backend, publicRouteTargetHealthCheckTimeout(backend))
+	if got := monitor.directTransports.len(); got != 1 {
+		t.Fatalf("direct health transport pool len = %d, want 1", got)
+	}
+
+	requestOnlyChange := backend
+	requestOnlyChange.HealthCheck.Path = "/ready"
+	requestOnlyChange.HealthCheck.Method = http.MethodHead
+	requestOnlyChange.UpstreamRequestHeaders = []publicRequestHeader{{Name: "X-Health", Value: "ok"}}
+	monitor.closeStaleDirectHealthTransports(requestOnlyChange)
+	if got := monitor.directTransports.len(); got != 1 {
+		t.Fatalf("pool len after request-only change = %d, want 1", got)
+	}
+	if reused := monitor.directTransports.transport(requestOnlyChange, publicRouteTargetHealthCheckTimeout(requestOnlyChange)); reused != first {
+		t.Fatal("request-only health check changes should reuse the existing transport")
+	}
+
+	timeoutChange := backend
+	timeoutChange.HealthCheck.Timeout = 2 * time.Second
+	monitor.closeStaleDirectHealthTransports(timeoutChange)
+	if got := monitor.directTransports.len(); got != 0 {
+		t.Fatalf("pool len after timeout change cleanup = %d, want 0", got)
+	}
+	second := monitor.directTransports.transport(timeoutChange, publicRouteTargetHealthCheckTimeout(timeoutChange))
+	if second == first {
+		t.Fatal("timeout change reused stale direct health transport")
+	}
+
+	originChange := timeoutChange
+	originChange.TargetOrigin = "http://127.0.0.1:8081/other?token=secret"
+	parsedOrigin, err := url.Parse(originChange.TargetOrigin)
+	if err != nil {
+		t.Fatalf("parse changed origin: %v", err)
+	}
+	originChange.ParsedOrigin = parsedOrigin
+	monitor.closeStaleDirectHealthTransports(originChange)
+	if got := monitor.directTransports.len(); got != 0 {
+		t.Fatalf("pool len after origin change cleanup = %d, want 0", got)
+	}
+
+	_ = monitor.directTransports.transport(originChange, publicRouteTargetHealthCheckTimeout(originChange))
+	monitor.closeDirectHealthTransportsForTarget(originChange.ID)
+	if got := monitor.directTransports.len(); got != 0 {
+		t.Fatalf("pool len after target cleanup = %d, want 0", got)
 	}
 }
 

--- a/internal/server/public_target_health_test.go
+++ b/internal/server/public_target_health_test.go
@@ -153,6 +153,54 @@ func TestDirectHealthTransportPoolEvictsStaleTargetKeys(t *testing.T) {
 	}
 }
 
+func TestDirectHealthGenerationPreventsStaleTransportResurrection(t *testing.T) {
+	monitor := newPublicRouteTargetHealthMonitor()
+	t.Cleanup(func() { monitor.closeDirectHealthTransports() })
+	oldTarget := testHealthTarget(t, 4, publicRouteTargetTransportDirect, "http://127.0.0.1:8080")
+	monitor.reconcile(nil, testHealthSnapshot(oldTarget), false)
+
+	monitor.mu.Lock()
+	state := monitor.states[oldTarget.ID]
+	state.directCheckRunning = true
+	state.directGeneration = 41
+	monitor.mu.Unlock()
+	_ = monitor.directTransports.transport(oldTarget, publicRouteTargetHealthCheckTimeout(oldTarget))
+
+	newTarget := oldTarget
+	newTarget.TargetOrigin = "http://127.0.0.1:8081"
+	parsedOrigin, err := url.Parse(newTarget.TargetOrigin)
+	if err != nil {
+		t.Fatalf("parse changed origin: %v", err)
+	}
+	newTarget.ParsedOrigin = parsedOrigin
+	monitor.reconcile(nil, testHealthSnapshot(newTarget), false)
+
+	if got := monitor.directTransports.len(); got != 0 {
+		t.Fatalf("pool len after reconcile = %d, want 0", got)
+	}
+	if _, _, ok := monitor.directCheckForGeneration(oldTarget.ID, 41); ok {
+		t.Fatal("stale health-loop generation remained eligible after reconcile")
+	}
+	if got := monitor.directTransports.len(); got != 0 {
+		t.Fatalf("stale generation recreated %d transports, want 0", got)
+	}
+
+	failedAttempt := newPublicRouteTargetHealthCheckAttempt(oldTarget)
+	failedAttempt.fail("request_failed", errors.New("old target failed"))
+	finishPublicRouteTargetHealthCheckAttempt(&failedAttempt)
+	monitor.recordDirectExplicitCheckForGeneration(oldTarget.ID, 41, failedAttempt)
+	monitor.mu.Lock()
+	snapshot := directHealthSnapshot(monitor.states[oldTarget.ID], true)
+	monitor.mu.Unlock()
+	if snapshot == nil || snapshot.Status != p2pstreamv1.PublicRouteTargetHealthStatus_PUBLIC_ROUTE_TARGET_HEALTH_STATUS_UNKNOWN {
+		t.Fatalf("stale result changed current health snapshot: %+v", snapshot)
+	}
+	traces, _ := monitor.listHealthTraces(oldTarget.ID, 0, 10, false)
+	if len(traces) != 0 {
+		t.Fatalf("stale result created %d traces, want 0", len(traces))
+	}
+}
+
 func TestAgentPoolHealthCheckRunsThroughAssignedAgent(t *testing.T) {
 	app := NewApp(nil, nil)
 	served := make(chan struct{})


### PR DESCRIPTION
## Summary
- add a keyed transport pool for direct target active health checks
- reuse pooled transports in the monitor loop while preserving standalone helper fallback cleanup
- close stale direct health transports when targets are removed, disabled, switched away from direct checks, or transport key fields change

Closes #120

## Tests
- go test ./internal/server -run 'TestDirect(TargetHealth|Health)|TestPublicRouteTargetHealthCheckURL|TestAgentPoolHealthCheckRunsThroughAssignedAgent|TestCancelledActiveHealthCheck|TestActiveHealthCheckTimeout' -count=1\n- go test ./internal/server -count=1\n- go test ./... -count=1