### PR TITLE
Bound agent-side tunnel open handling

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -335,6 +336,12 @@ func connectAndServe(client *http.Client, tunnelURL string, agentPublicID string
 }
 
 func serveTunnelSession(ctx context.Context, session *yamux.Session) error {
+	var handlers sync.WaitGroup
+	defer func() {
+		_ = session.Close()
+		handlers.Wait()
+	}()
+
 	for {
 		stream, err := session.Accept()
 		if err != nil {
@@ -345,7 +352,11 @@ func serveTunnelSession(ctx context.Context, session *yamux.Session) error {
 			log.Debug().Err(err).Msg("Tunnel stream accept loop stopped")
 			return fmt.Errorf("accept tunnel stream: %w", err)
 		}
-		go handleTunnelStream(ctx, stream)
+		handlers.Add(1)
+		go func(stream net.Conn) {
+			defer handlers.Done()
+			handleTunnelStream(ctx, stream)
+		}(stream)
 	}
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -43,6 +43,9 @@ var (
 	agentStableConnectionInterval = 20 * time.Second
 	agentReconnectBackoffMin      = time.Second
 	agentReconnectBackoffMax      = 30 * time.Second
+	agentTunnelOpenRequestTimeout = 10 * time.Second
+	agentTunnelDialTimeout        = 10 * time.Second
+	agentTunnelDialNetwork        = dialTunnelNetwork
 )
 
 const agentTunnelResponseHeaderTimeout = 15 * time.Second
@@ -349,7 +352,9 @@ func serveTunnelSession(ctx context.Context, session *yamux.Session) error {
 func handleTunnelStream(ctx context.Context, stream net.Conn) {
 	defer stream.Close()
 
+	setTunnelOpenRequestReadDeadline(stream)
 	openReq, err := tunnel.ReadOpenRequest(stream)
+	clearTunnelOpenRequestReadDeadline(stream)
 	if err != nil {
 		kind := tunnelOpenRequestErrorKind(err)
 		reqInternalError.Add(1)
@@ -370,8 +375,7 @@ func handleTunnelStream(ctx context.Context, stream net.Conn) {
 	activeRequests.Add(1)
 	defer activeRequests.Add(-1)
 
-	dialer := net.Dialer{}
-	upstream, err := dialer.DialContext(ctx, openReq.Network, openReq.Address)
+	upstream, err := dialTunnelDestination(ctx, openReq.Network, openReq.Address)
 	if err != nil {
 		kind := tunnelDialErrorKind(err)
 		reqInternalError.Add(1)
@@ -411,6 +415,35 @@ func handleTunnelStream(ctx context.Context, stream net.Conn) {
 	reqSuccess.Add(1)
 }
 
+func setTunnelOpenRequestReadDeadline(conn net.Conn) {
+	if agentTunnelOpenRequestTimeout <= 0 {
+		return
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(agentTunnelOpenRequestTimeout))
+}
+
+func clearTunnelOpenRequestReadDeadline(conn net.Conn) {
+	_ = conn.SetReadDeadline(time.Time{})
+}
+
+func dialTunnelDestination(ctx context.Context, network string, address string) (net.Conn, error) {
+	if agentTunnelDialTimeout <= 0 {
+		return agentTunnelDialNetwork(ctx, network, address)
+	}
+	dialCtx, cancel := context.WithTimeout(ctx, agentTunnelDialTimeout)
+	defer cancel()
+	return agentTunnelDialNetwork(dialCtx, network, address)
+}
+
+func dialTunnelNetwork(ctx context.Context, network string, address string) (net.Conn, error) {
+	dialer := agentTunnelDialer()
+	return dialer.DialContext(ctx, network, address)
+}
+
+func agentTunnelDialer() net.Dialer {
+	return net.Dialer{Timeout: agentTunnelDialTimeout}
+}
+
 func tunnelDialErrorKind(err error) string {
 	if isTimeoutError(err) {
 		return "dial_timeout"
@@ -421,6 +454,9 @@ func tunnelDialErrorKind(err error) string {
 func tunnelOpenRequestErrorKind(err error) string {
 	if errors.Is(err, tunnel.ErrUnsupportedVersion) {
 		return "unsupported_version"
+	}
+	if isTimeoutError(err) {
+		return "open_request_timeout"
 	}
 	return "invalid_open_request"
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -43,7 +43,6 @@ func TestAgentReconnectBackoffBounds(t *testing.T) {
 
 func TestTunnelSessionRelaysTCPStream(t *testing.T) {
 	resetAgentRequestCounters()
-	t.Cleanup(resetAgentRequestCounters)
 
 	upstream := startEchoListener(t)
 	clientConn, serverConn := net.Pipe()
@@ -58,12 +57,7 @@ func TestTunnelSessionRelaysTCPStream(t *testing.T) {
 	defer agentSession.Close()
 	defer serverSession.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	serveDone := make(chan error, 1)
-	go func() {
-		serveDone <- serveTunnelSession(ctx, agentSession)
-	}()
+	startTestTunnelSession(t, agentSession)
 
 	stream, err := serverSession.Open()
 	if err != nil {
@@ -90,19 +84,10 @@ func TestTunnelSessionRelaysTCPStream(t *testing.T) {
 	if string(buf) != "ping" {
 		t.Fatalf("echo = %q, want ping", buf)
 	}
-
-	cancel()
-	agentSession.Close()
-	select {
-	case <-serveDone:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for tunnel session to stop")
-	}
 }
 
 func TestTunnelSessionReturnsDialFailure(t *testing.T) {
 	resetAgentRequestCounters()
-	t.Cleanup(resetAgentRequestCounters)
 
 	clientConn, serverConn := net.Pipe()
 	agentSession, err := yamux.Client(clientConn, tunnel.DefaultYamuxConfig(nil))
@@ -116,11 +101,7 @@ func TestTunnelSessionReturnsDialFailure(t *testing.T) {
 	defer agentSession.Close()
 	defer serverSession.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		_ = serveTunnelSession(ctx, agentSession)
-	}()
+	startTestTunnelSession(t, agentSession)
 
 	stream, err := serverSession.Open()
 	if err != nil {
@@ -141,7 +122,6 @@ func TestTunnelSessionReturnsDialFailure(t *testing.T) {
 
 func TestTunnelSessionOpenRequestReadDeadlineKeepsSessionUsable(t *testing.T) {
 	resetAgentRequestCounters()
-	t.Cleanup(resetAgentRequestCounters)
 	withAgentTunnelOpenRequestTimeout(t, 25*time.Millisecond)
 
 	upstream := startEchoListener(t)
@@ -157,11 +137,7 @@ func TestTunnelSessionOpenRequestReadDeadlineKeepsSessionUsable(t *testing.T) {
 	defer agentSession.Close()
 	defer serverSession.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		_ = serveTunnelSession(ctx, agentSession)
-	}()
+	startTestTunnelSession(t, agentSession)
 
 	silent, err := serverSession.Open()
 	if err != nil {
@@ -226,7 +202,6 @@ func TestTunnelSessionOpenRequestReadDeadlineKeepsSessionUsable(t *testing.T) {
 
 func TestTunnelSessionDialTimeoutReturnsDialTimeout(t *testing.T) {
 	resetAgentRequestCounters()
-	t.Cleanup(resetAgentRequestCounters)
 	withAgentTunnelDialTimeout(t, 25*time.Millisecond)
 
 	clientConn, serverConn := net.Pipe()
@@ -242,12 +217,6 @@ func TestTunnelSessionDialTimeoutReturnsDialTimeout(t *testing.T) {
 	defer serverSession.Close()
 
 	upstream := startEchoListener(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		_ = serveTunnelSession(ctx, agentSession)
-	}()
-
 	var dialNetwork string
 	var dialAddress string
 	restoreDial := replaceAgentTunnelDialContext(func(ctx context.Context, network string, address string) (net.Conn, error) {
@@ -257,6 +226,7 @@ func TestTunnelSessionDialTimeoutReturnsDialTimeout(t *testing.T) {
 		return nil, ctx.Err()
 	})
 	t.Cleanup(restoreDial)
+	startTestTunnelSession(t, agentSession)
 
 	timeoutStream, err := serverSession.Open()
 	if err != nil {
@@ -305,7 +275,6 @@ func TestAgentTunnelDialerUsesConfiguredTimeout(t *testing.T) {
 
 func TestTunnelSessionInvalidOpenRequestKeepsSessionUsable(t *testing.T) {
 	resetAgentRequestCounters()
-	t.Cleanup(resetAgentRequestCounters)
 
 	upstream := startEchoListener(t)
 	clientConn, serverConn := net.Pipe()
@@ -320,11 +289,7 @@ func TestTunnelSessionInvalidOpenRequestKeepsSessionUsable(t *testing.T) {
 	defer agentSession.Close()
 	defer serverSession.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		_ = serveTunnelSession(ctx, agentSession)
-	}()
+	startTestTunnelSession(t, agentSession)
 
 	unsupported, err := serverSession.Open()
 	if err != nil {
@@ -409,6 +374,85 @@ func TestTunnelSessionReturnsWhenSessionCloses(t *testing.T) {
 	}
 }
 
+func TestTunnelSessionWaitsForAcceptedHandlerOnSessionClose(t *testing.T) {
+	resetAgentRequestCounters()
+
+	clientConn, serverConn := net.Pipe()
+	agentSession, err := yamux.Client(clientConn, tunnel.DefaultYamuxConfig(nil))
+	if err != nil {
+		t.Fatalf("agent yamux client: %v", err)
+	}
+	serverSession, err := yamux.Server(serverConn, tunnel.DefaultYamuxConfig(nil))
+	if err != nil {
+		_ = agentSession.Close()
+		t.Fatalf("server yamux session: %v", err)
+	}
+
+	dialStarted := make(chan struct{})
+	releaseDial := make(chan struct{})
+	released := false
+	release := func() {
+		if released {
+			return
+		}
+		released = true
+		close(releaseDial)
+	}
+	restoreDial := replaceAgentTunnelDialContext(func(context.Context, string, string) (net.Conn, error) {
+		close(dialStarted)
+		<-releaseDial
+		return nil, context.Canceled
+	})
+	t.Cleanup(restoreDial)
+
+	serveDone := make(chan struct{})
+	go func() {
+		_ = serveTunnelSession(context.Background(), agentSession)
+		close(serveDone)
+	}()
+	t.Cleanup(func() {
+		defer resetAgentRequestCounters()
+		release()
+		_ = agentSession.Close()
+		_ = serverSession.Close()
+		select {
+		case <-serveDone:
+		case <-time.After(2 * time.Second):
+			t.Error("timed out waiting for tunnel session handlers to stop")
+		}
+		waitForAgentActiveRequests(t, 0)
+	})
+
+	stream, err := serverSession.Open()
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	if err := tunnel.WriteOpenRequest(stream, tunnel.NewOpenRequest("req-blocked", "tcp", "127.0.0.1:1")); err != nil {
+		t.Fatalf("write open request: %v", err)
+	}
+	select {
+	case <-dialStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for tunnel handler to start")
+	}
+	waitForAgentActiveRequests(t, 1)
+
+	_ = agentSession.Close()
+	select {
+	case <-serveDone:
+		t.Fatal("tunnel session returned before its accepted handler stopped")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	release()
+	select {
+	case <-serveDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for tunnel session after handler stopped")
+	}
+	waitForAgentActiveRequests(t, 0)
+}
+
 func writeMalformedControlFrame(w io.Writer) error {
 	var header [4]byte
 	binary.BigEndian.PutUint32(header[:], 1)
@@ -439,6 +483,28 @@ func startEchoListener(t *testing.T) net.Listener {
 		}
 	}()
 	return ln
+}
+
+func startTestTunnelSession(t *testing.T, agentSession *yamux.Session) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- serveTunnelSession(ctx, agentSession)
+	}()
+
+	t.Cleanup(func() {
+		defer resetAgentRequestCounters()
+		cancel()
+		_ = agentSession.Close()
+		select {
+		case <-serveDone:
+		case <-time.After(2 * time.Second):
+			t.Error("timed out waiting for tunnel session to stop")
+		}
+		waitForAgentActiveRequests(t, 0)
+	})
 }
 
 func resetAgentRequestCounters() {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -139,6 +139,170 @@ func TestTunnelSessionReturnsDialFailure(t *testing.T) {
 	}
 }
 
+func TestTunnelSessionOpenRequestReadDeadlineKeepsSessionUsable(t *testing.T) {
+	resetAgentRequestCounters()
+	t.Cleanup(resetAgentRequestCounters)
+	withAgentTunnelOpenRequestTimeout(t, 25*time.Millisecond)
+
+	upstream := startEchoListener(t)
+	clientConn, serverConn := net.Pipe()
+	agentSession, err := yamux.Client(clientConn, tunnel.DefaultYamuxConfig(nil))
+	if err != nil {
+		t.Fatalf("agent yamux client: %v", err)
+	}
+	serverSession, err := yamux.Server(serverConn, tunnel.DefaultYamuxConfig(nil))
+	if err != nil {
+		t.Fatalf("server yamux session: %v", err)
+	}
+	defer agentSession.Close()
+	defer serverSession.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_ = serveTunnelSession(ctx, agentSession)
+	}()
+
+	silent, err := serverSession.Open()
+	if err != nil {
+		t.Fatalf("open silent stream: %v", err)
+	}
+	started := time.Now()
+	resp, err := tunnel.ReadOpenResponse(silent)
+	if err != nil {
+		t.Fatalf("read timeout open response: %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("open request timeout took %s, want under 1s", elapsed)
+	}
+	if resp.OK || resp.ErrorKind != "open_request_timeout" {
+		t.Fatalf("timeout response = %+v, want open_request_timeout", resp)
+	}
+	silent.Close()
+
+	partial, err := serverSession.Open()
+	if err != nil {
+		t.Fatalf("open partial stream: %v", err)
+	}
+	if _, err := partial.Write([]byte{0, 0}); err != nil {
+		t.Fatalf("write partial open request frame: %v", err)
+	}
+	resp, err = tunnel.ReadOpenResponse(partial)
+	if err != nil {
+		t.Fatalf("read partial-frame timeout response: %v", err)
+	}
+	if resp.OK || resp.ErrorKind != "open_request_timeout" {
+		t.Fatalf("partial-frame timeout response = %+v, want open_request_timeout", resp)
+	}
+	partial.Close()
+
+	valid, err := serverSession.Open()
+	if err != nil {
+		t.Fatalf("open valid stream after timeout: %v", err)
+	}
+	defer valid.Close()
+	if err := tunnel.WriteOpenRequest(valid, tunnel.NewOpenRequest("req-valid", "tcp", upstream.Addr().String())); err != nil {
+		t.Fatalf("write valid open request: %v", err)
+	}
+	resp, err = tunnel.ReadOpenResponse(valid)
+	if err != nil {
+		t.Fatalf("read valid open response: %v", err)
+	}
+	if !resp.OK {
+		t.Fatalf("valid response = %+v, want ok", resp)
+	}
+	time.Sleep(2 * agentTunnelOpenRequestTimeout)
+	if _, err := valid.Write([]byte("ok")); err != nil {
+		t.Fatalf("write valid stream after open deadline: %v", err)
+	}
+	buf := make([]byte, 2)
+	if _, err := io.ReadFull(valid, buf); err != nil {
+		t.Fatalf("read valid stream echo after open deadline: %v", err)
+	}
+	if string(buf) != "ok" {
+		t.Fatalf("valid stream echo = %q, want ok", buf)
+	}
+}
+
+func TestTunnelSessionDialTimeoutReturnsDialTimeout(t *testing.T) {
+	resetAgentRequestCounters()
+	t.Cleanup(resetAgentRequestCounters)
+	withAgentTunnelDialTimeout(t, 25*time.Millisecond)
+
+	clientConn, serverConn := net.Pipe()
+	agentSession, err := yamux.Client(clientConn, tunnel.DefaultYamuxConfig(nil))
+	if err != nil {
+		t.Fatalf("agent yamux client: %v", err)
+	}
+	serverSession, err := yamux.Server(serverConn, tunnel.DefaultYamuxConfig(nil))
+	if err != nil {
+		t.Fatalf("server yamux session: %v", err)
+	}
+	defer agentSession.Close()
+	defer serverSession.Close()
+
+	upstream := startEchoListener(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_ = serveTunnelSession(ctx, agentSession)
+	}()
+
+	var dialNetwork string
+	var dialAddress string
+	restoreDial := replaceAgentTunnelDialContext(func(ctx context.Context, network string, address string) (net.Conn, error) {
+		dialNetwork = network
+		dialAddress = address
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+	t.Cleanup(restoreDial)
+
+	timeoutStream, err := serverSession.Open()
+	if err != nil {
+		t.Fatalf("open timeout stream: %v", err)
+	}
+	if err := tunnel.WriteOpenRequest(timeoutStream, tunnel.NewOpenRequest("req-timeout", "tcp", "203.0.113.10:443")); err != nil {
+		t.Fatalf("write timeout open request: %v", err)
+	}
+	resp, err := tunnel.ReadOpenResponse(timeoutStream)
+	if err != nil {
+		t.Fatalf("read timeout open response: %v", err)
+	}
+	if resp.OK || resp.ErrorKind != "dial_timeout" {
+		t.Fatalf("timeout response = %+v, want dial_timeout", resp)
+	}
+	if dialNetwork != "tcp" || dialAddress != "203.0.113.10:443" {
+		t.Fatalf("dialed network/address = %q %q", dialNetwork, dialAddress)
+	}
+	waitForAgentActiveRequests(t, 0)
+	timeoutStream.Close()
+
+	restoreDial()
+	valid, err := serverSession.Open()
+	if err != nil {
+		t.Fatalf("open valid stream after dial timeout: %v", err)
+	}
+	defer valid.Close()
+	if err := tunnel.WriteOpenRequest(valid, tunnel.NewOpenRequest("req-valid", "tcp", upstream.Addr().String())); err != nil {
+		t.Fatalf("write valid open request: %v", err)
+	}
+	resp, err = tunnel.ReadOpenResponse(valid)
+	if err != nil {
+		t.Fatalf("read valid open response: %v", err)
+	}
+	if !resp.OK {
+		t.Fatalf("valid response = %+v, want ok", resp)
+	}
+}
+
+func TestAgentTunnelDialerUsesConfiguredTimeout(t *testing.T) {
+	withAgentTunnelDialTimeout(t, 37*time.Millisecond)
+	if got := agentTunnelDialer().Timeout; got != 37*time.Millisecond {
+		t.Fatalf("agent tunnel dial timeout = %s, want 37ms", got)
+	}
+}
+
 func TestTunnelSessionInvalidOpenRequestKeepsSessionUsable(t *testing.T) {
 	resetAgentRequestCounters()
 	t.Cleanup(resetAgentRequestCounters)
@@ -283,4 +447,47 @@ func resetAgentRequestCounters() {
 	reqClientError.Store(0)
 	reqServerError.Store(0)
 	reqInternalError.Store(0)
+}
+
+func withAgentTunnelOpenRequestTimeout(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	previous := agentTunnelOpenRequestTimeout
+	agentTunnelOpenRequestTimeout = timeout
+	t.Cleanup(func() {
+		agentTunnelOpenRequestTimeout = previous
+	})
+}
+
+func withAgentTunnelDialTimeout(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	previous := agentTunnelDialTimeout
+	agentTunnelDialTimeout = timeout
+	t.Cleanup(func() {
+		agentTunnelDialTimeout = previous
+	})
+}
+
+func replaceAgentTunnelDialContext(fn func(context.Context, string, string) (net.Conn, error)) func() {
+	previous := agentTunnelDialNetwork
+	restored := false
+	agentTunnelDialNetwork = fn
+	return func() {
+		if restored {
+			return
+		}
+		restored = true
+		agentTunnelDialNetwork = previous
+	}
+}
+
+func waitForAgentActiveRequests(t *testing.T, want int32) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := activeRequests.Load(); got == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("activeRequests = %d, want %d", activeRequests.Load(), want)
 }


### PR DESCRIPTION
## Summary
- add a 10s agent-side read deadline for tunnel open requests so silent/partial control frames do not pin goroutines
- add a 10s bounded destination dial context and dialer timeout so blackholed upstreams surface as dial_timeout
- clear control read deadlines before relay and keep per-stream failures from closing the yamux session
- add agent tunnel regressions for silent streams, partial frames, dial timeout, session reuse, and relay after deadline expiry

Closes #125

## Tests
- go test ./internal/agent -run 'TestTunnelSession|TestAgentTunnelDialer' -count=1\n- go test ./internal/agent ./internal/tunnel ./internal/server -count=1\n- go test -race ./internal/agent ./internal/tunnel -count=1\n- go test ./... -count=1