### PR TITLE
Fix agent stats reporter lifecycle

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -70,7 +73,10 @@ var agentCmd = &cobra.Command{
 			allowTargets = splitAgentAllowTargets(os.Getenv("AGENT_ALLOW_TARGETS"))
 		}
 
-		if err := agent.Run(agent.Options{
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+
+		if err := agent.RunContext(ctx, agent.Options{
 			ManagementURL:           mgmtURL,
 			PublicID:                agentID,
 			Name:                    agentName,
@@ -81,7 +87,7 @@ var agentCmd = &cobra.Command{
 			TLSKeyFile:              tlsKeyFile,
 			AllowInsecureManagement: allowInsecureManagement,
 			AllowTargets:            allowTargets,
-		}); err != nil {
+		}); err != nil && ctx.Err() == nil {
 			fmt.Fprintln(os.Stderr, "agent failed: "+err.Error())
 			os.Exit(1)
 		}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -46,9 +46,15 @@ var (
 	agentTunnelOpenRequestTimeout = 10 * time.Second
 	agentTunnelDialTimeout        = 10 * time.Second
 	agentTunnelDialNetwork        = dialTunnelNetwork
+	agentStatsReportInterval      = 5 * time.Second
+	agentStatsReportTimeout       = 10 * time.Second
 )
 
 const agentTunnelResponseHeaderTimeout = 15 * time.Second
+
+type agentStatsReportClient interface {
+	ReportStats(context.Context, *connect.Request[p2pstreamv1.AgentStatsRequest]) (*connect.Response[p2pstreamv1.AgentStatsResponse], error)
+}
 
 type Options struct {
 	ManagementURL           string
@@ -65,6 +71,14 @@ type Options struct {
 
 // Run is the main entry point to start the agent loop
 func Run(opts Options) error {
+	return RunContext(context.Background(), opts)
+}
+
+// RunContext starts the agent loop until the provided context is cancelled.
+func RunContext(ctx context.Context, opts Options) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if err := validateOptions(opts); err != nil {
 		return err
 	}
@@ -85,15 +99,32 @@ func Run(opts Options) error {
 		return err
 	}
 
-	go startStatsReporter(managementClient, opts.ManagementURL, opts.PublicID, opts.Token)
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	statsDone := make(chan struct{})
+	go func() {
+		defer close(statsDone)
+		startStatsReporter(runCtx, managementClient, opts.ManagementURL, opts.PublicID, opts.Token)
+	}()
+	defer func() {
+		cancel()
+		<-statsDone
+	}()
 
 	backoff := agentReconnectBackoffMin
 	for {
+		if err := runCtx.Err(); err != nil {
+			return err
+		}
 		log.Info().Str("tunnel_url", tunnelURL).Msg("Attempting to connect to management server...")
 
 		connectedAt := time.Now()
-		err := connectAndServe(tunnelClient, tunnelURL, opts.PublicID, opts.Name, opts.Token, destinationPolicy)
+		err := connectAndServe(runCtx, tunnelClient, tunnelURL, opts.PublicID, opts.Name, opts.Token, destinationPolicy)
 		if err != nil {
+			if runCtx.Err() != nil {
+				return runCtx.Err()
+			}
 			log.Warn().Err(err).Msg("Disconnected")
 		}
 		if time.Since(connectedAt) >= agentStableConnectionInterval {
@@ -102,7 +133,13 @@ func Run(opts Options) error {
 
 		sleep := jitterAgentReconnectBackoff(backoff)
 		log.Info().Dur("retry_in", sleep).Msg("Waiting before reconnect")
-		time.Sleep(sleep)
+		timer := time.NewTimer(sleep)
+		select {
+		case <-timer.C:
+		case <-runCtx.Done():
+			timer.Stop()
+			return runCtx.Err()
+		}
 		backoff = nextAgentReconnectBackoff(backoff)
 	}
 }
@@ -280,11 +317,14 @@ func managementTunnelHTTPClient(base *http.Client) (*http.Client, error) {
 	}, nil
 }
 
-func connectAndServe(client *http.Client, tunnelURL string, agentPublicID string, agentName string, agentToken string, destinationPolicy *agentDestinationPolicy) error {
-	ctx, cancel := context.WithCancel(context.Background())
+func connectAndServe(ctx context.Context, client *http.Client, tunnelURL string, agentPublicID string, agentName string, agentToken string, destinationPolicy *agentDestinationPolicy) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	serveCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, tunnelURL, nil)
+	req, err := http.NewRequestWithContext(serveCtx, http.MethodGet, tunnelURL, nil)
 	if err != nil {
 		return err
 	}
@@ -330,11 +370,11 @@ func connectAndServe(client *http.Client, tunnelURL string, agentPublicID string
 	log.Info().Msg("Connected tunnel successfully")
 
 	go func() {
-		<-ctx.Done()
+		<-serveCtx.Done()
 		_ = session.Close()
 	}()
 
-	if err := serveTunnelSession(ctx, session, destinationPolicy); err != nil {
+	if err := serveTunnelSession(serveCtx, session, destinationPolicy); err != nil {
 		log.Debug().Err(err).Msg("Tunnel session ended")
 		return err
 	}
@@ -556,47 +596,90 @@ func isTimeoutError(err error) bool {
 	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
-func startStatsReporter(httpClient *http.Client, mgmtURL string, agentPublicID string, agentToken string) {
+func startStatsReporter(ctx context.Context, httpClient *http.Client, mgmtURL string, agentPublicID string, agentToken string) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	client := p2pstreamv1connect.NewAgentManagementServiceClient(
 		httpClient,
 		mgmtURL,
 		connect.WithGRPC(), // We can use gRPC or Connect protocol, let's use default Connect or GRPC
 	)
-	cpuSampler := sysmetrics.NewProcessCPUSampler()
+	runStatsReporter(ctx, client, agentPublicID, agentToken, sysmetrics.NewProcessCPUSampler())
+}
 
-	ticker := time.NewTicker(5 * time.Second)
+func runStatsReporter(ctx context.Context, client agentStatsReportClient, agentPublicID string, agentToken string, cpuSampler *sysmetrics.ProcessCPUSampler) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	interval := agentStatsReportInterval
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
-	for range ticker.C {
-		var mem runtime.MemStats
-		runtime.ReadMemStats(&mem)
-		cpuPercent := 0.0
-		if cpuSampler != nil {
-			if sampled, ok, err := cpuSampler.Sample(); err == nil && ok {
-				cpuPercent = sampled
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := reportAgentStats(ctx, client, agentPublicID, agentToken, cpuSampler); err != nil && ctx.Err() == nil {
+				log.Debug().Err(err).Msg("Failed to report stats")
 			}
 		}
+	}
+}
 
-		req := &p2pstreamv1.AgentStatsRequest{
-			MemorySysMb:      int64(mem.Alloc / 1024 / 1024),
-			NumGoroutine:     int64(runtime.NumGoroutine()),
-			CpuPercent:       cpuPercent,
-			ActiveRequests:   activeRequests.Load(),
-			ReqSuccess:       int64(reqSuccess.Swap(0)),
-			ReqClientError:   int64(reqClientError.Swap(0)),
-			ReqServerError:   int64(reqServerError.Swap(0)),
-			ReqInternalError: int64(reqInternalError.Swap(0)),
-			BytesReceived:    bytesReceived.Swap(0),
-			BytesSent:        bytesSent.Swap(0),
-			AgentPublicId:    agentPublicID,
-		}
+func reportAgentStats(ctx context.Context, client agentStatsReportClient, agentPublicID string, agentToken string, cpuSampler *sysmetrics.ProcessCPUSampler) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	req := buildAgentStatsRequest(agentPublicID, cpuSampler)
 
-		connectReq := connect.NewRequest(req)
-		connectReq.Header().Set("Authorization", "Bearer "+agentToken)
+	connectReq := connect.NewRequest(req)
+	connectReq.Header().Set("Authorization", "Bearer "+agentToken)
 
-		_, err := client.ReportStats(context.Background(), connectReq)
-		if err != nil {
-			log.Debug().Err(err).Msg("Failed to report stats")
+	reportCtx := ctx
+	cancel := func() {}
+	if agentStatsReportTimeout > 0 {
+		reportCtx, cancel = context.WithTimeout(ctx, agentStatsReportTimeout)
+	}
+	defer cancel()
+
+	_, err := client.ReportStats(reportCtx, connectReq)
+	return err
+}
+
+func buildAgentStatsRequest(agentPublicID string, cpuSampler *sysmetrics.ProcessCPUSampler) *p2pstreamv1.AgentStatsRequest {
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	cpuPercent := 0.0
+	if cpuSampler != nil {
+		if sampled, ok, err := cpuSampler.Sample(); err == nil && ok {
+			cpuPercent = sampled
 		}
 	}
+
+	return &p2pstreamv1.AgentStatsRequest{
+		MemorySysMb:      agentStatsMemorySysMB(mem),
+		NumGoroutine:     int64(runtime.NumGoroutine()),
+		CpuPercent:       cpuPercent,
+		ActiveRequests:   activeRequests.Load(),
+		ReqSuccess:       int64(reqSuccess.Swap(0)),
+		ReqClientError:   int64(reqClientError.Swap(0)),
+		ReqServerError:   int64(reqServerError.Swap(0)),
+		ReqInternalError: int64(reqInternalError.Swap(0)),
+		BytesReceived:    bytesReceived.Swap(0),
+		BytesSent:        bytesSent.Swap(0),
+		AgentPublicId:    agentPublicID,
+	}
+}
+
+func agentStatsMemorySysMB(mem runtime.MemStats) int64 {
+	return int64(mem.Sys / 1024 / 1024)
 }

--- a/internal/agent/stats_reporter_test.go
+++ b/internal/agent/stats_reporter_test.go
@@ -1,0 +1,167 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+
+	p2pstreamv1 "p2pstream/gen/proto/p2pstream/v1"
+)
+
+type fakeAgentStatsReportClient struct {
+	report func(context.Context, *connect.Request[p2pstreamv1.AgentStatsRequest]) (*connect.Response[p2pstreamv1.AgentStatsResponse], error)
+}
+
+func (c fakeAgentStatsReportClient) ReportStats(ctx context.Context, req *connect.Request[p2pstreamv1.AgentStatsRequest]) (*connect.Response[p2pstreamv1.AgentStatsResponse], error) {
+	return c.report(ctx, req)
+}
+
+func TestAgentStatsMemoryUsesSysNotAlloc(t *testing.T) {
+	mem := runtime.MemStats{
+		Alloc: 12 << 20,
+		Sys:   34 << 20,
+	}
+	if got := agentStatsMemorySysMB(mem); got != 34 {
+		t.Fatalf("agentStatsMemorySysMB() = %d, want 34", got)
+	}
+}
+
+func TestStatsReporterStopsWhenContextCanceled(t *testing.T) {
+	withAgentStatsReportInterval(t, time.Hour)
+	ctx, cancel := context.WithCancel(context.Background())
+	reportCalled := make(chan struct{}, 1)
+	client := fakeAgentStatsReportClient{
+		report: func(context.Context, *connect.Request[p2pstreamv1.AgentStatsRequest]) (*connect.Response[p2pstreamv1.AgentStatsResponse], error) {
+			select {
+			case reportCalled <- struct{}{}:
+			default:
+			}
+			return connect.NewResponse(&p2pstreamv1.AgentStatsResponse{}), nil
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runStatsReporter(ctx, client, "agent-stats-test", "token", nil)
+	}()
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stats reporter to stop")
+	}
+	select {
+	case <-reportCalled:
+		t.Fatal("ReportStats ran before cancellation")
+	default:
+	}
+}
+
+func TestReportAgentStatsUsesPerAttemptTimeout(t *testing.T) {
+	withAgentStatsReportTimeout(t, 25*time.Millisecond)
+	client := fakeAgentStatsReportClient{
+		report: func(ctx context.Context, req *connect.Request[p2pstreamv1.AgentStatsRequest]) (*connect.Response[p2pstreamv1.AgentStatsResponse], error) {
+			if got := req.Header().Get("Authorization"); got != "Bearer stats-token" {
+				t.Fatalf("authorization header = %q, want bearer token", got)
+			}
+			if req.Msg.AgentPublicId != "agent-stats-test" {
+				t.Fatalf("agent public id = %q, want agent-stats-test", req.Msg.AgentPublicId)
+			}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	started := time.Now()
+	err := reportAgentStats(context.Background(), client, "agent-stats-test", "stats-token", nil)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("reportAgentStats() error = %T %[1]v, want deadline exceeded", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("reportAgentStats() took %s, want under 1s", elapsed)
+	}
+}
+
+func TestRunContextReturnsAfterCancellationDuringReconnectBackoff(t *testing.T) {
+	withAgentReconnectBackoff(t, time.Hour, time.Hour)
+	withAgentStatsReportInterval(t, time.Hour)
+
+	tunnelAttempt := make(chan struct{}, 1)
+	mgmt := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/agent/tunnel" {
+			select {
+			case tunnelAttempt <- struct{}{}:
+			default:
+			}
+			http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer mgmt.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- RunContext(ctx, Options{
+			ManagementURL:           mgmt.URL,
+			PublicID:                "agent-backoff-test",
+			Token:                   "token",
+			AllowInsecureManagement: true,
+		})
+	}()
+
+	select {
+	case <-tunnelAttempt:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for tunnel attempt")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("RunContext() error = %T %[1]v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for RunContext to stop")
+	}
+}
+
+func withAgentStatsReportInterval(t *testing.T, interval time.Duration) {
+	t.Helper()
+	previous := agentStatsReportInterval
+	agentStatsReportInterval = interval
+	t.Cleanup(func() {
+		agentStatsReportInterval = previous
+	})
+}
+
+func withAgentStatsReportTimeout(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	previous := agentStatsReportTimeout
+	agentStatsReportTimeout = timeout
+	t.Cleanup(func() {
+		agentStatsReportTimeout = previous
+	})
+}
+
+func withAgentReconnectBackoff(t *testing.T, min time.Duration, max time.Duration) {
+	t.Helper()
+	previousMin := agentReconnectBackoffMin
+	previousMax := agentReconnectBackoffMax
+	agentReconnectBackoffMin = min
+	agentReconnectBackoffMax = max
+	t.Cleanup(func() {
+		agentReconnectBackoffMin = previousMin
+		agentReconnectBackoffMax = previousMax
+	})
+}

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -669,7 +669,7 @@ func TestPublicProxyConfigAgentsUseMemoryLatestStats(t *testing.T) {
 	app.storeLatestAgentStats(agent.ID, stats.AgentStats{
 		Timestamp:        time.Unix(1700000000, 0).UTC(),
 		NumGoroutine:     12,
-		AllocAllocated:   256,
+		MemorySysMB:      256,
 		ReqSuccess:       7,
 		ReqClientError:   1,
 		ReqServerError:   2,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -188,7 +188,7 @@ func (a *App) ReportStats(
 	s := stats.AgentStats{
 		Timestamp:        time.Now(),
 		NumGoroutine:     int(payload.NumGoroutine),
-		AllocAllocated:   uint64(payload.MemorySysMb),
+		MemorySysMB:      uint64(payload.MemorySysMb),
 		ActiveRequests:   payload.ActiveRequests,
 		CPUPercent:       payload.CpuPercent,
 		ReqSuccess:       int32(payload.ReqSuccess),
@@ -254,7 +254,7 @@ func (a *App) latestAgentStatsSnapshot(agentID int64) (*p2pstreamv1.AgentStatsSn
 
 func agentStatsSnapshotFromRuntime(stat stats.AgentStats) *p2pstreamv1.AgentStatsSnapshot {
 	return &p2pstreamv1.AgentStatsSnapshot{
-		MemorySysMb:          int64(stat.AllocAllocated),
+		MemorySysMb:          int64(stat.MemorySysMB),
 		NumGoroutine:         int64(stat.NumGoroutine),
 		ReqSuccess:           int64(stat.ReqSuccess),
 		ReqClientError:       int64(stat.ReqClientError),

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -5,7 +5,7 @@ import "time"
 type AgentStats struct {
 	Timestamp      time.Time `json:"timestamp"`
 	NumGoroutine   int       `json:"num_goroutine"`
-	AllocAllocated uint64    `json:"memory_allocated_mb"`
+	MemorySysMB    uint64    `json:"memory_sys_mb"`
 	ActiveRequests int32     `json:"active_requests"`
 	CPUPercent     float64   `json:"cpu_percent"`
 

--- a/tests/integration/e2e_test.go
+++ b/tests/integration/e2e_test.go
@@ -66,8 +66,8 @@ func TestE2E_ReportStats(t *testing.T) {
 		t.Fatal("Expected stats to be stored in app, got nil")
 	}
 
-	if stats.AllocAllocated != 100 {
-		t.Errorf("Expected memory 100, got %d", stats.AllocAllocated)
+	if stats.MemorySysMB != 100 {
+		t.Errorf("Expected memory 100, got %d", stats.MemorySysMB)
 	}
 	if stats.ReqSuccess != 10 {
 		t.Errorf("Expected 10 successful reqs, got %d", stats.ReqSuccess)
@@ -98,7 +98,7 @@ func TestE2E_GetStatus(t *testing.T) {
 	app.LatestAgentStats.Store(&stats.AgentStats{
 		Timestamp:        time.UnixMilli(1700000000123),
 		NumGoroutine:     7,
-		AllocAllocated:   128,
+		MemorySysMB:      128,
 		ActiveRequests:   4,
 		ReqSuccess:       11,
 		ReqClientError:   2,


### PR DESCRIPTION
## Summary
- report `memory_sys_mb` from `runtime.MemStats.Sys` instead of live heap `Alloc`
- add `RunContext` and wire the agent CLI to signal cancellation
- make stats reporting context-aware with a bounded per-attempt timeout
- rename the internal runtime stats field to match system-memory semantics

Closes #127

## Tests
- `go test ./internal/agent -run 'TestAgentStats|TestStatsReporter|TestReportAgentStats|TestRunContext' -count=1 -v`\n- `go test ./internal/agent ./cmd ./internal/server ./tests/integration -count=1`\n- `go test ./... -count=1`\n- `go test -race ./internal/agent ./internal/server -count=1`\n- `git diff --check`\n- `git diff --cached --check`