### PR TITLE
Add agent destination allowlist

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -65,6 +65,10 @@ var agentCmd = &cobra.Command{
 		if !allowInsecureManagement {
 			allowInsecureManagement = envBool("AGENT_ALLOW_INSECURE_MANAGEMENT")
 		}
+		allowTargets, _ := cmd.Flags().GetStringArray("allow-target")
+		if len(allowTargets) == 0 {
+			allowTargets = splitAgentAllowTargets(os.Getenv("AGENT_ALLOW_TARGETS"))
+		}
 
 		if err := agent.Run(agent.Options{
 			ManagementURL:           mgmtURL,
@@ -76,6 +80,7 @@ var agentCmd = &cobra.Command{
 			TLSCertFile:             tlsCertFile,
 			TLSKeyFile:              tlsKeyFile,
 			AllowInsecureManagement: allowInsecureManagement,
+			AllowTargets:            allowTargets,
 		}); err != nil {
 			fmt.Fprintln(os.Stderr, "agent failed: "+err.Error())
 			os.Exit(1)
@@ -94,6 +99,7 @@ func init() {
 	agentCmd.Flags().String("tls-cert-file", "", "PEM client certificate for management mTLS")
 	agentCmd.Flags().String("tls-key-file", "", "PEM private key for management mTLS")
 	agentCmd.Flags().Bool("allow-insecure-management", false, "Allow an insecure HTTP management URL")
+	agentCmd.Flags().StringArray("allow-target", nil, "Opt-in tunnel destination allowlist entry; repeat for CIDR/IP/hostname with optional port or port range")
 }
 
 func defaultAgentManagementURL() string {
@@ -159,4 +165,18 @@ func envBool(key string) bool {
 	default:
 		return false
 	}
+}
+
+func splitAgentAllowTargets(value string) []string {
+	fields := strings.FieldsFunc(value, func(r rune) bool {
+		return r == ',' || r == '\n' || r == '\t' || r == ' '
+	})
+	targets := make([]string, 0, len(fields))
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field != "" {
+			targets = append(targets, field)
+		}
+	}
+	return targets
 }

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitAgentAllowTargets(t *testing.T) {
+	got := splitAgentAllowTargets("10.0.0.0/24:8080, app.internal:443\nmetrics.internal:9000-9010\t[2001:db8::/64]:8443")
+	want := []string{
+		"10.0.0.0/24:8080",
+		"app.internal:443",
+		"metrics.internal:9000-9010",
+		"[2001:db8::/64]:8443",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("splitAgentAllowTargets() = %#v, want %#v", got, want)
+	}
+}

--- a/docs/operations/security-hardening.md
+++ b/docs/operations/security-hardening.md
@@ -39,6 +39,7 @@ Use this before exposing management beyond a private network, after adding agent
    - Disable or delete unused agents.
    - Use agent mTLS with `MANAGEMENT_TLS_CLIENT_CA_FILE` when token-only auth is not enough.
    - Keep `AGENT_ALLOW_INSECURE_MANAGEMENT` unset except for isolated development.
+   - Set `AGENT_ALLOW_TARGETS` or repeated `--allow-target` flags when an agent should expose only specific destinations. If unset, the agent trusts the management server to request any reachable `host:port`.
 
 4. Harden public TLS and upstreams:
 
@@ -59,6 +60,7 @@ Review:
 - First-admin setup token handling is documented for operators.
 - `MANAGEMENT_PUBLIC_URL` is correct.
 - Unused listeners and agents are disabled or deleted.
+- Agents that need a constrained blast radius have explicit target allowlists.
 - Tracing is disabled after troubleshooting.
 
 ## Troubleshooting

--- a/docs/operations/systemd.md
+++ b/docs/operations/systemd.md
@@ -92,7 +92,7 @@ sudo systemctl restart p2pstream-agent
 sudo journalctl -u p2pstream-agent -f
 ```
 
-After rotating an agent token, run the generated Linux reinstall command on the existing agent host. The installer rewrites `/etc/p2pstream/agent.env`, refreshes installer-managed management CA material, and restarts `p2pstream-agent` so the new token and TLS settings are loaded. A locally configured `AGENT_ALLOW_TARGETS` is preserved when the reinstall command does not provide a replacement. To remove that policy intentionally, add `AGENT_CLEAR_ALLOW_TARGETS=true` to the installer environment.
+After rotating an agent token, run the generated Linux reinstall command on the existing agent host. The installer rewrites `/etc/p2pstream/agent.env`, refreshes installer-managed management CA material, and restarts `p2pstream-agent` so the new token and TLS settings are loaded. A locally configured `AGENT_ALLOW_TARGETS` is preserved when the reinstall command does not provide a replacement. If the existing policy cannot be read or uses ambiguous multiline syntax, the reinstall stops instead of removing it; provide a replacement explicitly or add `AGENT_CLEAR_ALLOW_TARGETS=true` to remove the policy intentionally.
 
 ## Uninstall Agent
 

--- a/docs/operations/systemd.md
+++ b/docs/operations/systemd.md
@@ -92,7 +92,7 @@ sudo systemctl restart p2pstream-agent
 sudo journalctl -u p2pstream-agent -f
 ```
 
-After rotating an agent token, run the generated Linux reinstall command on the existing agent host. The installer rewrites `/etc/p2pstream/agent.env`, refreshes installer-managed management CA material, and restarts `p2pstream-agent` so the new token and TLS settings are loaded.
+After rotating an agent token, run the generated Linux reinstall command on the existing agent host. The installer rewrites `/etc/p2pstream/agent.env`, refreshes installer-managed management CA material, and restarts `p2pstream-agent` so the new token and TLS settings are loaded. A locally configured `AGENT_ALLOW_TARGETS` is preserved when the reinstall command does not provide a replacement. To remove that policy intentionally, add `AGENT_CLEAR_ALLOW_TARGETS=true` to the installer environment.
 
 ## Uninstall Agent
 

--- a/docs/operations/systemd.md
+++ b/docs/operations/systemd.md
@@ -92,7 +92,7 @@ sudo systemctl restart p2pstream-agent
 sudo journalctl -u p2pstream-agent -f
 ```
 
-After rotating an agent token, run the generated Linux reinstall command on the existing agent host. The installer rewrites `/etc/p2pstream/agent.env`, refreshes installer-managed management CA material, and restarts `p2pstream-agent` so the new token and TLS settings are loaded. A locally configured `AGENT_ALLOW_TARGETS` is preserved when the reinstall command does not provide a replacement. If the existing policy cannot be read or uses ambiguous multiline syntax, the reinstall stops instead of removing it; provide a replacement explicitly or add `AGENT_CLEAR_ALLOW_TARGETS=true` to remove the policy intentionally.
+After rotating an agent token, run the generated Linux reinstall command on the existing agent host. The installer rewrites `/etc/p2pstream/agent.env`, refreshes installer-managed management CA material, and restarts `p2pstream-agent` so the new token and TLS settings are loaded. A locally configured `AGENT_ALLOW_TARGETS` is preserved when the reinstall command does not provide a replacement. If the existing environment file cannot be read or contains unsupported or multiline assignment syntax, the reinstall stops instead of risking a policy change; provide a replacement explicitly or add `AGENT_CLEAR_ALLOW_TARGETS=true` to remove the policy intentionally.
 
 ## Uninstall Agent
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -41,6 +41,7 @@ p2pstream agent [flags]
 | `--tls-cert-file` | `AGENT_TLS_CERT_FILE` | Client certificate for management mTLS. |
 | `--tls-key-file` | `AGENT_TLS_KEY_FILE` | Client private key for management mTLS. |
 | `--allow-insecure-management` | `AGENT_ALLOW_INSECURE_MANAGEMENT` | Permit HTTP management URL. |
+| `--allow-target` | `AGENT_ALLOW_TARGETS` | Opt-in destination allowlist entry. Repeat the flag, or separate env entries with commas/whitespace. |
 
 ## Validation Rules
 
@@ -48,6 +49,8 @@ p2pstream agent [flags]
 - Use only one password source: prompt, `--password-env`, or `--password-file`.
 - `agent` requires `AGENT_ID` and `AGENT_TOKEN`.
 - Agent HTTP management URLs are rejected unless `--allow-insecure-management` or `AGENT_ALLOW_INSECURE_MANAGEMENT` is set.
+- When no `--allow-target` or `AGENT_ALLOW_TARGETS` entries are set, the agent keeps the legacy behavior and trusts the management server to choose any tunnel destination.
+- Allow target entries are exact hostnames, IP literals, or CIDR prefixes with optional ports or port ranges, such as `myapp.internal:443`, `10.0.5.0/24:8080`, or `metrics.internal:9000-9010`. IPv6 entries with ports must use brackets, for example `[2001:db8::/64]:8443`.
 
 ## Runtime Effects
 
@@ -88,7 +91,9 @@ p2pstream agent \
   --management-url https://proxy.example.com:8081 \
   --management-ca-file /etc/p2pstream/management-ca.pem \
   --agent-id agent-abc123 \
-  --agent-token "$AGENT_TOKEN"
+  --agent-token "$AGENT_TOKEN" \
+  --allow-target myapp.internal:443 \
+  --allow-target 10.0.5.0/24:8080
 ```
 
 ## Related Tasks

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -82,7 +82,7 @@ Set these as environment variables before running the Linux agent installer scri
 - Agent boolean parsing accepts `1`, `true`, `yes`, `y`, and `on`.
 - Linux agent installs require `AGENT_TLS_CERT_FILE` and `AGENT_TLS_KEY_FILE` together, require user-supplied TLS files to be readable, and reject CA/client-certificate settings with HTTP management URLs.
 - Agent target allowlist entries are exact hostnames, IP literals, or CIDR prefixes with optional ports or port ranges. When unset, the agent trusts the management server to choose any tunnel destination.
-- Reinstall preserves an existing `AGENT_ALLOW_TARGETS` when no replacement is supplied. Set `AGENT_CLEAR_ALLOW_TARGETS=true` to remove it explicitly; it cannot be combined with `AGENT_ALLOW_TARGETS`.
+- Reinstall preserves the effective last single-line `AGENT_ALLOW_TARGETS` assignment when no replacement is supplied. It fails closed if the existing policy cannot be read or uses ambiguous multiline syntax. Set `AGENT_CLEAR_ALLOW_TARGETS=true` to remove it explicitly; it cannot be combined with `AGENT_ALLOW_TARGETS`.
 
 ## Runtime Effects
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -68,6 +68,7 @@ Set these as environment variables before running the Linux agent installer scri
 | `P2PSTREAM_CONFIG_DIR`   | `/etc/p2pstream`           | Agent config directory created by installer.                                 |
 | `P2PSTREAM_INSTALL_PATH` | `/usr/local/bin/p2pstream` | Binary install path.                                                         |
 | `P2PSTREAM_SYSTEMD_DIR`  | `/etc/systemd/system`      | Systemd unit directory used by installer and uninstaller.                    |
+| `AGENT_CLEAR_ALLOW_TARGETS` | `false`                 | Explicitly remove a previously installed local destination allowlist.        |
 
 ## Validation Rules
 
@@ -81,6 +82,7 @@ Set these as environment variables before running the Linux agent installer scri
 - Agent boolean parsing accepts `1`, `true`, `yes`, `y`, and `on`.
 - Linux agent installs require `AGENT_TLS_CERT_FILE` and `AGENT_TLS_KEY_FILE` together, require user-supplied TLS files to be readable, and reject CA/client-certificate settings with HTTP management URLs.
 - Agent target allowlist entries are exact hostnames, IP literals, or CIDR prefixes with optional ports or port ranges. When unset, the agent trusts the management server to choose any tunnel destination.
+- Reinstall preserves an existing `AGENT_ALLOW_TARGETS` when no replacement is supplied. Set `AGENT_CLEAR_ALLOW_TARGETS=true` to remove it explicitly; it cannot be combined with `AGENT_ALLOW_TARGETS`.
 
 ## Runtime Effects
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -82,7 +82,7 @@ Set these as environment variables before running the Linux agent installer scri
 - Agent boolean parsing accepts `1`, `true`, `yes`, `y`, and `on`.
 - Linux agent installs require `AGENT_TLS_CERT_FILE` and `AGENT_TLS_KEY_FILE` together, require user-supplied TLS files to be readable, and reject CA/client-certificate settings with HTTP management URLs.
 - Agent target allowlist entries are exact hostnames, IP literals, or CIDR prefixes with optional ports or port ranges. When unset, the agent trusts the management server to choose any tunnel destination.
-- Reinstall preserves the effective last single-line `AGENT_ALLOW_TARGETS` assignment when no replacement is supplied. It fails closed if the existing policy cannot be read or uses ambiguous multiline syntax. Set `AGENT_CLEAR_ALLOW_TARGETS=true` to remove it explicitly; it cannot be combined with `AGENT_ALLOW_TARGETS`.
+- Reinstall preserves the effective last single-line `AGENT_ALLOW_TARGETS` assignment when no replacement is supplied. It fails closed if the existing environment file cannot be read or contains unsupported or multiline assignment syntax. Set `AGENT_CLEAR_ALLOW_TARGETS=true` to remove it explicitly; it cannot be combined with `AGENT_ALLOW_TARGETS`.
 
 ## Runtime Effects
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -42,7 +42,7 @@ If every login throttle slot is occupied by an active block, new failed-login ke
 
 ### Agent Variables
 
-Set these on each agent host via `/etc/p2pstream/agent.env` or the generated installer environment. The agent installer writes these automatically from the setup dialog.
+Set these on each agent host via `/etc/p2pstream/agent.env` or the generated installer environment. The agent installer writes the generated setup values automatically; optional local hardening values such as `AGENT_ALLOW_TARGETS` can be supplied before running the installer or added to the env file afterward.
 
 | Variable                          | Description                                                          |
 | --------------------------------- | -------------------------------------------------------------------- |
@@ -55,6 +55,7 @@ Set these on each agent host via `/etc/p2pstream/agent.env` or the generated ins
 | `AGENT_TLS_CERT_FILE`             | Optional client certificate for management mTLS.                     |
 | `AGENT_TLS_KEY_FILE`              | Optional client private key for management mTLS.                     |
 | `AGENT_ALLOW_INSECURE_MANAGEMENT` | Allows HTTP management URL when truthy.                              |
+| `AGENT_ALLOW_TARGETS`             | Optional tunnel destination allowlist entries separated by commas or whitespace. |
 
 ### Installer Variables
 
@@ -79,6 +80,7 @@ Set these as environment variables before running the Linux agent installer scri
 - Bootstrap agent ID, name, and token must all be set together.
 - Agent boolean parsing accepts `1`, `true`, `yes`, `y`, and `on`.
 - Linux agent installs require `AGENT_TLS_CERT_FILE` and `AGENT_TLS_KEY_FILE` together, require user-supplied TLS files to be readable, and reject CA/client-certificate settings with HTTP management URLs.
+- Agent target allowlist entries are exact hostnames, IP literals, or CIDR prefixes with optional ports or port ranges. When unset, the agent trusts the management server to choose any tunnel destination.
 
 ## Runtime Effects
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -343,6 +344,12 @@ func connectAndServe(client *http.Client, tunnelURL string, agentPublicID string
 }
 
 func serveTunnelSession(ctx context.Context, session *yamux.Session, destinationPolicy *agentDestinationPolicy) error {
+	var handlers sync.WaitGroup
+	defer func() {
+		_ = session.Close()
+		handlers.Wait()
+	}()
+
 	for {
 		stream, err := session.Accept()
 		if err != nil {
@@ -353,7 +360,11 @@ func serveTunnelSession(ctx context.Context, session *yamux.Session, destination
 			log.Debug().Err(err).Msg("Tunnel stream accept loop stopped")
 			return fmt.Errorf("accept tunnel stream: %w", err)
 		}
-		go handleTunnelStream(ctx, stream, destinationPolicy)
+		handlers.Add(1)
+		go func(stream net.Conn) {
+			defer handlers.Done()
+			handleTunnelStream(ctx, stream, destinationPolicy)
+		}(stream)
 	}
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -60,11 +60,16 @@ type Options struct {
 	TLSCertFile             string
 	TLSKeyFile              string
 	AllowInsecureManagement bool
+	AllowTargets            []string
 }
 
 // Run is the main entry point to start the agent loop
 func Run(opts Options) error {
 	if err := validateOptions(opts); err != nil {
+		return err
+	}
+	destinationPolicy, err := newAgentDestinationPolicy(opts.AllowTargets)
+	if err != nil {
 		return err
 	}
 	managementClient, err := managementHTTPClient(opts)
@@ -87,7 +92,7 @@ func Run(opts Options) error {
 		log.Info().Str("tunnel_url", tunnelURL).Msg("Attempting to connect to management server...")
 
 		connectedAt := time.Now()
-		err := connectAndServe(tunnelClient, tunnelURL, opts.PublicID, opts.Name, opts.Token)
+		err := connectAndServe(tunnelClient, tunnelURL, opts.PublicID, opts.Name, opts.Token, destinationPolicy)
 		if err != nil {
 			log.Warn().Err(err).Msg("Disconnected")
 		}
@@ -146,6 +151,9 @@ func validateOptions(opts Options) error {
 	}
 	if parsed.Scheme != "https" && (hasClientCert || strings.TrimSpace(opts.ManagementCAFile) != "" || strings.TrimSpace(opts.ManagementCAPEMBase64) != "") {
 		return fmt.Errorf("agent TLS files require an https management URL")
+	}
+	if _, err := newAgentDestinationPolicy(opts.AllowTargets); err != nil {
+		return err
 	}
 	return nil
 }
@@ -272,7 +280,7 @@ func managementTunnelHTTPClient(base *http.Client) (*http.Client, error) {
 	}, nil
 }
 
-func connectAndServe(client *http.Client, tunnelURL string, agentPublicID string, agentName string, agentToken string) error {
+func connectAndServe(client *http.Client, tunnelURL string, agentPublicID string, agentName string, agentToken string, destinationPolicy *agentDestinationPolicy) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -326,7 +334,7 @@ func connectAndServe(client *http.Client, tunnelURL string, agentPublicID string
 		_ = session.Close()
 	}()
 
-	if err := serveTunnelSession(ctx, session); err != nil {
+	if err := serveTunnelSession(ctx, session, destinationPolicy); err != nil {
 		log.Debug().Err(err).Msg("Tunnel session ended")
 		return err
 	}
@@ -334,7 +342,7 @@ func connectAndServe(client *http.Client, tunnelURL string, agentPublicID string
 	return nil
 }
 
-func serveTunnelSession(ctx context.Context, session *yamux.Session) error {
+func serveTunnelSession(ctx context.Context, session *yamux.Session, destinationPolicy *agentDestinationPolicy) error {
 	for {
 		stream, err := session.Accept()
 		if err != nil {
@@ -345,11 +353,11 @@ func serveTunnelSession(ctx context.Context, session *yamux.Session) error {
 			log.Debug().Err(err).Msg("Tunnel stream accept loop stopped")
 			return fmt.Errorf("accept tunnel stream: %w", err)
 		}
-		go handleTunnelStream(ctx, stream)
+		go handleTunnelStream(ctx, stream, destinationPolicy)
 	}
 }
 
-func handleTunnelStream(ctx context.Context, stream net.Conn) {
+func handleTunnelStream(ctx context.Context, stream net.Conn, destinationPolicy *agentDestinationPolicy) {
 	defer stream.Close()
 
 	setTunnelOpenRequestReadDeadline(stream)
@@ -375,7 +383,7 @@ func handleTunnelStream(ctx context.Context, stream net.Conn) {
 	activeRequests.Add(1)
 	defer activeRequests.Add(-1)
 
-	upstream, err := dialTunnelDestination(ctx, openReq.Network, openReq.Address)
+	upstream, err := dialTunnelDestination(ctx, openReq.Network, openReq.Address, destinationPolicy)
 	if err != nil {
 		kind := tunnelDialErrorKind(err)
 		reqInternalError.Add(1)
@@ -426,13 +434,28 @@ func clearTunnelOpenRequestReadDeadline(conn net.Conn) {
 	_ = conn.SetReadDeadline(time.Time{})
 }
 
-func dialTunnelDestination(ctx context.Context, network string, address string) (net.Conn, error) {
+func dialTunnelDestination(ctx context.Context, network string, address string, destinationPolicy *agentDestinationPolicy) (net.Conn, error) {
+	dialAddress := address
 	if agentTunnelDialTimeout <= 0 {
-		return agentTunnelDialNetwork(ctx, network, address)
+		if destinationPolicy != nil {
+			var err error
+			dialAddress, err = destinationPolicy.dialAddress(ctx, network, address)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return agentTunnelDialNetwork(ctx, network, dialAddress)
 	}
 	dialCtx, cancel := context.WithTimeout(ctx, agentTunnelDialTimeout)
 	defer cancel()
-	return agentTunnelDialNetwork(dialCtx, network, address)
+	if destinationPolicy != nil {
+		var err error
+		dialAddress, err = destinationPolicy.dialAddress(dialCtx, network, address)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return agentTunnelDialNetwork(dialCtx, network, dialAddress)
 }
 
 func dialTunnelNetwork(ctx context.Context, network string, address string) (net.Conn, error) {
@@ -445,6 +468,9 @@ func agentTunnelDialer() net.Dialer {
 }
 
 func tunnelDialErrorKind(err error) string {
+	if errors.Is(err, errAgentDestinationForbidden) {
+		return "dial_forbidden"
+	}
 	if isTimeoutError(err) {
 		return "dial_timeout"
 	}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -43,7 +43,6 @@ func TestAgentReconnectBackoffBounds(t *testing.T) {
 
 func TestTunnelSessionRelaysTCPStream(t *testing.T) {
 	resetAgentRequestCounters()
-	t.Cleanup(resetAgentRequestCounters)
 
 	upstream := startEchoListener(t)
 	clientConn, serverConn := net.Pipe()
@@ -58,12 +57,7 @@ func TestTunnelSessionRelaysTCPStream(t *testing.T) {
 	defer agentSession.Close()
 	defer serverSession.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	serveDone := make(chan error, 1)
-	go func() {
-		serveDone <- serveTunnelSession(ctx, agentSession, nil)
-	}()
+	startTestTunnelSession(t, agentSession, nil)
 
 	stream, err := serverSession.Open()
 	if err != nil {
@@ -90,19 +84,10 @@ func TestTunnelSessionRelaysTCPStream(t *testing.T) {
 	if string(buf) != "ping" {
 		t.Fatalf("echo = %q, want ping", buf)
 	}
-
-	cancel()
-	agentSession.Close()
-	select {
-	case <-serveDone:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for tunnel session to stop")
-	}
 }
 
 func TestTunnelSessionReturnsDialFailure(t *testing.T) {
 	resetAgentRequestCounters()
-	t.Cleanup(resetAgentRequestCounters)
 
 	clientConn, serverConn := net.Pipe()
 	agentSession, err := yamux.Client(clientConn, tunnel.DefaultYamuxConfig(nil))
@@ -116,11 +101,7 @@ func TestTunnelSessionReturnsDialFailure(t *testing.T) {
 	defer agentSession.Close()
 	defer serverSession.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		_ = serveTunnelSession(ctx, agentSession, nil)
-	}()
+	startTestTunnelSession(t, agentSession, nil)
 
 	stream, err := serverSession.Open()
 	if err != nil {
@@ -141,7 +122,6 @@ func TestTunnelSessionReturnsDialFailure(t *testing.T) {
 
 func TestTunnelSessionDestinationAllowlistDeniesWithoutClosingSession(t *testing.T) {
 	resetAgentRequestCounters()
-	t.Cleanup(resetAgentRequestCounters)
 
 	upstream := startEchoListener(t)
 	clientConn, serverConn := net.Pipe()
@@ -160,18 +140,14 @@ func TestTunnelSessionDestinationAllowlistDeniesWithoutClosingSession(t *testing
 	if err != nil {
 		t.Fatalf("newAgentDestinationPolicy() error = %v", err)
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		_ = serveTunnelSession(ctx, agentSession, policy)
-	}()
-
 	dialCalled := make(chan struct{}, 1)
 	restoreDial := replaceAgentTunnelDialContext(func(ctx context.Context, network string, address string) (net.Conn, error) {
 		dialCalled <- struct{}{}
 		return nil, context.Canceled
 	})
 	t.Cleanup(restoreDial)
+	startTestTunnelSession(t, agentSession, policy)
+
 	denied, err := serverSession.Open()
 	if err != nil {
 		t.Fatalf("open denied stream: %v", err)
@@ -224,7 +200,6 @@ func TestTunnelSessionDestinationAllowlistDeniesWithoutClosingSession(t *testing
 
 func TestTunnelSessionOpenRequestReadDeadlineKeepsSessionUsable(t *testing.T) {
 	resetAgentRequestCounters()
-	t.Cleanup(resetAgentRequestCounters)
 	withAgentTunnelOpenRequestTimeout(t, 25*time.Millisecond)
 
 	upstream := startEchoListener(t)
@@ -240,11 +215,7 @@ func TestTunnelSessionOpenRequestReadDeadlineKeepsSessionUsable(t *testing.T) {
 	defer agentSession.Close()
 	defer serverSession.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		_ = serveTunnelSession(ctx, agentSession, nil)
-	}()
+	startTestTunnelSession(t, agentSession, nil)
 
 	silent, err := serverSession.Open()
 	if err != nil {
@@ -309,7 +280,6 @@ func TestTunnelSessionOpenRequestReadDeadlineKeepsSessionUsable(t *testing.T) {
 
 func TestTunnelSessionDialTimeoutReturnsDialTimeout(t *testing.T) {
 	resetAgentRequestCounters()
-	t.Cleanup(resetAgentRequestCounters)
 	withAgentTunnelDialTimeout(t, 25*time.Millisecond)
 
 	clientConn, serverConn := net.Pipe()
@@ -325,12 +295,6 @@ func TestTunnelSessionDialTimeoutReturnsDialTimeout(t *testing.T) {
 	defer serverSession.Close()
 
 	upstream := startEchoListener(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		_ = serveTunnelSession(ctx, agentSession, nil)
-	}()
-
 	var dialNetwork string
 	var dialAddress string
 	restoreDial := replaceAgentTunnelDialContext(func(ctx context.Context, network string, address string) (net.Conn, error) {
@@ -340,6 +304,7 @@ func TestTunnelSessionDialTimeoutReturnsDialTimeout(t *testing.T) {
 		return nil, ctx.Err()
 	})
 	t.Cleanup(restoreDial)
+	startTestTunnelSession(t, agentSession, nil)
 
 	timeoutStream, err := serverSession.Open()
 	if err != nil {
@@ -388,7 +353,6 @@ func TestAgentTunnelDialerUsesConfiguredTimeout(t *testing.T) {
 
 func TestTunnelSessionInvalidOpenRequestKeepsSessionUsable(t *testing.T) {
 	resetAgentRequestCounters()
-	t.Cleanup(resetAgentRequestCounters)
 
 	upstream := startEchoListener(t)
 	clientConn, serverConn := net.Pipe()
@@ -403,11 +367,7 @@ func TestTunnelSessionInvalidOpenRequestKeepsSessionUsable(t *testing.T) {
 	defer agentSession.Close()
 	defer serverSession.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		_ = serveTunnelSession(ctx, agentSession, nil)
-	}()
+	startTestTunnelSession(t, agentSession, nil)
 
 	unsupported, err := serverSession.Open()
 	if err != nil {
@@ -492,6 +452,85 @@ func TestTunnelSessionReturnsWhenSessionCloses(t *testing.T) {
 	}
 }
 
+func TestTunnelSessionWaitsForAcceptedHandlerOnSessionClose(t *testing.T) {
+	resetAgentRequestCounters()
+
+	clientConn, serverConn := net.Pipe()
+	agentSession, err := yamux.Client(clientConn, tunnel.DefaultYamuxConfig(nil))
+	if err != nil {
+		t.Fatalf("agent yamux client: %v", err)
+	}
+	serverSession, err := yamux.Server(serverConn, tunnel.DefaultYamuxConfig(nil))
+	if err != nil {
+		_ = agentSession.Close()
+		t.Fatalf("server yamux session: %v", err)
+	}
+
+	dialStarted := make(chan struct{})
+	releaseDial := make(chan struct{})
+	released := false
+	release := func() {
+		if released {
+			return
+		}
+		released = true
+		close(releaseDial)
+	}
+	restoreDial := replaceAgentTunnelDialContext(func(context.Context, string, string) (net.Conn, error) {
+		close(dialStarted)
+		<-releaseDial
+		return nil, context.Canceled
+	})
+	t.Cleanup(restoreDial)
+
+	serveDone := make(chan struct{})
+	go func() {
+		_ = serveTunnelSession(context.Background(), agentSession, nil)
+		close(serveDone)
+	}()
+	t.Cleanup(func() {
+		defer resetAgentRequestCounters()
+		release()
+		_ = agentSession.Close()
+		_ = serverSession.Close()
+		select {
+		case <-serveDone:
+		case <-time.After(2 * time.Second):
+			t.Error("timed out waiting for tunnel session handlers to stop")
+		}
+		waitForAgentActiveRequests(t, 0)
+	})
+
+	stream, err := serverSession.Open()
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	if err := tunnel.WriteOpenRequest(stream, tunnel.NewOpenRequest("req-blocked", "tcp", "127.0.0.1:1")); err != nil {
+		t.Fatalf("write open request: %v", err)
+	}
+	select {
+	case <-dialStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for tunnel handler to start")
+	}
+	waitForAgentActiveRequests(t, 1)
+
+	_ = agentSession.Close()
+	select {
+	case <-serveDone:
+		t.Fatal("tunnel session returned before its accepted handler stopped")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	release()
+	select {
+	case <-serveDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for tunnel session after handler stopped")
+	}
+	waitForAgentActiveRequests(t, 0)
+}
+
 func writeMalformedControlFrame(w io.Writer) error {
 	var header [4]byte
 	binary.BigEndian.PutUint32(header[:], 1)
@@ -522,6 +561,28 @@ func startEchoListener(t *testing.T) net.Listener {
 		}
 	}()
 	return ln
+}
+
+func startTestTunnelSession(t *testing.T, agentSession *yamux.Session, destinationPolicy *agentDestinationPolicy) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- serveTunnelSession(ctx, agentSession, destinationPolicy)
+	}()
+
+	t.Cleanup(func() {
+		defer resetAgentRequestCounters()
+		cancel()
+		_ = agentSession.Close()
+		select {
+		case <-serveDone:
+		case <-time.After(2 * time.Second):
+			t.Error("timed out waiting for tunnel session to stop")
+		}
+		waitForAgentActiveRequests(t, 0)
+	})
 }
 
 func resetAgentRequestCounters() {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -62,7 +62,7 @@ func TestTunnelSessionRelaysTCPStream(t *testing.T) {
 	defer cancel()
 	serveDone := make(chan error, 1)
 	go func() {
-		serveDone <- serveTunnelSession(ctx, agentSession)
+		serveDone <- serveTunnelSession(ctx, agentSession, nil)
 	}()
 
 	stream, err := serverSession.Open()
@@ -119,7 +119,7 @@ func TestTunnelSessionReturnsDialFailure(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
-		_ = serveTunnelSession(ctx, agentSession)
+		_ = serveTunnelSession(ctx, agentSession, nil)
 	}()
 
 	stream, err := serverSession.Open()
@@ -136,6 +136,89 @@ func TestTunnelSessionReturnsDialFailure(t *testing.T) {
 	}
 	if resp.OK || resp.ErrorKind != "dial_failed" {
 		t.Fatalf("open response = %+v, want dial_failed", resp)
+	}
+}
+
+func TestTunnelSessionDestinationAllowlistDeniesWithoutClosingSession(t *testing.T) {
+	resetAgentRequestCounters()
+	t.Cleanup(resetAgentRequestCounters)
+
+	upstream := startEchoListener(t)
+	clientConn, serverConn := net.Pipe()
+	agentSession, err := yamux.Client(clientConn, tunnel.DefaultYamuxConfig(nil))
+	if err != nil {
+		t.Fatalf("agent yamux client: %v", err)
+	}
+	serverSession, err := yamux.Server(serverConn, tunnel.DefaultYamuxConfig(nil))
+	if err != nil {
+		t.Fatalf("server yamux session: %v", err)
+	}
+	defer agentSession.Close()
+	defer serverSession.Close()
+
+	policy, err := newAgentDestinationPolicy([]string{"127.0.0.1"})
+	if err != nil {
+		t.Fatalf("newAgentDestinationPolicy() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_ = serveTunnelSession(ctx, agentSession, policy)
+	}()
+
+	dialCalled := make(chan struct{}, 1)
+	restoreDial := replaceAgentTunnelDialContext(func(ctx context.Context, network string, address string) (net.Conn, error) {
+		dialCalled <- struct{}{}
+		return nil, context.Canceled
+	})
+	t.Cleanup(restoreDial)
+	denied, err := serverSession.Open()
+	if err != nil {
+		t.Fatalf("open denied stream: %v", err)
+	}
+	if err := tunnel.WriteOpenRequest(denied, tunnel.NewOpenRequest("req-denied", "tcp", "127.0.0.2:8080")); err != nil {
+		t.Fatalf("write denied open request: %v", err)
+	}
+	resp, err := tunnel.ReadOpenResponse(denied)
+	if err != nil {
+		t.Fatalf("read denied open response: %v", err)
+	}
+	if resp.OK || resp.ErrorKind != "dial_forbidden" {
+		t.Fatalf("denied response = %+v, want dial_forbidden", resp)
+	}
+	select {
+	case <-dialCalled:
+		t.Fatal("dialer was called for forbidden destination")
+	default:
+	}
+	waitForAgentActiveRequests(t, 0)
+	denied.Close()
+	restoreDial()
+
+	allowed, err := serverSession.Open()
+	if err != nil {
+		t.Fatalf("open allowed stream after denied stream: %v", err)
+	}
+	defer allowed.Close()
+	if err := tunnel.WriteOpenRequest(allowed, tunnel.NewOpenRequest("req-allowed", "tcp", upstream.Addr().String())); err != nil {
+		t.Fatalf("write allowed open request: %v", err)
+	}
+	resp, err = tunnel.ReadOpenResponse(allowed)
+	if err != nil {
+		t.Fatalf("read allowed open response: %v", err)
+	}
+	if !resp.OK {
+		t.Fatalf("allowed response = %+v, want ok", resp)
+	}
+	if _, err := allowed.Write([]byte("ok")); err != nil {
+		t.Fatalf("write allowed stream: %v", err)
+	}
+	buf := make([]byte, 2)
+	if _, err := io.ReadFull(allowed, buf); err != nil {
+		t.Fatalf("read allowed echo: %v", err)
+	}
+	if string(buf) != "ok" {
+		t.Fatalf("allowed stream echo = %q, want ok", buf)
 	}
 }
 
@@ -160,7 +243,7 @@ func TestTunnelSessionOpenRequestReadDeadlineKeepsSessionUsable(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
-		_ = serveTunnelSession(ctx, agentSession)
+		_ = serveTunnelSession(ctx, agentSession, nil)
 	}()
 
 	silent, err := serverSession.Open()
@@ -245,7 +328,7 @@ func TestTunnelSessionDialTimeoutReturnsDialTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
-		_ = serveTunnelSession(ctx, agentSession)
+		_ = serveTunnelSession(ctx, agentSession, nil)
 	}()
 
 	var dialNetwork string
@@ -323,7 +406,7 @@ func TestTunnelSessionInvalidOpenRequestKeepsSessionUsable(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
-		_ = serveTunnelSession(ctx, agentSession)
+		_ = serveTunnelSession(ctx, agentSession, nil)
 	}()
 
 	unsupported, err := serverSession.Open()
@@ -399,7 +482,7 @@ func TestTunnelSessionReturnsWhenSessionCloses(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- serveTunnelSession(context.Background(), agentSession)
+		done <- serveTunnelSession(context.Background(), agentSession, nil)
 	}()
 	agentSession.Close()
 	select {

--- a/internal/agent/destination_allowlist.go
+++ b/internal/agent/destination_allowlist.go
@@ -1,0 +1,361 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"strconv"
+	"strings"
+)
+
+var (
+	errAgentDestinationForbidden = errors.New("agent destination forbidden by allowlist")
+	agentDestinationLookupIP     = lookupAgentDestinationIP
+)
+
+type agentDestinationPolicy struct {
+	rules          []agentDestinationRule
+	hasPrefixRules bool
+}
+
+type agentDestinationRule struct {
+	hostname  string
+	prefix    netip.Prefix
+	hasPrefix bool
+	ports     agentDestinationPortRange
+}
+
+type agentDestinationPortRange struct {
+	any bool
+	min int
+	max int
+}
+
+type agentDestinationForbiddenError struct {
+	reason string
+	cause  error
+}
+
+func (e *agentDestinationForbiddenError) Error() string {
+	if e.reason == "" {
+		return errAgentDestinationForbidden.Error()
+	}
+	return errAgentDestinationForbidden.Error() + ": " + e.reason
+}
+
+func (e *agentDestinationForbiddenError) Is(target error) bool {
+	return target == errAgentDestinationForbidden
+}
+
+func (e *agentDestinationForbiddenError) Unwrap() error {
+	return e.cause
+}
+
+func newAgentDestinationPolicy(rawRules []string) (*agentDestinationPolicy, error) {
+	policy := &agentDestinationPolicy{}
+	for _, raw := range rawRules {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		rule, err := parseAgentAllowTarget(raw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid agent allow target %q: %w", raw, err)
+		}
+		if rule.hasPrefix {
+			policy.hasPrefixRules = true
+		}
+		policy.rules = append(policy.rules, rule)
+	}
+	if len(policy.rules) == 0 {
+		return nil, nil
+	}
+	return policy, nil
+}
+
+func parseAgentAllowTarget(raw string) (agentDestinationRule, error) {
+	host, portSpec, hasPort, err := splitAgentAllowTarget(raw)
+	if err != nil {
+		return agentDestinationRule{}, err
+	}
+	ports := agentDestinationPortRange{any: true}
+	if hasPort {
+		ports, err = parseAgentDestinationPortRange(portSpec)
+		if err != nil {
+			return agentDestinationRule{}, err
+		}
+	}
+
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return agentDestinationRule{}, errors.New("host is required")
+	}
+	if strings.ContainsAny(host, " \t\r\n") {
+		return agentDestinationRule{}, errors.New("host must not contain whitespace")
+	}
+
+	rule := agentDestinationRule{ports: ports}
+	if prefix, err := netip.ParsePrefix(host); err == nil {
+		rule.prefix = normalizeAgentDestinationPrefix(prefix)
+		rule.hasPrefix = true
+		return rule, nil
+	}
+	if strings.Contains(host, "/") {
+		return agentDestinationRule{}, errors.New("CIDR prefix is invalid")
+	}
+	if addr, err := netip.ParseAddr(host); err == nil {
+		rule.prefix = prefixForAgentDestinationAddr(addr)
+		rule.hasPrefix = true
+		return rule, nil
+	}
+	hostname := normalizeAgentDestinationHost(host)
+	if hostname == "" {
+		return agentDestinationRule{}, errors.New("hostname is required")
+	}
+	if strings.Contains(hostname, "*") {
+		return agentDestinationRule{}, errors.New("wildcard hostnames are not supported")
+	}
+	if strings.ContainsAny(hostname, "[]/:") {
+		return agentDestinationRule{}, errors.New("hostname is invalid")
+	}
+	rule.hostname = hostname
+	return rule, nil
+}
+
+func splitAgentAllowTarget(raw string) (host string, portSpec string, hasPort bool, err error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return "", "", false, errors.New("target is required")
+	}
+	if strings.HasPrefix(value, "[") {
+		end := strings.LastIndex(value, "]")
+		if end < 0 {
+			return "", "", false, errors.New("bracketed host is missing closing bracket")
+		}
+		host = value[1:end]
+		rest := value[end+1:]
+		if rest == "" {
+			return host, "", false, nil
+		}
+		if strings.HasPrefix(rest, ":") && len(rest) > 1 {
+			return host, rest[1:], true, nil
+		}
+		return "", "", false, errors.New("bracketed host must be followed by an optional port")
+	}
+	if strings.Count(value, ":") == 1 {
+		before, after, _ := strings.Cut(value, ":")
+		if before == "" {
+			return "", "", false, errors.New("host is required")
+		}
+		if after == "" {
+			return "", "", false, errors.New("port is required")
+		}
+		return before, after, true, nil
+	}
+	return value, "", false, nil
+}
+
+func parseAgentDestinationPortRange(spec string) (agentDestinationPortRange, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return agentDestinationPortRange{}, errors.New("port is required")
+	}
+	if startText, endText, ok := strings.Cut(spec, "-"); ok {
+		start, err := parseAgentDestinationPort(startText)
+		if err != nil {
+			return agentDestinationPortRange{}, err
+		}
+		end, err := parseAgentDestinationPort(endText)
+		if err != nil {
+			return agentDestinationPortRange{}, err
+		}
+		if start > end {
+			return agentDestinationPortRange{}, errors.New("port range start must be less than or equal to end")
+		}
+		return agentDestinationPortRange{min: start, max: end}, nil
+	}
+	port, err := parseAgentDestinationPort(spec)
+	if err != nil {
+		return agentDestinationPortRange{}, err
+	}
+	return agentDestinationPortRange{min: port, max: port}, nil
+}
+
+func parseAgentDestinationPort(spec string) (int, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return 0, errors.New("port is required")
+	}
+	for _, r := range spec {
+		if r < '0' || r > '9' {
+			return 0, fmt.Errorf("port %q is invalid", spec)
+		}
+	}
+	port, err := strconv.Atoi(spec)
+	if err != nil {
+		return 0, fmt.Errorf("port %q is invalid", spec)
+	}
+	if port < 1 || port > 65535 {
+		return 0, fmt.Errorf("port %d is outside 1-65535", port)
+	}
+	return port, nil
+}
+
+func (p *agentDestinationPolicy) dialAddress(ctx context.Context, network string, address string) (string, error) {
+	if p == nil || len(p.rules) == 0 {
+		return address, nil
+	}
+	host, portText, err := net.SplitHostPort(strings.TrimSpace(address))
+	if err != nil {
+		return "", agentDestinationForbidden("requested address must be host:port", err)
+	}
+	port, err := parseAgentDestinationPort(portText)
+	if err != nil {
+		return "", agentDestinationForbidden("requested address port is invalid", err)
+	}
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return "", agentDestinationForbidden("requested address host is required", nil)
+	}
+
+	if addr, err := netip.ParseAddr(host); err == nil {
+		addr = normalizeAgentDestinationAddr(addr)
+		if p.matchesAddr(addr, port) {
+			return address, nil
+		}
+		return "", agentDestinationForbidden("requested IP address is not allowed", nil)
+	}
+
+	hostname := normalizeAgentDestinationHost(host)
+	if hostname == "" || strings.ContainsAny(hostname, "[]/:") {
+		return "", agentDestinationForbidden("requested hostname is invalid", nil)
+	}
+	if p.matchesHostname(hostname, port) {
+		return address, nil
+	}
+	if !p.hasPrefixRules {
+		return "", agentDestinationForbidden("requested hostname is not allowed", nil)
+	}
+
+	addrs, err := agentDestinationLookupIP(ctx, host)
+	if err != nil {
+		if isTimeoutError(err) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) ||
+			(ctx != nil && (errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded))) {
+			return "", err
+		}
+		return "", agentDestinationForbidden("requested hostname did not resolve to an allowed address", err)
+	}
+	for _, addr := range addrs {
+		addr = normalizeAgentDestinationAddr(addr)
+		if !agentDestinationAddrMatchesNetwork(addr, network) {
+			continue
+		}
+		if p.matchesAddr(addr, port) {
+			return net.JoinHostPort(addr.String(), strconv.Itoa(port)), nil
+		}
+	}
+	return "", agentDestinationForbidden("requested hostname resolved outside the allowlist", nil)
+}
+
+func (p *agentDestinationPolicy) matchesHostname(hostname string, port int) bool {
+	for _, rule := range p.rules {
+		if rule.hostname == "" || rule.hostname != hostname {
+			continue
+		}
+		if rule.ports.matches(port) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *agentDestinationPolicy) matchesAddr(addr netip.Addr, port int) bool {
+	for _, rule := range p.rules {
+		if !rule.hasPrefix {
+			continue
+		}
+		if rule.prefix.Contains(addr) && rule.ports.matches(port) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r agentDestinationPortRange) matches(port int) bool {
+	if r.any {
+		return true
+	}
+	return port >= r.min && port <= r.max
+}
+
+func normalizeAgentDestinationHost(host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	host = strings.TrimSuffix(host, ".")
+	return host
+}
+
+func normalizeAgentDestinationAddr(addr netip.Addr) netip.Addr {
+	return addr.Unmap().WithZone("")
+}
+
+func normalizeAgentDestinationPrefix(prefix netip.Prefix) netip.Prefix {
+	addr := normalizeAgentDestinationAddr(prefix.Addr())
+	bits := prefix.Bits()
+	if prefix.Addr().Is4In6() && addr.Is4() {
+		bits -= 96
+	}
+	if addr.Is4() && bits > 32 {
+		bits = 32
+	}
+	if bits < 0 {
+		bits = 0
+	}
+	return netip.PrefixFrom(addr, bits).Masked()
+}
+
+func prefixForAgentDestinationAddr(addr netip.Addr) netip.Prefix {
+	addr = normalizeAgentDestinationAddr(addr)
+	if addr.Is4() {
+		return netip.PrefixFrom(addr, 32)
+	}
+	return netip.PrefixFrom(addr, 128)
+}
+
+func agentDestinationForbidden(reason string, cause error) error {
+	return &agentDestinationForbiddenError{reason: reason, cause: cause}
+}
+
+func agentDestinationAddrMatchesNetwork(addr netip.Addr, network string) bool {
+	switch strings.ToLower(strings.TrimSpace(network)) {
+	case "tcp4":
+		return addr.Is4()
+	case "tcp6":
+		return addr.Is6()
+	default:
+		return true
+	}
+}
+
+func lookupAgentDestinationIP(ctx context.Context, host string) ([]netip.Addr, error) {
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	addrs := make([]netip.Addr, 0, len(ips))
+	for _, ip := range ips {
+		if ip.IP == nil {
+			continue
+		}
+		addr, ok := netip.AddrFromSlice(ip.IP)
+		if !ok {
+			continue
+		}
+		addrs = append(addrs, normalizeAgentDestinationAddr(addr))
+	}
+	if len(addrs) == 0 {
+		return nil, errors.New("hostname did not resolve to IP addresses")
+	}
+	return addrs, nil
+}

--- a/internal/agent/destination_allowlist_test.go
+++ b/internal/agent/destination_allowlist_test.go
@@ -1,0 +1,187 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"testing"
+)
+
+func TestAgentDestinationPolicyAllowsWhenUnset(t *testing.T) {
+	policy, err := newAgentDestinationPolicy(nil)
+	if err != nil {
+		t.Fatalf("newAgentDestinationPolicy() error = %v", err)
+	}
+	if policy != nil {
+		t.Fatalf("policy = %#v, want nil", policy)
+	}
+}
+
+func TestAgentDestinationPolicyExactHostnameRules(t *testing.T) {
+	policy, err := newAgentDestinationPolicy([]string{"App.Internal.:443", "metrics.internal:9000-9002"})
+	if err != nil {
+		t.Fatalf("newAgentDestinationPolicy() error = %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		address     string
+		wantAddress string
+		wantAllowed bool
+	}{
+		{name: "normalizes case and trailing dot", address: "app.internal:443", wantAddress: "app.internal:443", wantAllowed: true},
+		{name: "allows port range", address: "metrics.internal:9001", wantAddress: "metrics.internal:9001", wantAllowed: true},
+		{name: "rejects wrong port", address: "app.internal:444", wantAllowed: false},
+		{name: "rejects wrong host", address: "other.internal:443", wantAllowed: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := policy.dialAddress(context.Background(), "tcp", tt.address)
+			if tt.wantAllowed {
+				if err != nil {
+					t.Fatalf("dialAddress() error = %v", err)
+				}
+				if got != tt.wantAddress {
+					t.Fatalf("dialAddress() = %q, want %q", got, tt.wantAddress)
+				}
+				return
+			}
+			if !errors.Is(err, errAgentDestinationForbidden) {
+				t.Fatalf("dialAddress() error = %T %[1]v, want forbidden", err)
+			}
+		})
+	}
+}
+
+func TestAgentDestinationPolicyCIDRRulesResolveAndDialCheckedIP(t *testing.T) {
+	policy, err := newAgentDestinationPolicy([]string{"10.0.5.0/24:8080", "[2001:db8::/64]:8443"})
+	if err != nil {
+		t.Fatalf("newAgentDestinationPolicy() error = %v", err)
+	}
+	restoreLookup := replaceAgentDestinationLookup(func(ctx context.Context, host string) ([]netip.Addr, error) {
+		switch host {
+		case "svc.internal":
+			return []netip.Addr{netip.MustParseAddr("10.0.5.24"), netip.MustParseAddr("198.51.100.7")}, nil
+		case "v6.internal":
+			return []netip.Addr{netip.MustParseAddr("2001:db8::25")}, nil
+		case "outside.internal":
+			return []netip.Addr{netip.MustParseAddr("10.0.6.24")}, nil
+		default:
+			return nil, fmt.Errorf("unexpected lookup host %q", host)
+		}
+	})
+	t.Cleanup(restoreLookup)
+
+	tests := []struct {
+		name        string
+		network     string
+		address     string
+		wantAddress string
+		wantAllowed bool
+	}{
+		{name: "resolved IPv4 CIDR", network: "tcp", address: "svc.internal:8080", wantAddress: "10.0.5.24:8080", wantAllowed: true},
+		{name: "honors tcp6 network", network: "tcp6", address: "v6.internal:8443", wantAddress: "[2001:db8::25]:8443", wantAllowed: true},
+		{name: "rejects resolved IP outside CIDR", network: "tcp", address: "outside.internal:8080", wantAllowed: false},
+		{name: "rejects wrong port", network: "tcp", address: "svc.internal:8081", wantAllowed: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := policy.dialAddress(context.Background(), tt.network, tt.address)
+			if tt.wantAllowed {
+				if err != nil {
+					t.Fatalf("dialAddress() error = %v", err)
+				}
+				if got != tt.wantAddress {
+					t.Fatalf("dialAddress() = %q, want %q", got, tt.wantAddress)
+				}
+				return
+			}
+			if !errors.Is(err, errAgentDestinationForbidden) {
+				t.Fatalf("dialAddress() error = %T %[1]v, want forbidden", err)
+			}
+		})
+	}
+}
+
+func TestAgentDestinationPolicyPropagatesLookupCancellation(t *testing.T) {
+	policy, err := newAgentDestinationPolicy([]string{"10.0.5.0/24:8080"})
+	if err != nil {
+		t.Fatalf("newAgentDestinationPolicy() error = %v", err)
+	}
+	restoreLookup := replaceAgentDestinationLookup(func(ctx context.Context, host string) ([]netip.Addr, error) {
+		return nil, context.Canceled
+	})
+	t.Cleanup(restoreLookup)
+
+	_, err = policy.dialAddress(context.Background(), "tcp", "svc.internal:8080")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("dialAddress() error = %T %[1]v, want context.Canceled", err)
+	}
+	if errors.Is(err, errAgentDestinationForbidden) {
+		t.Fatalf("dialAddress() error = %T %[1]v, should not be forbidden", err)
+	}
+}
+
+func TestAgentDestinationPolicyIPLiteralRules(t *testing.T) {
+	policy, err := newAgentDestinationPolicy([]string{"127.0.0.1:8080", "[::1]:8443", "[fe80::1]:443"})
+	if err != nil {
+		t.Fatalf("newAgentDestinationPolicy() error = %v", err)
+	}
+	tests := []struct {
+		name        string
+		address     string
+		wantAllowed bool
+	}{
+		{name: "IPv4 literal", address: "127.0.0.1:8080", wantAllowed: true},
+		{name: "IPv6 literal", address: "[::1]:8443", wantAllowed: true},
+		{name: "IPv6 scoped literal", address: "[fe80::1%eth0]:443", wantAllowed: true},
+		{name: "wrong IPv4 port", address: "127.0.0.1:8081", wantAllowed: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := policy.dialAddress(context.Background(), "tcp", tt.address)
+			if tt.wantAllowed && err != nil {
+				t.Fatalf("dialAddress() error = %v", err)
+			}
+			if !tt.wantAllowed && !errors.Is(err, errAgentDestinationForbidden) {
+				t.Fatalf("dialAddress() error = %T %[1]v, want forbidden", err)
+			}
+		})
+	}
+}
+
+func TestNewAgentDestinationPolicyRejectsInvalidRules(t *testing.T) {
+	tests := []string{
+		":443",
+		"app.internal:",
+		"app.internal:0",
+		"app.internal:65536",
+		"app.internal:9001-9000",
+		"10.0.0.0/33",
+		"[2001:db8::1",
+		"*.internal:443",
+	}
+	for _, raw := range tests {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := newAgentDestinationPolicy([]string{raw}); err == nil {
+				t.Fatalf("newAgentDestinationPolicy(%q) error = nil, want error", raw)
+			}
+		})
+	}
+}
+
+func replaceAgentDestinationLookup(fn func(context.Context, string) ([]netip.Addr, error)) func() {
+	previous := agentDestinationLookupIP
+	restored := false
+	agentDestinationLookupIP = fn
+	return func() {
+		if restored {
+			return
+		}
+		restored = true
+		agentDestinationLookupIP = previous
+	}
+}

--- a/internal/server/public_routing.go
+++ b/internal/server/public_routing.go
@@ -872,6 +872,10 @@ func shouldMarkAgentPassiveFailure(requestCtx context.Context, err error) bool {
 	if err == nil {
 		return false
 	}
+	var dialErr agentDialError
+	if errors.As(err, &dialErr) && dialErr.Kind == "dial_forbidden" {
+		return false
+	}
 	return !requestContextCanceled(requestCtx, err)
 }
 

--- a/internal/server/public_routing_timeout_test.go
+++ b/internal/server/public_routing_timeout_test.go
@@ -352,6 +352,34 @@ func TestAgentProxyClosedSessionMarksPassiveFailure(t *testing.T) {
 	}
 }
 
+func TestAgentProxyDialForbiddenDoesNotMarkPassiveFailure(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("upstream should not be reached when agent rejects destination")
+	}))
+	defer upstream.Close()
+
+	app, target, agent, fake := newAgentProxyTunnelTestApp(t, 7, upstream.URL, 500*time.Millisecond)
+	fake.openResponse = func(open tunnel.OpenRequest) tunnel.OpenResponse {
+		return tunnel.OpenResponse{OK: false, ErrorKind: "dial_forbidden", Error: "agent destination forbidden by allowlist"}
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://public.test/agent", nil)
+	proxyAgentTargetForTest(app, rec, req, target, agent)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("dial forbidden status = %d body=%q, want 502", rec.Code, rec.Body.String())
+	}
+	if !app.TargetHealth.agentAvailable(target.ID, agent.AgentID) {
+		t.Fatal("agent dial_forbidden should not make the agent unavailable")
+	}
+	traces, _ := app.TargetHealth.listHealthTraces(target.ID, agent.AgentID, 10, false)
+	if len(traces) != 0 {
+		t.Fatalf("unexpected health traces after dial_forbidden: %+v", traces)
+	}
+	fake.waitOpenRequestCount(t, 1)
+}
+
 func TestAgentProxyHTTPSOriginTLSVerification(t *testing.T) {
 	tlsUpstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("secure upstream"))
@@ -442,6 +470,7 @@ type fakeYamuxAgent struct {
 	serverSession        *yamux.Session
 	agentSession         *yamux.Session
 	requests             chan tunnel.OpenRequest
+	openResponse         func(tunnel.OpenRequest) tunnel.OpenResponse
 	suppressOpenResponse bool
 	mu                   sync.Mutex
 	openRequests         int
@@ -527,6 +556,11 @@ func (f *fakeYamuxAgent) handleStream(stream net.Conn) {
 	}
 	if f.suppressOpenResponse {
 		_, _ = io.Copy(io.Discard, stream)
+		return
+	}
+	if f.openResponse != nil {
+		resp := f.openResponse(open)
+		_ = tunnel.WriteOpenResponse(stream, resp)
 		return
 	}
 	upstream, err := (&net.Dialer{}).DialContext(context.Background(), open.Network, open.Address)

--- a/scripts/install-agent.sh
+++ b/scripts/install-agent.sh
@@ -151,6 +151,14 @@ agent_env_value_is_supported_single_line() {
     return 1
   fi
 
+  while (( index < length )); do
+    char="${value:index:1}"
+    if [[ "$char" == "'" || "$char" == '"' ]]; then
+      return 1
+    fi
+    index=$((index + 1))
+  done
+
   local trailing_backslashes=0
   index=$((length - 1))
   while (( index >= 0 )) && [[ "${value:index:1}" == $'\\' ]]; do
@@ -168,8 +176,8 @@ load_existing_agent_env_assignment() {
   local contents
   local line
   local trimmed
+  local assignment_name
   local value
-  local suffix
 
   EXISTING_AGENT_ENV_ASSIGNMENT=""
   if [[ ! -e "$ENV_FILE" && ! -L "$ENV_FILE" ]]; then
@@ -188,26 +196,19 @@ load_existing_agent_env_assignment() {
     if [[ -z "$trimmed" || "$trimmed" == \#* || "$trimmed" == \;* ]]; then
       continue
     fi
-    if [[ "$trimmed" == "${name}="* ]]; then
-      value="${trimmed#"${name}="}"
-      if ! agent_env_value_is_supported_single_line "$value"; then
-        fail "cannot safely preserve ${name} from ${ENV_FILE}: multiline or ambiguous assignment; provide ${name} or set AGENT_CLEAR_ALLOW_TARGETS=true"
-      fi
+    if [[ "$trimmed" != *=* ]]; then
+      fail "cannot safely preserve ${name} from ${ENV_FILE}: unsupported or multiline environment syntax; provide ${name} or set AGENT_CLEAR_ALLOW_TARGETS=true"
+    fi
+    assignment_name="${trimmed%%=*}"
+    value="${trimmed#*=}"
+    if [[ ! "$assignment_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      fail "cannot safely preserve ${name} from ${ENV_FILE}: unsupported or multiline environment syntax; provide ${name} or set AGENT_CLEAR_ALLOW_TARGETS=true"
+    fi
+    if ! agent_env_value_is_supported_single_line "$value"; then
+      fail "cannot safely preserve ${name} from ${ENV_FILE}: unsupported or multiline environment syntax; provide ${name} or set AGENT_CLEAR_ALLOW_TARGETS=true"
+    fi
+    if [[ "$assignment_name" == "$name" ]]; then
       EXISTING_AGENT_ENV_ASSIGNMENT="${name}=${value}"
-      continue
-    fi
-    if [[ "$trimmed" == "$name"* ]]; then
-      suffix="${trimmed:${#name}:1}"
-      if [[ -z "$suffix" || ! "$suffix" =~ [A-Za-z0-9_] ]]; then
-        fail "cannot safely preserve ${name} from ${ENV_FILE}: ambiguous assignment; provide ${name} or set AGENT_CLEAR_ALLOW_TARGETS=true"
-      fi
-    fi
-    if [[ "$trimmed" == export[[:space:]]* ]]; then
-      trimmed="${trimmed#export}"
-      trimmed="$(trim_leading_agent_env_whitespace "$trimmed")"
-      if [[ "$trimmed" == "${name}="* ]]; then
-        fail "cannot safely preserve ${name} from ${ENV_FILE}: unsupported export assignment; provide ${name} or set AGENT_CLEAR_ALLOW_TARGETS=true"
-      fi
     fi
   done <<<"$contents"
 }

--- a/scripts/install-agent.sh
+++ b/scripts/install-agent.sh
@@ -77,8 +77,37 @@ latest_release_tag() {
   printf '%s' "$tag"
 }
 
+existing_agent_env_assignment() {
+  local name="$1"
+  local line
+  [[ -f "$ENV_FILE" ]] || return 1
+  while IFS= read -r line; do
+    case "$line" in
+      "${name}="*)
+        printf '%s\n' "$line"
+        return 0
+        ;;
+    esac
+  done <"$ENV_FILE"
+  return 1
+}
+
+validate_allow_target_inputs() {
+  case "${AGENT_CLEAR_ALLOW_TARGETS:-false}" in
+    true|false) ;;
+    *) fail "AGENT_CLEAR_ALLOW_TARGETS must be true or false" ;;
+  esac
+  if [[ "${AGENT_CLEAR_ALLOW_TARGETS:-false}" == "true" && -n "${AGENT_ALLOW_TARGETS:-}" ]]; then
+    fail "AGENT_CLEAR_ALLOW_TARGETS=true cannot be combined with AGENT_ALLOW_TARGETS"
+  fi
+}
+
 write_agent_env() {
   local tmp_file="$1"
+  local preserved_allow_targets=""
+  if [[ -z "${AGENT_ALLOW_TARGETS:-}" && "${AGENT_CLEAR_ALLOW_TARGETS:-false}" != "true" ]]; then
+    preserved_allow_targets="$(existing_agent_env_assignment AGENT_ALLOW_TARGETS || true)"
+  fi
   {
     printf 'MANAGEMENT_URL=%s\n' "$(systemd_env_value "$MANAGEMENT_URL")"
     if [[ -n "${MANAGEMENT_CA_FILE:-}" ]]; then
@@ -95,6 +124,8 @@ write_agent_env() {
     fi
     if [[ -n "${AGENT_ALLOW_TARGETS:-}" ]]; then
       printf 'AGENT_ALLOW_TARGETS=%s\n' "$(systemd_env_value "$AGENT_ALLOW_TARGETS")"
+    elif [[ -n "$preserved_allow_targets" ]]; then
+      printf '%s\n' "$preserved_allow_targets"
     fi
     printf 'AGENT_ID=%s\n' "$(systemd_env_value "$AGENT_ID")"
     printf 'AGENT_TOKEN=%s\n' "$(systemd_env_value "$AGENT_TOKEN")"
@@ -231,6 +262,7 @@ main() {
   require_env AGENT_TOKEN
   validate_management_url_inputs
   validate_tls_inputs
+  validate_allow_target_inputs
   ensure_service_user
 
   local repository="${P2PSTREAM_REPOSITORY:-$DEFAULT_REPOSITORY}"

--- a/scripts/install-agent.sh
+++ b/scripts/install-agent.sh
@@ -12,6 +12,7 @@ readonly MANAGEMENT_CA_PEM_FILE="${CONFIG_DIR}/management-ca.pem"
 readonly SERVICE_USER="p2pstream"
 readonly SERVICE_GROUP="p2pstream"
 INSTALL_TMP_DIR=""
+EXISTING_AGENT_ENV_ASSIGNMENT=""
 
 fail() {
   printf 'p2pstream agent install failed: %s\n' "$*" >&2
@@ -77,19 +78,138 @@ latest_release_tag() {
   printf '%s' "$tag"
 }
 
-existing_agent_env_assignment() {
-  local name="$1"
-  local line
-  [[ -f "$ENV_FILE" ]] || return 1
-  while IFS= read -r line; do
-    case "$line" in
-      "${name}="*)
-        printf '%s\n' "$line"
+trim_leading_agent_env_whitespace() {
+  local value="$1"
+  while [[ "$value" == " "* || "$value" == $'\t'* || "$value" == $'\r'* ]]; do
+    value="${value:1}"
+  done
+  printf '%s' "$value"
+}
+
+agent_env_value_is_supported_single_line() {
+  local value="$1"
+  local length="${#value}"
+  local index=0
+  local char
+
+  while (( index < length )); do
+    char="${value:index:1}"
+    if [[ "$char" != " " && "$char" != $'\t' && "$char" != $'\r' ]]; then
+      break
+    fi
+    index=$((index + 1))
+  done
+  if (( index == length )); then
+    return 0
+  fi
+
+  char="${value:index:1}"
+  if [[ "$char" == "'" ]]; then
+    index=$((index + 1))
+    while (( index < length )) && [[ "${value:index:1}" != "'" ]]; do
+      index=$((index + 1))
+    done
+    if (( index == length )); then
+      return 1
+    fi
+    index=$((index + 1))
+    while (( index < length )); do
+      char="${value:index:1}"
+      if [[ "$char" != " " && "$char" != $'\t' && "$char" != $'\r' ]]; then
+        return 1
+      fi
+      index=$((index + 1))
+    done
+    return 0
+  fi
+
+  if [[ "$char" == '"' ]]; then
+    index=$((index + 1))
+    while (( index < length )); do
+      char="${value:index:1}"
+      if [[ "$char" == $'\\' ]]; then
+        index=$((index + 1))
+        if (( index == length )); then
+          return 1
+        fi
+        index=$((index + 1))
+        continue
+      fi
+      if [[ "$char" == '"' ]]; then
+        index=$((index + 1))
+        while (( index < length )); do
+          char="${value:index:1}"
+          if [[ "$char" != " " && "$char" != $'\t' && "$char" != $'\r' ]]; then
+            return 1
+          fi
+          index=$((index + 1))
+        done
         return 0
-        ;;
-    esac
-  done <"$ENV_FILE"
-  return 1
+      fi
+      index=$((index + 1))
+    done
+    return 1
+  fi
+
+  local trailing_backslashes=0
+  index=$((length - 1))
+  while (( index >= 0 )) && [[ "${value:index:1}" == $'\\' ]]; do
+    trailing_backslashes=$((trailing_backslashes + 1))
+    index=$((index - 1))
+  done
+  if (( trailing_backslashes % 2 != 0 )); then
+    return 1
+  fi
+  return 0
+}
+
+load_existing_agent_env_assignment() {
+  local name="$1"
+  local contents
+  local line
+  local trimmed
+  local value
+  local suffix
+
+  EXISTING_AGENT_ENV_ASSIGNMENT=""
+  if [[ ! -e "$ENV_FILE" && ! -L "$ENV_FILE" ]]; then
+    return 0
+  fi
+  if [[ ! -f "$ENV_FILE" || ! -r "$ENV_FILE" ]]; then
+    fail "cannot safely read existing ${ENV_FILE} to preserve ${name}; provide ${name} or set AGENT_CLEAR_ALLOW_TARGETS=true"
+  fi
+  if ! contents="$(sed -n 'p' "$ENV_FILE")"; then
+    fail "cannot safely read existing ${ENV_FILE} to preserve ${name}; provide ${name} or set AGENT_CLEAR_ALLOW_TARGETS=true"
+  fi
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%$'\r'}"
+    trimmed="$(trim_leading_agent_env_whitespace "$line")"
+    if [[ -z "$trimmed" || "$trimmed" == \#* || "$trimmed" == \;* ]]; then
+      continue
+    fi
+    if [[ "$trimmed" == "${name}="* ]]; then
+      value="${trimmed#"${name}="}"
+      if ! agent_env_value_is_supported_single_line "$value"; then
+        fail "cannot safely preserve ${name} from ${ENV_FILE}: multiline or ambiguous assignment; provide ${name} or set AGENT_CLEAR_ALLOW_TARGETS=true"
+      fi
+      EXISTING_AGENT_ENV_ASSIGNMENT="${name}=${value}"
+      continue
+    fi
+    if [[ "$trimmed" == "$name"* ]]; then
+      suffix="${trimmed:${#name}:1}"
+      if [[ -z "$suffix" || ! "$suffix" =~ [A-Za-z0-9_] ]]; then
+        fail "cannot safely preserve ${name} from ${ENV_FILE}: ambiguous assignment; provide ${name} or set AGENT_CLEAR_ALLOW_TARGETS=true"
+      fi
+    fi
+    if [[ "$trimmed" == export[[:space:]]* ]]; then
+      trimmed="${trimmed#export}"
+      trimmed="$(trim_leading_agent_env_whitespace "$trimmed")"
+      if [[ "$trimmed" == "${name}="* ]]; then
+        fail "cannot safely preserve ${name} from ${ENV_FILE}: unsupported export assignment; provide ${name} or set AGENT_CLEAR_ALLOW_TARGETS=true"
+      fi
+    fi
+  done <<<"$contents"
 }
 
 validate_allow_target_inputs() {
@@ -102,12 +222,16 @@ validate_allow_target_inputs() {
   fi
 }
 
+prepare_allow_target_preservation() {
+  EXISTING_AGENT_ENV_ASSIGNMENT=""
+  if [[ -z "${AGENT_ALLOW_TARGETS:-}" && "${AGENT_CLEAR_ALLOW_TARGETS:-false}" != "true" ]]; then
+    load_existing_agent_env_assignment AGENT_ALLOW_TARGETS
+  fi
+}
+
 write_agent_env() {
   local tmp_file="$1"
-  local preserved_allow_targets=""
-  if [[ -z "${AGENT_ALLOW_TARGETS:-}" && "${AGENT_CLEAR_ALLOW_TARGETS:-false}" != "true" ]]; then
-    preserved_allow_targets="$(existing_agent_env_assignment AGENT_ALLOW_TARGETS || true)"
-  fi
+  local preserved_allow_targets="$EXISTING_AGENT_ENV_ASSIGNMENT"
   {
     printf 'MANAGEMENT_URL=%s\n' "$(systemd_env_value "$MANAGEMENT_URL")"
     if [[ -n "${MANAGEMENT_CA_FILE:-}" ]]; then
@@ -263,6 +387,7 @@ main() {
   validate_management_url_inputs
   validate_tls_inputs
   validate_allow_target_inputs
+  prepare_allow_target_preservation
   ensure_service_user
 
   local repository="${P2PSTREAM_REPOSITORY:-$DEFAULT_REPOSITORY}"

--- a/scripts/install-agent.sh
+++ b/scripts/install-agent.sh
@@ -93,6 +93,9 @@ write_agent_env() {
     if [[ "${AGENT_ALLOW_INSECURE_MANAGEMENT:-}" == "true" ]]; then
       printf 'AGENT_ALLOW_INSECURE_MANAGEMENT="true"\n'
     fi
+    if [[ -n "${AGENT_ALLOW_TARGETS:-}" ]]; then
+      printf 'AGENT_ALLOW_TARGETS=%s\n' "$(systemd_env_value "$AGENT_ALLOW_TARGETS")"
+    fi
     printf 'AGENT_ID=%s\n' "$(systemd_env_value "$AGENT_ID")"
     printf 'AGENT_TOKEN=%s\n' "$(systemd_env_value "$AGENT_TOKEN")"
   } >"$tmp_file"

--- a/scripts/test-agent-lifecycle.sh
+++ b/scripts/test-agent-lifecycle.sh
@@ -275,6 +275,105 @@ test_reinstall_explicitly_clears_allow_targets() {
   assert_contains "${CONFIG_DIR}/agent.env" "AGENT_TOKEN=\"new-token\""
 }
 
+test_reinstall_preserves_effective_last_allow_targets() {
+  setup_fixture
+  printf '%s\n' \
+    'MANAGEMENT_URL="https://mgmt.example.test:8081"' \
+    'AGENT_ALLOW_TARGETS=""' \
+    '   AGENT_ALLOW_TARGETS="effective.internal:443"' \
+    'AGENT_ID="agent-one"' \
+    'AGENT_TOKEN="old-token"' >"${CONFIG_DIR}/agent.env"
+
+  run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="new-token"
+
+  assert_contains "${CONFIG_DIR}/agent.env" 'AGENT_ALLOW_TARGETS="effective.internal:443"'
+  assert_not_contains "${CONFIG_DIR}/agent.env" 'AGENT_ALLOW_TARGETS=""'
+  [[ "$(grep -c '^AGENT_ALLOW_TARGETS=' "${CONFIG_DIR}/agent.env")" == "1" ]] \
+    || fail "expected exactly one normalized AGENT_ALLOW_TARGETS assignment"
+}
+
+test_reinstall_preserves_unterminated_allow_targets_line() {
+  setup_fixture
+  printf '%s\n' \
+    'MANAGEMENT_URL="https://mgmt.example.test:8081"' \
+    'AGENT_ID="agent-one"' \
+    'AGENT_TOKEN="old-token"' >"${CONFIG_DIR}/agent.env"
+  printf '%s' 'AGENT_ALLOW_TARGETS="tail.internal:443"' >>"${CONFIG_DIR}/agent.env"
+
+  run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="new-token"
+
+  assert_contains "${CONFIG_DIR}/agent.env" 'AGENT_ALLOW_TARGETS="tail.internal:443"'
+}
+
+test_reinstall_fails_closed_on_ambiguous_allow_targets() {
+  setup_fixture
+  printf '%s\n' \
+    'MANAGEMENT_URL="https://mgmt.example.test:8081"' \
+    'AGENT_ALLOW_TARGETS="first.internal:443,' \
+    'second.internal:443"' \
+    'AGENT_ID="agent-one"' \
+    'AGENT_TOKEN="old-token"' >"${CONFIG_DIR}/agent.env"
+
+  if run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="new-token" \
+    >"${TEST_DIR}/ambiguous-policy.out" 2>"${TEST_DIR}/ambiguous-policy.err"; then
+    fail "ambiguous existing AGENT_ALLOW_TARGETS should fail closed"
+  fi
+  assert_contains "${TEST_DIR}/ambiguous-policy.err" "cannot safely preserve AGENT_ALLOW_TARGETS"
+  assert_contains "${CONFIG_DIR}/agent.env" 'AGENT_ALLOW_TARGETS="first.internal:443,'
+  assert_absent "$INSTALL_PATH"
+  assert_not_contains "$COMMAND_LOG" "curl "
+  assert_not_contains "$SYSTEMCTL_LOG" "restart p2pstream-agent"
+
+  run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    AGENT_ALLOW_TARGETS="replacement.internal:443" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="new-token"
+  assert_contains "${CONFIG_DIR}/agent.env" 'AGENT_ALLOW_TARGETS="replacement.internal:443"'
+  assert_not_contains "${CONFIG_DIR}/agent.env" "second.internal:443"
+}
+
+test_reinstall_fails_closed_on_allow_targets_read_error() {
+  setup_fixture
+  printf '%s\n' \
+    'MANAGEMENT_URL="https://mgmt.example.test:8081"' \
+    'AGENT_ALLOW_TARGETS="preserved.internal:443"' \
+    'AGENT_ID="agent-one"' \
+    'AGENT_TOKEN="old-token"' >"${CONFIG_DIR}/agent.env"
+  write_executable "${FAKE_BIN}/sed" \
+    '#!/usr/bin/env bash' \
+    'exit 1'
+
+  if run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="new-token" \
+    >"${TEST_DIR}/policy-read.out" 2>"${TEST_DIR}/policy-read.err"; then
+    fail "unreadable existing AGENT_ALLOW_TARGETS should fail closed"
+  fi
+  assert_contains "${TEST_DIR}/policy-read.err" "cannot safely read existing"
+  assert_contains "${CONFIG_DIR}/agent.env" 'AGENT_ALLOW_TARGETS="preserved.internal:443"'
+  assert_absent "$INSTALL_PATH"
+  assert_not_contains "$COMMAND_LOG" "curl "
+  assert_not_contains "$SYSTEMCTL_LOG" "restart p2pstream-agent"
+
+  run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    AGENT_CLEAR_ALLOW_TARGETS="true" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="new-token"
+  assert_not_contains "${CONFIG_DIR}/agent.env" "AGENT_ALLOW_TARGETS"
+}
+
 test_reinstall_without_ca_removes_stale_managed_ca() {
   setup_fixture
   printf 'stale CA\n' >"${CONFIG_DIR}/management-ca.pem"
@@ -384,6 +483,10 @@ run_test() {
 run_test "first install" test_first_install
 run_test "reinstall overwrites token and CA" test_reinstall_overwrites_token_and_ca
 run_test "reinstall explicitly clears allow targets" test_reinstall_explicitly_clears_allow_targets
+run_test "reinstall preserves effective last allow targets" test_reinstall_preserves_effective_last_allow_targets
+run_test "reinstall preserves unterminated allow targets line" test_reinstall_preserves_unterminated_allow_targets_line
+run_test "reinstall fails closed on ambiguous allow targets" test_reinstall_fails_closed_on_ambiguous_allow_targets
+run_test "reinstall fails closed on allow targets read error" test_reinstall_fails_closed_on_allow_targets_read_error
 run_test "reinstall without CA removes stale managed CA" test_reinstall_without_ca_removes_stale_managed_ca
 run_test "staging version downloads staging asset" test_staging_version_downloads_staging_asset
 run_test "validation failures" test_validation_failures

--- a/scripts/test-agent-lifecycle.sh
+++ b/scripts/test-agent-lifecycle.sh
@@ -212,6 +212,7 @@ test_first_install() {
   run_installer \
     MANAGEMENT_URL="https://mgmt.example.test:8081" \
     MANAGEMENT_CA_PEM_BASE64="$(base64_value "CA-one")" \
+    AGENT_ALLOW_TARGETS="myapp.internal:443,10.0.5.0/24:8080" \
     AGENT_ID="agent-one" \
     AGENT_TOKEN="token-one"
 
@@ -221,6 +222,7 @@ test_first_install() {
   assert_exists "${SYSTEMD_DIR}/p2pstream-agent.service"
   assert_contains "${CONFIG_DIR}/agent.env" "MANAGEMENT_URL=\"https://mgmt.example.test:8081\""
   assert_contains "${CONFIG_DIR}/agent.env" "MANAGEMENT_CA_FILE=\"${CONFIG_DIR}/management-ca.pem\""
+  assert_contains "${CONFIG_DIR}/agent.env" "AGENT_ALLOW_TARGETS=\"myapp.internal:443,10.0.5.0/24:8080\""
   assert_contains "${CONFIG_DIR}/agent.env" "AGENT_ID=\"agent-one\""
   assert_contains "${CONFIG_DIR}/agent.env" "AGENT_TOKEN=\"token-one\""
   assert_contains "${CONFIG_DIR}/management-ca.pem" "CA-one"

--- a/scripts/test-agent-lifecycle.sh
+++ b/scripts/test-agent-lifecycle.sh
@@ -374,6 +374,62 @@ test_reinstall_fails_closed_on_allow_targets_read_error() {
   assert_not_contains "${CONFIG_DIR}/agent.env" "AGENT_ALLOW_TARGETS"
 }
 
+test_reinstall_rejects_unrelated_multiline_context() {
+  setup_fixture
+  printf '%s\n' \
+    'MANAGEMENT_URL="https://mgmt.example.test:8081"' \
+    'AGENT_ALLOW_TARGETS="restrictive.internal:443"' \
+    'OTHER="continued\' \
+    'AGENT_ALLOW_TARGETS=""' \
+    '"' \
+    'AGENT_ID="agent-one"' \
+    'AGENT_TOKEN="old-token"' >"${CONFIG_DIR}/agent.env"
+
+  if run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="new-token" \
+    >"${TEST_DIR}/continued-policy.out" 2>"${TEST_DIR}/continued-policy.err"; then
+    fail "unrelated multiline context should fail before changing AGENT_ALLOW_TARGETS"
+  fi
+  assert_contains "${TEST_DIR}/continued-policy.err" "unsupported or multiline environment syntax"
+  assert_contains "${CONFIG_DIR}/agent.env" 'AGENT_ALLOW_TARGETS="restrictive.internal:443"'
+  assert_absent "$INSTALL_PATH"
+  assert_not_contains "$COMMAND_LOG" "curl "
+  assert_not_contains "$SYSTEMCTL_LOG" "restart p2pstream-agent"
+
+  run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    AGENT_ALLOW_TARGETS="replacement.internal:443" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="new-token"
+  assert_contains "${CONFIG_DIR}/agent.env" 'AGENT_ALLOW_TARGETS="replacement.internal:443"'
+
+  printf '%s\n' \
+    'MANAGEMENT_URL="https://mgmt.example.test:8081"' \
+    'AGENT_ALLOW_TARGETS="restrictive.internal:443"' \
+    'OTHER=prefix"unsupported' \
+    'AGENT_ID="agent-one"' \
+    'AGENT_TOKEN="old-token"' >"${CONFIG_DIR}/agent.env"
+  if run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="new-token" \
+    >"${TEST_DIR}/unquoted-policy.out" 2>"${TEST_DIR}/unquoted-policy.err"; then
+    fail "quote characters in an unquoted environment value should fail closed"
+  fi
+  assert_contains "${TEST_DIR}/unquoted-policy.err" "unsupported or multiline environment syntax"
+  assert_contains "${CONFIG_DIR}/agent.env" 'AGENT_ALLOW_TARGETS="restrictive.internal:443"'
+
+  run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    AGENT_CLEAR_ALLOW_TARGETS="true" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="new-token"
+  assert_not_contains "${CONFIG_DIR}/agent.env" "AGENT_ALLOW_TARGETS"
+  assert_not_contains "${CONFIG_DIR}/agent.env" "OTHER="
+}
+
 test_reinstall_without_ca_removes_stale_managed_ca() {
   setup_fixture
   printf 'stale CA\n' >"${CONFIG_DIR}/management-ca.pem"
@@ -487,6 +543,7 @@ run_test "reinstall preserves effective last allow targets" test_reinstall_prese
 run_test "reinstall preserves unterminated allow targets line" test_reinstall_preserves_unterminated_allow_targets_line
 run_test "reinstall fails closed on ambiguous allow targets" test_reinstall_fails_closed_on_ambiguous_allow_targets
 run_test "reinstall fails closed on allow targets read error" test_reinstall_fails_closed_on_allow_targets_read_error
+run_test "reinstall rejects unrelated multiline context" test_reinstall_rejects_unrelated_multiline_context
 run_test "reinstall without CA removes stale managed CA" test_reinstall_without_ca_removes_stale_managed_ca
 run_test "staging version downloads staging asset" test_staging_version_downloads_staging_asset
 run_test "validation failures" test_validation_failures

--- a/scripts/test-agent-lifecycle.sh
+++ b/scripts/test-agent-lifecycle.sh
@@ -236,6 +236,7 @@ test_reinstall_overwrites_token_and_ca() {
   run_installer \
     MANAGEMENT_URL="https://mgmt.example.test:8081" \
     MANAGEMENT_CA_PEM_BASE64="$(base64_value "old CA")" \
+    AGENT_ALLOW_TARGETS="myapp.internal:443,10.0.5.0/24:8080" \
     AGENT_ID="agent-one" \
     AGENT_TOKEN="old-token"
   : >"$SYSTEMCTL_LOG"
@@ -248,10 +249,30 @@ test_reinstall_overwrites_token_and_ca() {
 
   assert_contains "${CONFIG_DIR}/agent.env" "AGENT_TOKEN=\"new-token\""
   assert_not_contains "${CONFIG_DIR}/agent.env" "old-token"
+  assert_contains "${CONFIG_DIR}/agent.env" "AGENT_ALLOW_TARGETS=\"myapp.internal:443,10.0.5.0/24:8080\""
   assert_contains "${CONFIG_DIR}/management-ca.pem" "new CA"
   assert_not_contains "${CONFIG_DIR}/management-ca.pem" "old CA"
   assert_systemctl_enable_before_restart
   assert_not_contains "$SYSTEMCTL_LOG" "enable --now"
+}
+
+test_reinstall_explicitly_clears_allow_targets() {
+  setup_fixture
+  run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    AGENT_ALLOW_TARGETS="myapp.internal:443" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="old-token"
+
+  run_installer \
+    MANAGEMENT_URL="https://mgmt.example.test:8081" \
+    AGENT_CLEAR_ALLOW_TARGETS="true" \
+    AGENT_ID="agent-one" \
+    AGENT_TOKEN="new-token"
+
+  assert_not_contains "${CONFIG_DIR}/agent.env" "AGENT_ALLOW_TARGETS"
+  assert_not_contains "${CONFIG_DIR}/agent.env" "AGENT_CLEAR_ALLOW_TARGETS"
+  assert_contains "${CONFIG_DIR}/agent.env" "AGENT_TOKEN=\"new-token\""
 }
 
 test_reinstall_without_ca_removes_stale_managed_ca() {
@@ -301,6 +322,11 @@ test_validation_failures() {
     fail "unsupported P2PSTREAM_VERSION should fail"
   fi
   assert_contains "${TEST_DIR}/version.err" "P2PSTREAM_VERSION must be latest, staging, or vX.Y.Z"
+
+  if run_installer MANAGEMENT_URL="https://mgmt.example.test:8081" AGENT_ALLOW_TARGETS="myapp.internal:443" AGENT_CLEAR_ALLOW_TARGETS="true" AGENT_ID="agent-one" AGENT_TOKEN="token-one" >/dev/null 2>"${TEST_DIR}/allow-targets.err"; then
+    fail "conflicting allow-target inputs should fail"
+  fi
+  assert_contains "${TEST_DIR}/allow-targets.err" "AGENT_CLEAR_ALLOW_TARGETS=true cannot be combined with AGENT_ALLOW_TARGETS"
 }
 
 test_uninstall_full_purge() {
@@ -357,6 +383,7 @@ run_test() {
 
 run_test "first install" test_first_install
 run_test "reinstall overwrites token and CA" test_reinstall_overwrites_token_and_ca
+run_test "reinstall explicitly clears allow targets" test_reinstall_explicitly_clears_allow_targets
 run_test "reinstall without CA removes stale managed CA" test_reinstall_without_ca_removes_stale_managed_ca
 run_test "staging version downloads staging asset" test_staging_version_downloads_staging_asset
 run_test "validation failures" test_validation_failures


### PR DESCRIPTION
## Summary
- add opt-in agent destination allowlist via repeated `--allow-target` and `AGENT_ALLOW_TARGETS`
- enforce exact hostname/IP/CIDR rules before dialing, resolving CIDR hostname targets and dialing the checked IP
- return `dial_forbidden` without closing the tunnel session or marking the agent passive-unhealthy
- document the trust default and wire optional allowlist env through the Linux installer
- preserve the effective last allowlist assignment on reinstall, require an explicit clear to remove it, and fail closed before mutation on unreadable or ambiguous environment files

Closes #126

## Tests
- `go test ./internal/agent ./internal/tunnel ./internal/server ./cmd -count=1`
- `go test ./... -count=1`
- `go test -race ./internal/agent ./internal/server -count=1`
- `scripts/test-agent-lifecycle.sh`
- `git diff --check`