### PR TITLE
Use ECDSA generated TLS certificates

### DIFF
--- a/internal/server/management_tls.go
+++ b/internal/server/management_tls.go
@@ -1,8 +1,8 @@
 package server
 
 import (
+	"crypto"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
@@ -192,7 +192,7 @@ func managementCertBaseDir(cfg *config.Config) string {
 	return filepath.Join(filepath.Clean(configDir), "certs")
 }
 
-func loadOrCreateManagementCA(certFile string, keyFile string) ([]byte, []byte, *x509.Certificate, *rsa.PrivateKey, error) {
+func loadOrCreateManagementCA(certFile string, keyFile string) ([]byte, []byte, *x509.Certificate, crypto.Signer, error) {
 	if certPEM, certErr := os.ReadFile(certFile); certErr == nil {
 		if keyPEM, keyErr := os.ReadFile(keyFile); keyErr == nil {
 			cert, key, err := parseManagementCA(certPEM, keyPEM)
@@ -215,7 +215,7 @@ func loadOrCreateManagementCA(certFile string, keyFile string) ([]byte, []byte, 
 	return certPEM, keyPEM, cert, key, nil
 }
 
-func parseManagementCA(certPEM []byte, keyPEM []byte) (*x509.Certificate, *rsa.PrivateKey, error) {
+func parseManagementCA(certPEM []byte, keyPEM []byte) (*x509.Certificate, crypto.Signer, error) {
 	certBlock, _ := pem.Decode(certPEM)
 	if certBlock == nil {
 		return nil, nil, fmt.Errorf("management CA certificate is not PEM")
@@ -228,7 +228,7 @@ func parseManagementCA(certPEM []byte, keyPEM []byte) (*x509.Certificate, *rsa.P
 	if keyBlock == nil {
 		return nil, nil, fmt.Errorf("management CA key is not PEM")
 	}
-	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	key, err := parseManagementPrivateKey(keyBlock)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -238,8 +238,29 @@ func parseManagementCA(certPEM []byte, keyPEM []byte) (*x509.Certificate, *rsa.P
 	return cert, key, nil
 }
 
-func generateManagementCAPEM() ([]byte, []byte, *x509.Certificate, *rsa.PrivateKey, error) {
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
+func parseManagementPrivateKey(block *pem.Block) (crypto.Signer, error) {
+	switch block.Type {
+	case "RSA PRIVATE KEY":
+		return x509.ParsePKCS1PrivateKey(block.Bytes)
+	case "EC PRIVATE KEY":
+		return x509.ParseECPrivateKey(block.Bytes)
+	case "PRIVATE KEY":
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		signer, ok := key.(crypto.Signer)
+		if !ok {
+			return nil, fmt.Errorf("management CA private key is %T, want signing key", key)
+		}
+		return signer, nil
+	default:
+		return nil, fmt.Errorf("unsupported management CA private key PEM type %q", block.Type)
+	}
+}
+
+func generateManagementCAPEM() ([]byte, []byte, *x509.Certificate, crypto.Signer, error) {
+	key, keyPEM, err := generateECDSAPrivateKeyPEM()
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -263,14 +284,14 @@ func generateManagementCAPEM() ([]byte, []byte, *x509.Certificate, *rsa.PrivateK
 		return nil, nil, nil, nil, err
 	}
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
-		pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}),
+		keyPEM,
 		cert,
 		key,
 		nil
 }
 
-func generateManagementServerCertificatePEM(caCert *x509.Certificate, caKey *rsa.PrivateKey, hosts []string) ([]byte, []byte, error) {
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
+func generateManagementServerCertificatePEM(caCert *x509.Certificate, caKey crypto.Signer, hosts []string) ([]byte, []byte, error) {
+	key, keyPEM, err := generateECDSAPrivateKeyPEM()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -280,7 +301,7 @@ func generateManagementServerCertificatePEM(caCert *x509.Certificate, caKey *rsa
 		Subject:               pkix.Name{CommonName: "p2pstream management"},
 		NotBefore:             now.Add(-time.Minute),
 		NotAfter:              now.Add(10 * 365 * 24 * time.Hour),
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 	}
@@ -296,7 +317,7 @@ func generateManagementServerCertificatePEM(caCert *x509.Certificate, caKey *rsa
 		return nil, nil, err
 	}
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
-		pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}),
+		keyPEM,
 		nil
 }
 
@@ -467,11 +488,15 @@ func writePEMFile(path string, contents []byte, mode os.FileMode) error {
 
 func randomSerialNumber() *big.Int {
 	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
-	serial, err := rand.Int(rand.Reader, serialLimit)
-	if err != nil {
-		return big.NewInt(time.Now().UnixNano())
+	for {
+		serial, err := rand.Int(rand.Reader, serialLimit)
+		if err != nil {
+			return big.NewInt(time.Now().UnixNano())
+		}
+		if serial.Sign() > 0 {
+			return serial
+		}
 	}
-	return serial
 }
 
 func managementCAPEMSHA256(caPEM string) string {

--- a/internal/server/management_tls_test.go
+++ b/internal/server/management_tls_test.go
@@ -50,10 +50,23 @@ func TestNewManagementTLSConfigAutoGeneratesVerifiableCertificate(t *testing.T) 
 	if !roots.AppendCertsFromPEM([]byte(cfg.ManagementCAPEM)) {
 		t.Fatal("management CA PEM did not parse")
 	}
+	caCert, err := parseLeafCertificate([]byte(cfg.ManagementCAPEM))
+	if err != nil {
+		t.Fatalf("parse management CA certificate: %v", err)
+	}
+	assertECDSAP256Certificate(t, caCert)
+
 	cert, err := x509.ParseCertificate(tlsConfig.Certificates[0].Certificate[0])
 	if err != nil {
 		t.Fatalf("parse server certificate: %v", err)
 	}
+	assertECDSAP256Certificate(t, cert)
+	keyPEM, err := os.ReadFile(filepath.Join(cfg.CertsDir, "management", "server.key.pem"))
+	if err != nil {
+		t.Fatalf("read generated management key: %v", err)
+	}
+	assertECDSAP256PrivateKeyPEM(t, keyPEM)
+
 	for _, host := range []string{"10.42.0.5", "localhost", "server", "p2pstream.local", "example.test", "192.0.2.10"} {
 		if _, err := cert.Verify(x509.VerifyOptions{Roots: roots, DNSName: host}); err != nil {
 			t.Fatalf("generated management certificate did not verify for %s: %v", host, err)

--- a/internal/server/public_tls.go
+++ b/internal/server/public_tls.go
@@ -1,18 +1,19 @@
 package server
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
-	"math/big"
 	"net"
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -31,6 +32,13 @@ type publicWildcardCertificate struct {
 	suffix  string
 	cert    *tls.Certificate
 }
+
+var publicFallbackCertificateCache = struct {
+	sync.Mutex
+	cert *tls.Certificate
+}{}
+
+const publicFallbackCertificateRenewBefore = time.Minute
 
 func newPublicTLSConfig(listenerID int64, snap *publicProxySnapshot, acmeManager *publicACMEManager) (*tls.Config, error) {
 	tlsConfig, _, err := newPublicTLSConfigWithSelectorStore(listenerID, snap, acmeManager)
@@ -91,6 +99,9 @@ func (s *publicTLSSelectorStore) fallbackCertificate() *tls.Certificate {
 	if selector == nil {
 		return nil
 	}
+	if !publicFallbackCertificateFresh(selector.fallback, time.Now()) {
+		return nil
+	}
 	return selector.fallback
 }
 
@@ -132,7 +143,7 @@ func newPublicTLSSelector(listenerID int64, snap *publicProxySnapshot, acmeManag
 
 	if fallback == nil {
 		var err error
-		fallback, err = generateFallbackCertificate()
+		fallback, err = cachedFallbackCertificate()
 		if err != nil {
 			return nil, err
 		}
@@ -172,6 +183,20 @@ func clientSupportsALPN(hello *tls.ClientHelloInfo, proto string) bool {
 	return false
 }
 
+func cachedFallbackCertificate() (*tls.Certificate, error) {
+	publicFallbackCertificateCache.Lock()
+	defer publicFallbackCertificateCache.Unlock()
+	if publicFallbackCertificateFresh(publicFallbackCertificateCache.cert, time.Now()) {
+		return publicFallbackCertificateCache.cert, nil
+	}
+	cert, err := generateFallbackCertificate()
+	if err != nil {
+		return nil, err
+	}
+	publicFallbackCertificateCache.cert = cert
+	return cert, nil
+}
+
 func generateFallbackCertificate() (*tls.Certificate, error) {
 	certPEM, keyPEM, err := generateSelfSignedCertificatePEM(24 * time.Hour)
 	if err != nil {
@@ -181,7 +206,27 @@ func generateFallbackCertificate() (*tls.Certificate, error) {
 	if err != nil {
 		return nil, err
 	}
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return nil, err
+	}
+	cert.Leaf = leaf
 	return &cert, nil
+}
+
+func publicFallbackCertificateFresh(cert *tls.Certificate, now time.Time) bool {
+	if cert == nil || len(cert.Certificate) == 0 {
+		return false
+	}
+	leaf := cert.Leaf
+	if leaf == nil {
+		parsed, err := x509.ParseCertificate(cert.Certificate[0])
+		if err != nil {
+			return false
+		}
+		leaf = parsed
+	}
+	return leaf.NotAfter.After(now.Add(publicFallbackCertificateRenewBefore))
 }
 
 func generateManagedSelfSignedCertificatePEM() ([]byte, []byte, error) {
@@ -193,26 +238,20 @@ func generatePublicSelfSignedCertificatePEM(hostnamePattern string, validFor tim
 	if hostnamePattern == "" {
 		return nil, nil, nil, errors.New("hostname pattern is required")
 	}
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
-	serial, err := rand.Int(rand.Reader, serialLimit)
+	key, keyPEM, err := generateECDSAPrivateKeyPEM()
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
 	now := time.Now().UTC()
 	template := &x509.Certificate{
-		SerialNumber: serial,
+		SerialNumber: randomSerialNumber(),
 		Subject: pkix.Name{
 			CommonName: hostnamePattern,
 		},
 		NotBefore:             now.Add(-time.Minute),
 		NotAfter:              now.Add(validFor),
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 	}
@@ -232,31 +271,24 @@ func generatePublicSelfSignedCertificatePEM(hostnamePattern string, validFor tim
 	}
 
 	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
 	return certPEM, keyPEM, cert, nil
 }
 
 func generateSelfSignedCertificatePEM(validFor time.Duration) ([]byte, []byte, error) {
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
-	serial, err := rand.Int(rand.Reader, serialLimit)
+	key, keyPEM, err := generateECDSAPrivateKeyPEM()
 	if err != nil {
 		return nil, nil, err
 	}
 
 	now := time.Now()
 	template := &x509.Certificate{
-		SerialNumber: serial,
+		SerialNumber: randomSerialNumber(),
 		Subject: pkix.Name{
 			CommonName: "p2pstream.local",
 		},
 		NotBefore:             now.Add(-time.Minute),
 		NotAfter:              now.Add(validFor),
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 		DNSNames:              []string{"localhost", "p2pstream.local"},
@@ -272,6 +304,17 @@ func generateSelfSignedCertificatePEM(validFor time.Duration) ([]byte, []byte, e
 	}
 
 	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
 	return certPEM, keyPEM, nil
+}
+
+func generateECDSAPrivateKeyPEM() (*ecdsa.PrivateKey, []byte, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	return key, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), nil
 }

--- a/internal/server/public_tls_test.go
+++ b/internal/server/public_tls_test.go
@@ -2,7 +2,11 @@ package server
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -50,6 +54,115 @@ func TestPublicTLSSelectorRefreshesRunningListenerWithoutRestart(t *testing.T) {
 	}
 }
 
+func TestPublicTLSFallbackCertificateIsCachedAcrossConfigBuilds(t *testing.T) {
+	snap := &publicProxySnapshot{
+		Listeners: map[int64]publicListenerConfig{
+			1: {
+				ID:       1,
+				Name:     "https",
+				Protocol: publicListenerProtocolHTTPS,
+				Enabled:  true,
+			},
+		},
+		RouteTargets:     map[int64]publicRouteTargetConfig{},
+		RoutesByListener: map[int64][]publicRouteConfig{},
+		CertsByListener:  map[int64][]publicTLSCertificateConfig{},
+	}
+
+	firstConfig, err := newPublicTLSConfig(1, snap, nil)
+	if err != nil {
+		t.Fatalf("first newPublicTLSConfig() error = %v", err)
+	}
+	secondConfig, err := newPublicTLSConfig(1, snap, nil)
+	if err != nil {
+		t.Fatalf("second newPublicTLSConfig() error = %v", err)
+	}
+
+	first, err := firstConfig.GetCertificate(&tls.ClientHelloInfo{ServerName: "unknown.example.com"})
+	if err != nil {
+		t.Fatalf("first fallback GetCertificate() error = %v", err)
+	}
+	second, err := secondConfig.GetCertificate(&tls.ClientHelloInfo{ServerName: "another.example.com"})
+	if err != nil {
+		t.Fatalf("second fallback GetCertificate() error = %v", err)
+	}
+	if first == nil || second == nil || len(first.Certificate) == 0 || len(second.Certificate) == 0 {
+		t.Fatalf("missing fallback certificates: first=%+v second=%+v", first, second)
+	}
+	if !bytes.Equal(first.Certificate[0], second.Certificate[0]) {
+		t.Fatal("fallback certificate was regenerated across public TLS config builds")
+	}
+	assertECDSAP256CertificateDER(t, first.Certificate[0])
+}
+
+func TestPublicTLSSelectorRefreshPreservesFallbackCertificate(t *testing.T) {
+	snap := publicTLSFallbackOnlySnapshot(1)
+	tlsConfig, selector, err := newPublicTLSConfigWithSelectorStore(1, snap, nil)
+	if err != nil {
+		t.Fatalf("newPublicTLSConfigWithSelectorStore() error = %v", err)
+	}
+	first, err := tlsConfig.GetCertificate(&tls.ClientHelloInfo{ServerName: "unknown.example.com"})
+	if err != nil {
+		t.Fatalf("first fallback GetCertificate() error = %v", err)
+	}
+	if err := selector.refresh(1, snap, nil); err != nil {
+		t.Fatalf("selector refresh error = %v", err)
+	}
+	second, err := tlsConfig.GetCertificate(&tls.ClientHelloInfo{ServerName: "unknown.example.com"})
+	if err != nil {
+		t.Fatalf("second fallback GetCertificate() error = %v", err)
+	}
+	if first == nil || second == nil || len(first.Certificate) == 0 || len(second.Certificate) == 0 {
+		t.Fatalf("missing fallback certificates: first=%+v second=%+v", first, second)
+	}
+	if !bytes.Equal(first.Certificate[0], second.Certificate[0]) {
+		t.Fatal("fallback certificate changed during selector refresh")
+	}
+}
+
+func TestGeneratedPublicTLSCertificatesUseECDSAP256(t *testing.T) {
+	certPEM, keyPEM, err := generateSelfSignedCertificatePEM(time.Hour)
+	if err != nil {
+		t.Fatalf("generate fallback certificate PEM: %v", err)
+	}
+	cert, err := parseLeafCertificate(certPEM)
+	if err != nil {
+		t.Fatalf("parse fallback certificate: %v", err)
+	}
+	assertECDSAP256Certificate(t, cert)
+	assertECDSAP256PrivateKeyPEM(t, keyPEM)
+
+	certPEM, keyPEM, err = generateManagedSelfSignedCertificatePEM()
+	if err != nil {
+		t.Fatalf("generate managed certificate PEM: %v", err)
+	}
+	cert, err = parseLeafCertificate(certPEM)
+	if err != nil {
+		t.Fatalf("parse managed certificate: %v", err)
+	}
+	assertECDSAP256Certificate(t, cert)
+	assertECDSAP256PrivateKeyPEM(t, keyPEM)
+
+	certPEM, keyPEM, cert, err = generatePublicSelfSignedCertificatePEM("public.example.com", time.Hour)
+	if err != nil {
+		t.Fatalf("generate public certificate PEM: %v", err)
+	}
+	if _, err := tls.X509KeyPair(certPEM, keyPEM); err != nil {
+		t.Fatalf("generated public certificate key pair did not load: %v", err)
+	}
+	assertECDSAP256Certificate(t, cert)
+	assertECDSAP256PrivateKeyPEM(t, keyPEM)
+
+	fallback, err := generateFallbackCertificate()
+	if err != nil {
+		t.Fatalf("generate fallback certificate: %v", err)
+	}
+	if fallback == nil || len(fallback.Certificate) == 0 {
+		t.Fatalf("missing fallback certificate: %+v", fallback)
+	}
+	assertECDSAP256CertificateDER(t, fallback.Certificate[0])
+}
+
 func testPublicTLSSnapshot(t *testing.T, listenerID int64, hostname string, name string) (*publicProxySnapshot, []byte) {
 	t.Helper()
 	certPEM, keyPEM, leaf, err := generatePublicSelfSignedCertificatePEM(hostname, time.Hour)
@@ -89,6 +202,71 @@ func testPublicTLSSnapshot(t *testing.T, listenerID int64, hostname string, name
 			}},
 		},
 	}, leaf.Raw
+}
+
+func publicTLSFallbackOnlySnapshot(listenerID int64) *publicProxySnapshot {
+	return &publicProxySnapshot{
+		Listeners: map[int64]publicListenerConfig{
+			listenerID: {
+				ID:       listenerID,
+				Name:     "https",
+				Protocol: publicListenerProtocolHTTPS,
+				Enabled:  true,
+			},
+		},
+		RouteTargets:     map[int64]publicRouteTargetConfig{},
+		RoutesByListener: map[int64][]publicRouteConfig{},
+		CertsByListener:  map[int64][]publicTLSCertificateConfig{},
+	}
+}
+
+func assertECDSAP256CertificateDER(t *testing.T, der []byte) {
+	t.Helper()
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse certificate DER: %v", err)
+	}
+	assertECDSAP256Certificate(t, cert)
+}
+
+func assertECDSAP256Certificate(t *testing.T, cert *x509.Certificate) {
+	t.Helper()
+	if cert.SerialNumber == nil || cert.SerialNumber.Sign() <= 0 {
+		t.Fatalf("certificate serial = %v, want positive non-zero", cert.SerialNumber)
+	}
+	if cert.PublicKeyAlgorithm != x509.ECDSA {
+		t.Fatalf("certificate public key algorithm = %s, want ECDSA", cert.PublicKeyAlgorithm)
+	}
+	publicKey, ok := cert.PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		t.Fatalf("certificate public key is %T, want *ecdsa.PublicKey", cert.PublicKey)
+	}
+	if publicKey.Curve != elliptic.P256() {
+		t.Fatalf("certificate curve = %v, want P-256", publicKey.Curve)
+	}
+	if !cert.IsCA {
+		if cert.KeyUsage&x509.KeyUsageDigitalSignature == 0 {
+			t.Fatalf("certificate key usage = %v, want digital signature", cert.KeyUsage)
+		}
+		if cert.KeyUsage&x509.KeyUsageKeyEncipherment != 0 {
+			t.Fatalf("certificate key usage = %v, did not expect key encipherment for ECDSA", cert.KeyUsage)
+		}
+	}
+}
+
+func assertECDSAP256PrivateKeyPEM(t *testing.T, keyPEM []byte) {
+	t.Helper()
+	block, _ := pem.Decode(keyPEM)
+	if block == nil {
+		t.Fatal("private key PEM did not parse")
+	}
+	key, err := x509.ParseECPrivateKey(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse EC private key: %v", err)
+	}
+	if key.Curve != elliptic.P256() {
+		t.Fatalf("private key curve = %v, want P-256", key.Curve)
+	}
 }
 
 func assertPublicTLSCertificateDER(t *testing.T, tlsConfig *tls.Config, hostname string, want []byte) {


### PR DESCRIPTION
## Summary
- switch generated public/fallback/self-signed and auto-management TLS certificates to ECDSA P-256
- cache the public fallback certificate process-wide while it remains fresh instead of regenerating on every TLS config build
- keep existing RSA management CA files loadable while generating new management CA/server certs as ECDSA
- assert generated cert key type, key usage, serials, and fallback reuse in focused tests

Closes #122

## Tests
- go test ./internal/server -run 'Test(PublicTLS|GeneratedPublicTLS|NewManagementTLS)' -count=1\n- go test ./internal/server -count=1\n- go test ./... -count=1