### PR TITLE
Bound agent open handshakes

### DIFF
--- a/internal/server/public_routing.go
+++ b/internal/server/public_routing.go
@@ -26,6 +26,8 @@ var errNoRouteBackendAvailable = errors.New("no route backend available")
 var errNoRouteTargetAvailable = errors.New("no route target available")
 var errNoPublicRouteAvailable = errors.New("no public route available")
 
+var agentOpenHandshakeTimeout = 10 * time.Second
+
 type publicRouteTargetHealthConfig struct {
 	ID                            int64
 	Name                          string
@@ -713,9 +715,7 @@ func (a *App) dialViaAgent(ctx context.Context, agent *AgentConn, network string
 		return nil, errAgentDisconnected
 	}
 
-	if deadline, ok := ctx.Deadline(); ok {
-		_ = conn.SetDeadline(deadline)
-	}
+	_ = conn.SetDeadline(agentOpenHandshakeDeadline(ctx, time.Now()))
 	handshakeDone := make(chan struct{})
 	stopHandshakeWatch := func() {
 		select {
@@ -737,12 +737,12 @@ func (a *App) dialViaAgent(ctx context.Context, agent *AgentConn, network string
 	req := tunnel.NewOpenRequest(requestID, network, address)
 	if err := tunnel.WriteOpenRequest(conn, req); err != nil {
 		_ = conn.Close()
-		return nil, err
+		return nil, agentOpenHandshakeError(ctx, err)
 	}
 	resp, err := tunnel.ReadOpenResponse(conn)
 	if err != nil {
 		_ = conn.Close()
-		return nil, err
+		return nil, agentOpenHandshakeError(ctx, err)
 	}
 	if !resp.OK {
 		_ = conn.Close()
@@ -756,6 +756,27 @@ func (a *App) dialViaAgent(ctx context.Context, agent *AgentConn, network string
 	}
 	_ = conn.SetDeadline(time.Time{})
 	return conn, nil
+}
+
+func agentOpenHandshakeDeadline(ctx context.Context, now time.Time) time.Time {
+	deadline := now.Add(agentOpenHandshakeTimeout)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		return ctxDeadline
+	}
+	return deadline
+}
+
+func agentOpenHandshakeError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if ctx != nil && errors.Is(ctx.Err(), context.Canceled) {
+		return err
+	}
+	if isTimeoutError(err) || (ctx != nil && errors.Is(ctx.Err(), context.DeadlineExceeded)) {
+		return agentDialError{Kind: "dial_timeout", Err: err.Error()}
+	}
+	return err
 }
 
 func redactAgentDialAddress(address string) string {

--- a/internal/server/public_routing_timeout_test.go
+++ b/internal/server/public_routing_timeout_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -237,6 +238,95 @@ func TestAgentProxyResponseTimeoutMarksPassiveFailure(t *testing.T) {
 	}
 }
 
+func TestDialViaAgentOpenHandshakeTimesOutWithoutContextDeadline(t *testing.T) {
+	withAgentOpenHandshakeTimeout(t, 25*time.Millisecond)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("upstream should not be reached before agent open response")
+	}))
+	defer upstream.Close()
+
+	app, target, agent, fake := newAgentProxyTunnelTestApp(t, 7, upstream.URL, 2*time.Second)
+	fake.suppressOpenResponse = true
+	ctx := context.Background()
+	if _, ok := ctx.Deadline(); ok {
+		t.Fatal("test context unexpectedly has a deadline")
+	}
+
+	started := time.Now()
+	conn, err := app.dialViaAgent(ctx, agent, "tcp", target.ParsedURL.Host, "request-timeout-test")
+	if conn != nil {
+		_ = conn.Close()
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("agent open handshake timeout took %s, want under 1s", elapsed)
+	}
+	var dialErr agentDialError
+	if !errors.As(err, &dialErr) || dialErr.Kind != "dial_timeout" {
+		t.Fatalf("dialViaAgent error = %T %[1]v, want agent dial_timeout", err)
+	}
+	fake.waitOpenRequestCount(t, 1)
+}
+
+func TestAgentProxyOpenHandshakeTimeoutWithoutRequestDeadline(t *testing.T) {
+	withAgentOpenHandshakeTimeout(t, 25*time.Millisecond)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("upstream should not be reached before agent open response")
+	}))
+	defer upstream.Close()
+
+	app, target, agent, fake := newAgentProxyTunnelTestApp(t, 7, upstream.URL, 2*time.Second)
+	fake.suppressOpenResponse = true
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://public.test/agent", nil)
+	if _, ok := req.Context().Deadline(); ok {
+		t.Fatal("test request unexpectedly has a context deadline")
+	}
+
+	started := time.Now()
+	proxyAgentTargetForTest(app, rec, req, target, agent)
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("agent open handshake timeout took %s, want under 1s", elapsed)
+	}
+
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("open handshake timeout status = %d body=%q, want 504", rec.Code, rec.Body.String())
+	}
+	waitForAgentActiveRequests(t, agent, 0)
+	fake.waitOpenRequestCount(t, 1)
+	if app.TargetHealth.agentAvailable(target.ID, agent.AgentID) {
+		t.Fatal("agent open handshake timeout should make the agent unavailable during passive cooldown")
+	}
+	traces, _ := app.TargetHealth.listHealthTraces(target.ID, agent.AgentID, 10, false)
+	if len(traces) == 0 ||
+		traces[0].ErrorKind != "passive_failure" ||
+		!strings.Contains(traces[0].Error, "dial_timeout") {
+		t.Fatalf("latest trace = %+v, want passive dial_timeout failure", traces)
+	}
+}
+
+func TestAgentOpenHandshakeDeadlineUsesEarlierRequestDeadline(t *testing.T) {
+	withAgentOpenHandshakeTimeout(t, 10*time.Second)
+	now := time.Now()
+
+	if got, want := agentOpenHandshakeDeadline(context.Background(), now), now.Add(10*time.Second); !got.Equal(want) {
+		t.Fatalf("handshake deadline without context deadline = %s, want %s", got, want)
+	}
+
+	earlier := now.Add(time.Second)
+	earlierCtx, cancelEarlier := context.WithDeadline(context.Background(), earlier)
+	defer cancelEarlier()
+	if got := agentOpenHandshakeDeadline(earlierCtx, now); !got.Equal(earlier) {
+		t.Fatalf("handshake deadline with earlier context = %s, want %s", got, earlier)
+	}
+
+	later := now.Add(time.Minute)
+	laterCtx, cancelLater := context.WithDeadline(context.Background(), later)
+	defer cancelLater()
+	if got, want := agentOpenHandshakeDeadline(laterCtx, now), now.Add(10*time.Second); !got.Equal(want) {
+		t.Fatalf("handshake deadline with later context = %s, want %s", got, want)
+	}
+}
+
 func TestAgentProxyClosedSessionMarksPassiveFailure(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("should not be reached"))
@@ -349,13 +439,14 @@ func newAgentProxyTunnelTestApp(t *testing.T, agentID int64, upstreamURL string,
 }
 
 type fakeYamuxAgent struct {
-	serverSession *yamux.Session
-	agentSession  *yamux.Session
-	requests      chan tunnel.OpenRequest
-	mu            sync.Mutex
-	openRequests  int
-	wg            sync.WaitGroup
-	closeOnce     sync.Once
+	serverSession        *yamux.Session
+	agentSession         *yamux.Session
+	requests             chan tunnel.OpenRequest
+	suppressOpenResponse bool
+	mu                   sync.Mutex
+	openRequests         int
+	wg                   sync.WaitGroup
+	closeOnce            sync.Once
 }
 
 func newFakeYamuxAgent(t *testing.T, agentID int64, publicID string) (*AgentConn, *fakeYamuxAgent) {
@@ -434,6 +525,10 @@ func (f *fakeYamuxAgent) handleStream(stream net.Conn) {
 	case f.requests <- open:
 	default:
 	}
+	if f.suppressOpenResponse {
+		_, _ = io.Copy(io.Discard, stream)
+		return
+	}
 	upstream, err := (&net.Dialer{}).DialContext(context.Background(), open.Network, open.Address)
 	if err != nil {
 		_ = tunnel.WriteOpenResponse(stream, tunnel.OpenResponse{OK: false, ErrorKind: "dial_failed", Error: err.Error()})
@@ -475,6 +570,15 @@ func (f *fakeYamuxAgent) waitOpenRequestCount(t *testing.T, want int) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("fake yamux open requests = %d, want %d", f.openRequestCount(), want)
+}
+
+func withAgentOpenHandshakeTimeout(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	previous := agentOpenHandshakeTimeout
+	agentOpenHandshakeTimeout = timeout
+	t.Cleanup(func() {
+		agentOpenHandshakeTimeout = previous
+	})
 }
 
 func waitForAgentActiveRequests(t *testing.T, agent *AgentConn, want int64) {


### PR DESCRIPTION
## Summary
- add a fixed 10s server-side deadline around the agent open request/response handshake
- preserve earlier request context deadlines and return handshake timeouts as agent dial timeouts
- extend tunnel timeout tests with a silent fake agent covering direct dial and proxy behavior without request deadlines

Closes #121

## Tests
- go test ./internal/server -run 'Test(DialViaAgentOpenHandshake|AgentProxy(OpenHandshake|ResponseTimeout|ClosedSession|RelaysThroughYamuxTunnel)|AgentOpenHandshakeDeadline|AgentTransportPool)' -count=1\n- go test ./internal/server -count=1\n- go test ./... -count=1