### PR TITLE
release: v0.1.46

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -333,6 +333,7 @@ func defaultDatabaseURL(dbPath string) string {
 	values.Set("_journal_mode", "WAL")
 	values.Set("_synchronous", "NORMAL")
 	values.Set("_busy_timeout", "10000")
+	values.Set("_txlock", "immediate")
 	values.Set("_fk", "1")
 	values.Set("cache", "private")
 	return "file:" + filepath.ToSlash(dbPath) + "?" + values.Encode()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -480,6 +480,7 @@ func assertSQLiteURL(t *testing.T, got, wantDBPath string) {
 		"_journal_mode": "WAL",
 		"_synchronous":  "NORMAL",
 		"_busy_timeout": "10000",
+		"_txlock":       "immediate",
 		"_fk":           "1",
 		"cache":         "private",
 	}

--- a/internal/db/connection_open_test.go
+++ b/internal/db/connection_open_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNormalizeSQLiteDSNForcesWALAndPrivateCache(t *testing.T) {
@@ -29,8 +30,67 @@ func TestNormalizeSQLiteDSNForcesWALAndPrivateCache(t *testing.T) {
 	if values.Get("_busy_timeout") != "10000" {
 		t.Fatalf("expected 10000 busy timeout, got %q", values.Get("_busy_timeout"))
 	}
+	if values.Get("_txlock") != "immediate" {
+		t.Fatalf("expected immediate transaction locking, got %q", values.Get("_txlock"))
+	}
 	if values.Get("cache") != "private" {
 		t.Fatalf("expected private cache, got %q", values.Get("cache"))
+	}
+}
+
+func TestOpenReadThenWriteTransactionDoesNotLoseToConcurrentWriter(t *testing.T) {
+	database, err := Open(filepath.Join(t.TempDir(), "transaction-lock-test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = database.Close() }()
+	if _, err := database.Exec(`CREATE TABLE transaction_lock_test (id INTEGER PRIMARY KEY, value TEXT NOT NULL)`); err != nil {
+		t.Fatalf("create test table: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	tx, err := database.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin transaction: %v", err)
+	}
+	defer tx.Rollback()
+	var count int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM transaction_lock_test`).Scan(&count); err != nil {
+		t.Fatalf("establish read snapshot: %v", err)
+	}
+
+	writerDone := make(chan error, 1)
+	go func() {
+		_, err := database.ExecContext(ctx, `INSERT INTO transaction_lock_test (id, value) VALUES (2, 'concurrent')`)
+		writerDone <- err
+	}()
+
+	writerFinished := false
+	select {
+	case err := <-writerDone:
+		writerFinished = true
+		if err != nil {
+			t.Fatalf("concurrent writer: %v", err)
+		}
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	if _, err := tx.ExecContext(ctx, `INSERT INTO transaction_lock_test (id, value) VALUES (1, 'transaction')`); err != nil {
+		t.Fatalf("write after read snapshot: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit transaction: %v", err)
+	}
+	if !writerFinished {
+		select {
+		case err := <-writerDone:
+			if err != nil {
+				t.Fatalf("concurrent writer after commit: %v", err)
+			}
+		case <-ctx.Done():
+			t.Fatalf("concurrent writer did not finish: %v", ctx.Err())
+		}
 	}
 }
 

--- a/internal/db/sqlite_dsn.go
+++ b/internal/db/sqlite_dsn.go
@@ -38,6 +38,10 @@ func applySQLitePragmas(values url.Values) {
 	values.Set("_journal_mode", "WAL")
 	values.Set("_synchronous", "NORMAL")
 	values.Set("_busy_timeout", "10000")
+	// Reserve the single SQLite writer when a write transaction begins. A
+	// deferred transaction can otherwise lose a read-to-write upgrade with
+	// SQLITE_BUSY without honoring the busy timeout.
+	values.Set("_txlock", "immediate")
 	values.Set("_fk", "1")
 	values.Set("cache", "private")
 }

--- a/internal/server/public_access_handlers.go
+++ b/internal/server/public_access_handlers.go
@@ -123,6 +123,10 @@ func (a *App) CreatePublicAccessUser(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
+	params, err := validatePublicAccessUserInput(req.Msg.Username, req.Msg.Password, req.Msg.Enabled, req.Msg.Groups, "")
+	if err != nil {
+		return nil, err
+	}
 	tx, err := a.DB.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
@@ -135,10 +139,6 @@ func (a *App) CreatePublicAccessUser(
 	}
 	if normalizePublicAccessProviderType(provider.ProviderType) != publicAccessProviderTypeLocal {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("users can only be added to a local access provider"))
-	}
-	params, err := validatePublicAccessUserInput(req.Msg.Username, req.Msg.Password, req.Msg.Enabled, req.Msg.Groups, "")
-	if err != nil {
-		return nil, err
 	}
 	user, err := qtx.CreatePublicAccessUser(ctx, db.CreatePublicAccessUserParams{
 		ProviderID: req.Msg.ProviderId, Username: params.Username, PasswordHash: params.PasswordHash,
@@ -163,19 +163,26 @@ func (a *App) UpdatePublicAccessUser(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
-	tx, err := a.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
-	}
-	defer tx.Rollback()
-	qtx := a.DB.WithTx(tx)
-	existing, err := qtx.GetPublicAccessUser(ctx, req.Msg.Id)
+	existing, err := a.DB.GetPublicAccessUser(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, publicDBError(err)
 	}
 	params, err := validatePublicAccessUserInput(req.Msg.Username, req.Msg.Password, req.Msg.Enabled, req.Msg.Groups, existing.PasswordHash)
 	if err != nil {
 		return nil, err
+	}
+	tx, err := a.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	defer tx.Rollback()
+	qtx := a.DB.WithTx(tx)
+	current, err := qtx.GetPublicAccessUser(ctx, req.Msg.Id)
+	if err != nil {
+		return nil, publicDBError(err)
+	}
+	if req.Msg.Password == "" {
+		params.PasswordHash = current.PasswordHash
 	}
 	params.ID = req.Msg.Id
 	user, err := qtx.UpdatePublicAccessUser(ctx, params)

--- a/internal/server/public_cache.go
+++ b/internal/server/public_cache.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/textproto"
@@ -2235,6 +2236,9 @@ func (a *App) validatePublicCacheRouteIDs(ctx context.Context, ids []int64) ([]i
 	}
 	for _, id := range ids {
 		if _, err := a.DB.GetPublicRoute(ctx, id); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("cache rule route %d no longer exists; remove it from the rule scope before saving", id))
+			}
 			return nil, publicDBError(err)
 		}
 	}
@@ -2248,6 +2252,9 @@ func (a *App) validatePublicCacheTargetIDs(ctx context.Context, ids []int64) ([]
 	}
 	for _, id := range ids {
 		if _, err := a.DB.GetPublicRouteTarget(ctx, id); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("cache rule route target %d no longer exists; remove it from the rule scope before saving", id))
+			}
 			return nil, publicDBError(err)
 		}
 	}

--- a/internal/server/public_cache_test.go
+++ b/internal/server/public_cache_test.go
@@ -460,6 +460,17 @@ func TestPublicCacheRejectsSensitiveConfiguredVaryHeaders(t *testing.T) {
 	}
 }
 
+func TestPublicCacheScopeValidationExplainsMissingReferences(t *testing.T) {
+	app, _, closeDB := newTestPublicCacheApp(t)
+	defer closeDB()
+	if _, err := app.validatePublicCacheRouteIDs(context.Background(), []int64{404}); connect.CodeOf(err) != connect.CodeInvalidArgument || !strings.Contains(err.Error(), "cache rule route 404 no longer exists") {
+		t.Fatalf("missing route error = %v", err)
+	}
+	if _, err := app.validatePublicCacheTargetIDs(context.Background(), []int64{405}); connect.CodeOf(err) != connect.CodeInvalidArgument || !strings.Contains(err.Error(), "cache rule route target 405 no longer exists") {
+		t.Fatalf("missing target error = %v", err)
+	}
+}
+
 func TestPublicCacheGeneratedForwardedVaryHeadersAreCaseInsensitive(t *testing.T) {
 	rule := publicCacheRuleConfig{
 		TTL:              time.Hour,

--- a/internal/server/public_config.go
+++ b/internal/server/public_config.go
@@ -127,11 +127,13 @@ type existingSensitiveUpstreamHeaderValue struct {
 }
 
 type existingPublicRouteTargetSecrets struct {
+	TargetIDs          map[int64]struct{}
 	UpstreamHeaders    map[int64]existingSensitiveUpstreamHeaderValue
 	BasicAuthPasswords map[int64]string
 }
 
 type publicRouteTargetMutationInput struct {
+	ID              int64
 	Params          db.CreatePublicRouteTargetParams
 	UpstreamHeaders []publicRouteTargetUpstreamHeaderInput
 	ResponseHeaders []publicRouteTargetResponseHeaderInput

--- a/internal/server/public_config_handlers.go
+++ b/internal/server/public_config_handlers.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"connectrpc.com/connect"
 
@@ -402,10 +403,12 @@ func (a *App) existingPublicRouteTargetSecrets(ctx context.Context, routeID int6
 		return existingPublicRouteTargetSecrets{}, err
 	}
 	secrets := existingPublicRouteTargetSecrets{
+		TargetIDs:          make(map[int64]struct{}, len(targets)),
 		UpstreamHeaders:    make(map[int64]existingSensitiveUpstreamHeaderValue),
 		BasicAuthPasswords: make(map[int64]string),
 	}
 	for _, target := range targets {
+		secrets.TargetIDs[target.ID] = struct{}{}
 		if target.UpstreamBasicAuthEnabled != 0 && target.UpstreamBasicAuthPassword != "" {
 			secrets.BasicAuthPasswords[target.ID] = target.UpstreamBasicAuthPassword
 		}
@@ -485,12 +488,70 @@ func (a *App) updatePublicRouteWithTargets(
 	if err != nil {
 		return db.PublicRoute{}, nil, err
 	}
-	if err := qtx.DeletePublicRouteTargets(ctx, params.ID); err != nil {
-		return db.PublicRoute{}, nil, err
-	}
-	storedTargets, err := insertPublicRouteTargets(ctx, qtx, params.ID, targets)
+	existingTargets, err := qtx.ListPublicRouteTargetsByRoute(ctx, params.ID)
 	if err != nil {
 		return db.PublicRoute{}, nil, err
+	}
+	existingIDs := make(map[int64]struct{}, len(existingTargets))
+	for _, target := range existingTargets {
+		existingIDs[target.ID] = struct{}{}
+	}
+	retainedIDs := make(map[int64]struct{}, len(targets))
+	for _, target := range targets {
+		if target.ID > 0 {
+			retainedIDs[target.ID] = struct{}{}
+		}
+	}
+	// Free final position values before applying the submitted order. Existing
+	// targets move to a route-local temporary range so swaps cannot collide with
+	// UNIQUE(route_id, position); omitted targets are replacements and can be
+	// removed before new rows are inserted.
+	for _, target := range existingTargets {
+		if _, retained := retainedIDs[target.ID]; !retained {
+			if err := qtx.DeletePublicRouteTarget(ctx, target.ID); err != nil {
+				return db.PublicRoute{}, nil, err
+			}
+			delete(existingIDs, target.ID)
+			continue
+		}
+		staged := publicRouteTargetStoredUpdateParams(target)
+		staged.Position = -target.ID
+		if _, err := qtx.UpdatePublicRouteTarget(ctx, staged); err != nil {
+			return db.PublicRoute{}, nil, err
+		}
+	}
+	storedTargets := make([]db.PublicRouteTarget, 0, len(targets))
+	for idx, target := range targets {
+		target.Params.RouteID = params.ID
+		target.Params.Position = int64(idx)
+		var stored db.PublicRouteTarget
+		if target.ID > 0 {
+			if _, ok := existingIDs[target.ID]; !ok {
+				return db.PublicRoute{}, nil, fmt.Errorf("route target %d does not belong to route %d", target.ID, params.ID)
+			}
+			stored, err = qtx.UpdatePublicRouteTarget(ctx, publicRouteTargetUpdateParams(target.ID, target.Params))
+			if err == nil {
+				err = qtx.DeletePublicRouteTargetUpstreamHeaders(ctx, target.ID)
+			}
+			if err == nil {
+				err = qtx.DeletePublicRouteTargetResponseHeaders(ctx, target.ID)
+			}
+			delete(existingIDs, target.ID)
+		} else {
+			stored, err = qtx.CreatePublicRouteTarget(ctx, target.Params)
+		}
+		if err != nil {
+			return db.PublicRoute{}, nil, err
+		}
+		if err := insertPublicRouteTargetHeaders(ctx, qtx, stored.ID, target); err != nil {
+			return db.PublicRoute{}, nil, err
+		}
+		storedTargets = append(storedTargets, stored)
+	}
+	for id := range existingIDs {
+		if err := qtx.DeletePublicRouteTarget(ctx, id); err != nil {
+			return db.PublicRoute{}, nil, err
+		}
 	}
 	if err := tx.Commit(); err != nil {
 		return db.PublicRoute{}, nil, err
@@ -513,30 +574,75 @@ func insertPublicRouteTargets(
 		if err != nil {
 			return nil, err
 		}
-		for headerIdx, header := range target.UpstreamHeaders {
-			if _, err := queries.CreatePublicRouteTargetUpstreamHeader(ctx, db.CreatePublicRouteTargetUpstreamHeaderParams{
-				TargetID:  stored.ID,
-				Position:  int64(headerIdx),
-				Name:      header.Name,
-				Value:     header.Value,
-				Sensitive: header.Sensitive,
-			}); err != nil {
-				return nil, err
-			}
-		}
-		for headerIdx, header := range target.ResponseHeaders {
-			if _, err := queries.CreatePublicRouteTargetResponseHeader(ctx, db.CreatePublicRouteTargetResponseHeaderParams{
-				TargetID: stored.ID,
-				Position: int64(headerIdx),
-				Name:     header.Name,
-				Value:    header.Value,
-			}); err != nil {
-				return nil, err
-			}
+		if err := insertPublicRouteTargetHeaders(ctx, queries, stored.ID, target); err != nil {
+			return nil, err
 		}
 		storedTargets = append(storedTargets, stored)
 	}
 	return storedTargets, nil
+}
+
+func insertPublicRouteTargetHeaders(ctx context.Context, queries *db.Queries, targetID int64, target publicRouteTargetMutationInput) error {
+	for headerIdx, header := range target.UpstreamHeaders {
+		if _, err := queries.CreatePublicRouteTargetUpstreamHeader(ctx, db.CreatePublicRouteTargetUpstreamHeaderParams{
+			TargetID:  targetID,
+			Position:  int64(headerIdx),
+			Name:      header.Name,
+			Value:     header.Value,
+			Sensitive: header.Sensitive,
+		}); err != nil {
+			return err
+		}
+	}
+	for headerIdx, header := range target.ResponseHeaders {
+		if _, err := queries.CreatePublicRouteTargetResponseHeader(ctx, db.CreatePublicRouteTargetResponseHeaderParams{
+			TargetID: targetID,
+			Position: int64(headerIdx),
+			Name:     header.Name,
+			Value:    header.Value,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func publicRouteTargetUpdateParams(id int64, params db.CreatePublicRouteTargetParams) db.UpdatePublicRouteTargetParams {
+	return db.UpdatePublicRouteTargetParams{
+		ID: id, RouteID: params.RouteID, Name: params.Name, Position: params.Position,
+		PriorityGroup: params.PriorityGroup, Weight: params.Weight, Enabled: params.Enabled,
+		TargetType: params.TargetType, Url: params.Url, Transport: params.Transport,
+		AgentSelectorJson: params.AgentSelectorJson, AgentLoadBalancing: params.AgentLoadBalancing,
+		TlsSkipVerify: params.TlsSkipVerify, UpstreamBasicAuthEnabled: params.UpstreamBasicAuthEnabled,
+		UpstreamBasicAuthUsername: params.UpstreamBasicAuthUsername, UpstreamBasicAuthPassword: params.UpstreamBasicAuthPassword,
+		UpstreamResponseHeaderTimeoutMillis: params.UpstreamResponseHeaderTimeoutMillis,
+		HealthCheckEnabled:                  params.HealthCheckEnabled, HealthCheckMethod: params.HealthCheckMethod,
+		HealthCheckPath: params.HealthCheckPath, HealthCheckIntervalMillis: params.HealthCheckIntervalMillis,
+		HealthCheckTimeoutMillis: params.HealthCheckTimeoutMillis, HealthCheckHealthyThreshold: params.HealthCheckHealthyThreshold,
+		HealthCheckUnhealthyThreshold: params.HealthCheckUnhealthyThreshold,
+		HealthCheckExpectedStatusMin:  params.HealthCheckExpectedStatusMin, HealthCheckExpectedStatusMax: params.HealthCheckExpectedStatusMax,
+		StaticStatusCode: params.StaticStatusCode, StaticResponseBody: params.StaticResponseBody,
+		StaticResponseBodyMode: params.StaticResponseBodyMode, StaticResponseTemplateID: params.StaticResponseTemplateID,
+	}
+}
+
+func publicRouteTargetStoredUpdateParams(target db.PublicRouteTarget) db.UpdatePublicRouteTargetParams {
+	return db.UpdatePublicRouteTargetParams{
+		ID: target.ID, RouteID: target.RouteID, Name: target.Name, Position: target.Position,
+		PriorityGroup: target.PriorityGroup, Weight: target.Weight, Enabled: target.Enabled,
+		TargetType: target.TargetType, Url: target.Url, Transport: target.Transport,
+		AgentSelectorJson: target.AgentSelectorJson, AgentLoadBalancing: target.AgentLoadBalancing,
+		TlsSkipVerify: target.TlsSkipVerify, UpstreamBasicAuthEnabled: target.UpstreamBasicAuthEnabled,
+		UpstreamBasicAuthUsername: target.UpstreamBasicAuthUsername, UpstreamBasicAuthPassword: target.UpstreamBasicAuthPassword,
+		UpstreamResponseHeaderTimeoutMillis: target.UpstreamResponseHeaderTimeoutMillis,
+		HealthCheckEnabled:                  target.HealthCheckEnabled, HealthCheckMethod: target.HealthCheckMethod,
+		HealthCheckPath: target.HealthCheckPath, HealthCheckIntervalMillis: target.HealthCheckIntervalMillis,
+		HealthCheckTimeoutMillis: target.HealthCheckTimeoutMillis, HealthCheckHealthyThreshold: target.HealthCheckHealthyThreshold,
+		HealthCheckUnhealthyThreshold: target.HealthCheckUnhealthyThreshold,
+		HealthCheckExpectedStatusMin:  target.HealthCheckExpectedStatusMin, HealthCheckExpectedStatusMax: target.HealthCheckExpectedStatusMax,
+		StaticStatusCode: target.StaticStatusCode, StaticResponseBody: target.StaticResponseBody,
+		StaticResponseBodyMode: target.StaticResponseBodyMode, StaticResponseTemplateID: target.StaticResponseTemplateID,
+	}
 }
 
 func (a *App) DeletePublicRoute(

--- a/internal/server/public_config_test.go
+++ b/internal/server/public_config_test.go
@@ -129,10 +129,79 @@ func TestPublicRouteUpdatePreservesMaskedSensitiveUpstreamHeaders(t *testing.T) 
 	if got := updateResp.Msg.Route.Targets[0].UpstreamRequestHeaders[0]; got.Value != "" || got.ValueSet {
 		t.Fatalf("updated sensitive header proto = %+v, want masked with value_set=false", got)
 	}
+	if got, want := updateResp.Msg.Route.Targets[0].Id, createResp.Msg.Route.Targets[0].Id; got != want {
+		t.Fatalf("updated target ID = %d, want preserved ID %d", got, want)
+	}
 	assertPublicRouteUpstreamHeaderValues(t, app.DB, updateResp.Msg.Route.Id, map[string]string{
 		"x-secret": "top-secret",
 		"cookie":   "session=abc",
 	})
+}
+
+func TestPublicRouteUpdateRejectsTargetIDFromAnotherRoute(t *testing.T) {
+	app := NewApp(nil, newServerTestDB(t))
+	header := createTestAdminSession(t, app)
+	listener := seedPublicConfigTestListener(t, app.DB)
+
+	firstReq := testPublicRouteRequest(listener.ID, "/first-target", nil)
+	firstReq.Header().Set("Cookie", header.Get("Cookie"))
+	firstResp, err := app.CreatePublicRoute(context.Background(), firstReq)
+	if err != nil {
+		t.Fatalf("create first route: %v", err)
+	}
+	secondReq := testPublicRouteRequest(listener.ID, "/second-target", nil)
+	secondReq.Header().Set("Cookie", header.Get("Cookie"))
+	secondResp, err := app.CreatePublicRoute(context.Background(), secondReq)
+	if err != nil {
+		t.Fatalf("create second route: %v", err)
+	}
+
+	forgedTarget := firstResp.Msg.Route.Targets[0]
+	updateReq := testPublicRouteUpdateRequest(secondResp.Msg.Route, "/second-target", []*p2pstreamv1.PublicRouteTarget{forgedTarget})
+	updateReq.Header().Set("Cookie", header.Get("Cookie"))
+	_, err = app.UpdatePublicRoute(context.Background(), updateReq)
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("cross-route target update error = %v, want invalid argument", err)
+	}
+	stored, err := app.DB.GetPublicRouteTarget(context.Background(), secondResp.Msg.Route.Targets[0].Id)
+	if err != nil || stored.RouteID != secondResp.Msg.Route.Id {
+		t.Fatalf("second route target after rejected update = %+v, err %v", stored, err)
+	}
+}
+
+func TestPublicRouteUpdateReordersTargetsWithoutChangingIDs(t *testing.T) {
+	app := NewApp(nil, newServerTestDB(t))
+	header := createTestAdminSession(t, app)
+	listener := seedPublicConfigTestListener(t, app.DB)
+	createReq := testPublicRouteRequest(listener.ID, "/reorder-targets", nil)
+	createReq.Msg.Targets = append(createReq.Msg.Targets, &p2pstreamv1.PublicRouteTarget{
+		Name:       "target-2",
+		Enabled:    true,
+		TargetType: p2pstreamv1.PublicRouteTargetType_PUBLIC_ROUTE_TARGET_TYPE_PROXY,
+		Url:        "http://127.0.0.1:9001",
+		Transport:  p2pstreamv1.PublicRouteTargetTransport_PUBLIC_ROUTE_TARGET_TRANSPORT_DIRECT,
+		Weight:     100,
+	})
+	createReq.Header().Set("Cookie", header.Get("Cookie"))
+	created, err := app.CreatePublicRoute(context.Background(), createReq)
+	if err != nil {
+		t.Fatalf("create route: %v", err)
+	}
+	firstID := created.Msg.Route.Targets[0].Id
+	secondID := created.Msg.Route.Targets[1].Id
+
+	updateReq := testPublicRouteUpdateRequest(created.Msg.Route, "/reorder-targets", []*p2pstreamv1.PublicRouteTarget{
+		created.Msg.Route.Targets[1],
+		created.Msg.Route.Targets[0],
+	})
+	updateReq.Header().Set("Cookie", header.Get("Cookie"))
+	updated, err := app.UpdatePublicRoute(context.Background(), updateReq)
+	if err != nil {
+		t.Fatalf("reorder route targets: %v", err)
+	}
+	if got := updated.Msg.Route.Targets; len(got) != 2 || got[0].Id != secondID || got[1].Id != firstID {
+		t.Fatalf("reordered targets = %+v, want IDs [%d, %d]", got, secondID, firstID)
+	}
 }
 
 func TestPublicRouteUpdateRejectsMaskedSensitiveHeaderFromAnotherRoute(t *testing.T) {

--- a/internal/server/public_config_validation.go
+++ b/internal/server/public_config_validation.go
@@ -130,9 +130,22 @@ func (a *App) validatePublicRouteTargets(
 	}
 	resp := make([]publicRouteTargetMutationInput, 0, len(targets))
 	enabledTargets := 0
+	seenTargetIDs := make(map[int64]struct{}, len(targets))
 	for idx, target := range targets {
 		if target == nil {
 			continue
+		}
+		if target.Id < 0 {
+			return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("route target ID cannot be negative"))
+		}
+		if target.Id > 0 {
+			if _, ok := existingSecrets.TargetIDs[target.Id]; !ok {
+				return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("route target %d does not belong to this route", target.Id))
+			}
+			if _, ok := seenTargetIDs[target.Id]; ok {
+				return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("route target %d is duplicated", target.Id))
+			}
+			seenTargetIDs[target.Id] = struct{}{}
 		}
 		targetType, err := publicRouteTargetTypeStringFromProto(target.TargetType)
 		if err != nil {
@@ -257,6 +270,7 @@ func (a *App) validatePublicRouteTargets(
 			enabledTargets++
 		}
 		resp = append(resp, publicRouteTargetMutationInput{
+			ID:              target.Id,
 			Params:          params,
 			UpstreamHeaders: upstreamHeaders,
 			ResponseHeaders: responseHeaders,

--- a/internal/server/public_retry.go
+++ b/internal/server/public_retry.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -467,12 +468,18 @@ func (a *App) validatePublicRetryRuleInput(
 	}
 	for _, id := range routeIDs {
 		if _, err := a.DB.GetPublicRoute(ctx, id); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return publicRetryRuleMutationInput{}, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("retry rule route %d no longer exists; remove it from the rule scope before saving", id))
+			}
 			return publicRetryRuleMutationInput{}, publicDBError(err)
 		}
 	}
 	for _, id := range targetIDs {
 		target, err := a.DB.GetPublicRouteTarget(ctx, id)
 		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return publicRetryRuleMutationInput{}, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("retry rule route target %d no longer exists; remove it from the rule scope before saving", id))
+			}
 			return publicRetryRuleMutationInput{}, publicDBError(err)
 		}
 		if normalizePublicRouteTargetType(target.TargetType) != publicRouteTargetTypeProxy || normalizePublicRouteTargetTransport(target.Transport) != publicRouteTargetTransportAgent {

--- a/internal/server/public_retry_test.go
+++ b/internal/server/public_retry_test.go
@@ -949,6 +949,33 @@ func TestValidatePublicRetryRuleStatusCodes(t *testing.T) {
 	}
 }
 
+func TestValidatePublicRetryRuleExplainsMissingScopeReferences(t *testing.T) {
+	app := NewApp(nil, newServerTestDB(t))
+	tests := []struct {
+		name      string
+		routeIDs  []int64
+		targetIDs []int64
+		want      string
+	}{
+		{name: "route", routeIDs: []int64{404}, want: "retry rule route 404 no longer exists"},
+		{name: "target", targetIDs: []int64{405}, want: "retry rule route target 405 no longer exists"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := app.validatePublicRetryRuleInput(
+				context.Background(), "stale-scope", 100, true, []string{http.MethodGet}, 1,
+				p2pstreamv1.PublicRetryFailureMode_PUBLIC_RETRY_FAILURE_MODE_CONNECTION_FAILURES,
+				p2pstreamv1.PublicRetryBodyMode_PUBLIC_RETRY_BODY_MODE_NEVER,
+				0, p2pstreamv1.PublicRetryResponseBodyMode_PUBLIC_RETRY_RESPONSE_BODY_MODE_STREAM, 0,
+				0, nil, tt.routeIDs, tt.targetIDs, nil, false,
+			)
+			if connect.CodeOf(err) != connect.CodeInvalidArgument || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("validation error = %v, want invalid argument containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestValidatePublicRetryRuleBufferedResponseRequiresRiskAcknowledgementAndBound(t *testing.T) {
 	app := NewApp(nil, nil)
 	_, err := app.validatePublicRetryRuleInput(

--- a/web/management/src/components/editors/PublicCacheRuleEditorModal.vue
+++ b/web/management/src/components/editors/PublicCacheRuleEditorModal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, inject, reactive, ref } from "vue";
-import { NButton, NCheckbox, NDrawer, NDrawerContent, NDynamicTags, NInput, NInputNumber, NRadioButton, NRadioGroup, NTransfer } from "naive-ui";
+import { NAlert, NButton, NCheckbox, NDrawer, NDrawerContent, NDynamicTags, NInput, NInputNumber, NRadioButton, NRadioGroup, NTransfer } from "naive-ui";
 import type { TransferOption } from "naive-ui";
 import AccessibleSelect from "@/components/ui/AccessibleSelect.vue";
 import PublicPolicyMatchEditor from "@/components/editors/PublicPolicyMatchEditor.vue";
@@ -16,6 +16,7 @@ import {
   type PolicyMatchForm,
 } from "@/lib/publicPolicyMatch";
 import { cacheScopeLabel, routeDestinationLabel, routeTargetName, routeTargetTypeLabel } from "@/lib/publicProxyLabels";
+import { unavailableSelectionIds } from "@/lib/scopeSelections";
 import {
   PublicCacheQueryMode,
   PublicCacheScope,
@@ -90,8 +91,10 @@ const queryModeOptions = [
 ];
 
 const queryParamsEditorVisible = computed(() => queryModeUsesParams(form.queryMode));
-const routeTransferOptions = computed<CacheTransferOption[]>(() =>
-  routes.value.map((route) => {
+const unavailableRouteIds = computed(() => unavailableSelectionIds(form.routeIds, routes.value.map((route) => route.id)));
+const unavailableTargetIds = computed(() => unavailableSelectionIds(form.targetIds, proxyTargets.value.map((target) => target.id)));
+const routeTransferOptions = computed<CacheTransferOption[]>(() => [
+  ...routes.value.map((route) => {
     const value = route.id.toString();
     return {
       label: `${routeLabel(route)} - ${routeDetail(route)}`,
@@ -100,9 +103,15 @@ const routeTransferOptions = computed<CacheTransferOption[]>(() =>
       disabled: !form.routeIds.includes(value) && form.routeIds.length >= maxCacheListItems,
     };
   }),
-);
-const targetTransferOptions = computed<CacheTransferOption[]>(() =>
-  proxyTargets.value.map((target) => {
+  ...unavailableRouteIds.value.map((value) => ({
+    label: `#${value} unavailable route - remove before saving`,
+    value,
+    searchText: `#${value} unavailable missing route`,
+    disabled: false,
+  })),
+]);
+const targetTransferOptions = computed<CacheTransferOption[]>(() => [
+  ...proxyTargets.value.map((target) => {
     const value = target.id.toString();
     return {
       label: `#${target.id.toString()} ${routeTargetName(target)} - ${targetDetail(target)}`,
@@ -111,7 +120,13 @@ const targetTransferOptions = computed<CacheTransferOption[]>(() =>
       disabled: !form.targetIds.includes(value) && form.targetIds.length >= maxCacheListItems,
     };
   }),
-);
+  ...unavailableTargetIds.value.map((value) => ({
+    label: `#${value} unavailable target - remove before saving`,
+    value,
+    searchText: `#${value} unavailable missing target`,
+    disabled: false,
+  })),
+]);
 const routeSelectionSummary = computed(() => form.routeIds.length ? `${form.routeIds.length.toString()} selected` : "All routes");
 const targetSelectionSummary = computed(() => form.targetIds.length ? `${form.targetIds.length.toString()} selected` : "All proxy targets");
 const filterSelectionSummary = computed(() => `${routeSelectionSummary.value} / ${targetSelectionSummary.value}`);
@@ -119,12 +134,16 @@ const queryModeSummary = computed(() => queryModeOptions.find((option) => option
 const normalizedQueryParams = computed(() => normalizeUniqueStrings(form.queryParams));
 const normalizedVaryHeaders = computed(() => normalizeVaryHeaders(form.varyHeaders));
 const normalizedCacheStatusCodes = computed(() => normalizeStatusCodes(form.cacheStatusCodes));
-const routeSelectionValidationReason = computed(() =>
-  form.routeIds.length > maxCacheListItems ? `Cache rules can filter at most ${maxCacheListItems.toString()} routes.` : "",
-);
-const targetSelectionValidationReason = computed(() =>
-  form.targetIds.length > maxCacheListItems ? `Cache rules can filter at most ${maxCacheListItems.toString()} targets.` : "",
-);
+const routeSelectionValidationReason = computed(() => {
+  if (form.routeIds.length > maxCacheListItems) return `Cache rules can filter at most ${maxCacheListItems.toString()} routes.`;
+  if (unavailableRouteIds.value.length) return `Remove unavailable route #${unavailableRouteIds.value[0]} from the saved scope.`;
+  return "";
+});
+const targetSelectionValidationReason = computed(() => {
+  if (form.targetIds.length > maxCacheListItems) return `Cache rules can filter at most ${maxCacheListItems.toString()} targets.`;
+  if (unavailableTargetIds.value.length) return `Remove unavailable target #${unavailableTargetIds.value[0]} from the saved scope.`;
+  return "";
+});
 const queryParamsValidationReason = computed(() => {
   if (!queryParamsEditorVisible.value) return "";
   if (form.queryParams.length > maxCacheListItems) return `Cache rules can list at most ${maxCacheListItems.toString()} query parameters.`;
@@ -509,6 +528,14 @@ defineExpose({ openCreate, openEdit, close });
             <span class="cache-summary-chip">{{ cacheScopeLabel(form.scope) }}</span>
           </div>
         </div>
+
+        <NAlert
+          v-if="unavailableRouteIds.length || unavailableTargetIds.length"
+          type="warning"
+          title="Saved scope contains unavailable entries"
+        >
+          One or more routes or targets were removed after this rule was saved. Remove the entries marked unavailable below before saving.
+        </NAlert>
 
         <div class="target-grid">
           <div class="target-panel">

--- a/web/management/src/components/editors/PublicRetryRuleEditorModal.vue
+++ b/web/management/src/components/editors/PublicRetryRuleEditorModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, inject, reactive, ref } from "vue";
 import {
+  NAlert,
   NButton,
   NButtonGroup,
   NCheckbox,
@@ -31,6 +32,7 @@ import {
   routeTargetName,
   routeTargetTypeLabel,
 } from "@/lib/publicProxyLabels";
+import { unavailableSelectionIds } from "@/lib/scopeSelections";
 import {
   PublicRetryBodyMode,
   PublicRetryFailureMode,
@@ -137,25 +139,43 @@ const responseDeliverySummary = computed(() => form.responseBodyMode === PublicR
   ? `Best effort through ${form.maxBufferedResponseBodyKiB.toLocaleString()} KiB / ${form.maxBufferedResponseWaitSeconds.toLocaleString()}s`
   : "Immediate streaming");
 
-const routeTransferOptions = computed<RetryTransferOption[]>(() => routes.value.map((route) => {
-  const value = route.id.toString();
-  return {
-    label: `${routeLabel(route)} — ${routeDestinationLabel(route)}`,
+const unavailableRouteIds = computed(() => unavailableSelectionIds(form.routeIds, routes.value.map((route) => route.id)));
+const unavailableTargetIds = computed(() => unavailableSelectionIds(form.targetIds, agentTargets.value.map((target) => target.id)));
+const routeTransferOptions = computed<RetryTransferOption[]>(() => [
+  ...routes.value.map((route) => {
+    const value = route.id.toString();
+    return {
+      label: `${routeLabel(route)} — ${routeDestinationLabel(route)}`,
+      value,
+      searchText: `${routeLabel(route)} ${routeDestinationLabel(route)}`.toLowerCase(),
+      disabled: !form.routeIds.includes(value) && form.routeIds.length >= maxFilterItems,
+    };
+  }),
+  ...unavailableRouteIds.value.map((value) => ({
+    label: `#${value} unavailable route — remove before saving`,
     value,
-    searchText: `${routeLabel(route)} ${routeDestinationLabel(route)}`.toLowerCase(),
-    disabled: !form.routeIds.includes(value) && form.routeIds.length >= maxFilterItems,
-  };
-}));
-const targetTransferOptions = computed<RetryTransferOption[]>(() => agentTargets.value.map((target) => {
-  const value = target.id.toString();
-  const detail = `${routeTargetTypeLabel(target.targetType)} / ${target.url || "no upstream URL"}`;
-  return {
-    label: `#${value} ${routeTargetName(target)} — ${detail}`,
+    searchText: `#${value} unavailable missing route`,
+    disabled: false,
+  })),
+]);
+const targetTransferOptions = computed<RetryTransferOption[]>(() => [
+  ...agentTargets.value.map((target) => {
+    const value = target.id.toString();
+    const detail = `${routeTargetTypeLabel(target.targetType)} / ${target.url || "no upstream URL"}`;
+    return {
+      label: `#${value} ${routeTargetName(target)} — ${detail}`,
+      value,
+      searchText: `#${value} ${routeTargetName(target)} ${detail}`.toLowerCase(),
+      disabled: !form.targetIds.includes(value) && form.targetIds.length >= maxFilterItems,
+    };
+  }),
+  ...unavailableTargetIds.value.map((value) => ({
+    label: `#${value} unavailable target — remove before saving`,
     value,
-    searchText: `#${value} ${routeTargetName(target)} ${detail}`.toLowerCase(),
-    disabled: !form.targetIds.includes(value) && form.targetIds.length >= maxFilterItems,
-  };
-}));
+    searchText: `#${value} unavailable missing target`,
+    disabled: false,
+  })),
+]);
 
 const submitDisabledReason = computed(() => {
   if (isBusy?.value) return BUSY_REASON;
@@ -164,6 +184,8 @@ const submitDisabledReason = computed(() => {
   if (!Number.isInteger(form.maxRetries) || form.maxRetries < 1 || form.maxRetries > 3) return "Retries must be between 1 and 3.";
   if (form.routeIds.length > maxFilterItems) return `Select at most ${maxFilterItems.toString()} routes.`;
   if (form.targetIds.length > maxFilterItems) return `Select at most ${maxFilterItems.toString()} targets.`;
+  if (unavailableRouteIds.value.length) return `Remove unavailable route #${unavailableRouteIds.value[0]} from the saved scope.`;
+  if (unavailableTargetIds.value.length) return `Remove unavailable target #${unavailableTargetIds.value[0]} from the saved scope.`;
   const methodError = methodsValidationReason(normalizedMethods.value);
   if (methodError) return methodError;
   const statusError = statusCodesValidationReason();
@@ -596,6 +618,13 @@ defineExpose({ openCreate, openEdit, close });
             <h4 class="copy-sm weight-semibold base-text">Route and target scope</h4>
             <p class="margin-top-xs copy-xs line-normal muted-text">Empty filters match every agent-backed proxy target. Direct and static targets are not eligible.</p>
           </div>
+          <NAlert
+            v-if="unavailableRouteIds.length || unavailableTargetIds.length"
+            type="warning"
+            title="Saved scope contains unavailable entries"
+          >
+            One or more routes or targets were removed after this rule was saved. Remove the entries marked unavailable below before saving.
+          </NAlert>
           <div class="target-grid">
             <div class="target-panel">
               <div class="target-panel-head"><div><p class="panel-eyebrow">Routes</p><h5 class="panel-heading">{{ routeSummary }}</h5></div></div>

--- a/web/management/src/lib/scopeSelections.test.ts
+++ b/web/management/src/lib/scopeSelections.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { unavailableSelectionIds } from "@/lib/scopeSelections";
+
+describe("unavailableSelectionIds", () => {
+  test("keeps missing saved references visible without duplicating them", () => {
+    expect(unavailableSelectionIds([21n, 19n, 23n, 19n], [21n, 23n, 25n])).toEqual(["19"]);
+  });
+
+  test("normalizes identifier representations", () => {
+    expect(unavailableSelectionIds(["21", 23, 25n], [21n, "23", 25])).toEqual([]);
+  });
+});

--- a/web/management/src/lib/scopeSelections.ts
+++ b/web/management/src/lib/scopeSelections.ts
@@ -1,0 +1,17 @@
+export type SelectionID = string | number | bigint;
+
+export function unavailableSelectionIds(
+  selectedIds: readonly SelectionID[],
+  availableIds: readonly SelectionID[],
+): string[] {
+  const available = new Set(availableIds.map(String));
+  const seen = new Set<string>();
+  const unavailable: string[] = [];
+  for (const rawId of selectedIds) {
+    const id = String(rawId);
+    if (!id || available.has(id) || seen.has(id)) continue;
+    seen.add(id);
+    unavailable.push(id);
+  }
+  return unavailable;
+}


### PR DESCRIPTION
## Release

Promotes the validated `staging` build to stable as `v0.1.46`.

### Fixes
- prevent SQLite lock failures when managing local access users
- preserve route target IDs across edits so retry and cache rule scopes remain valid
- surface legacy unavailable scope entries for explicit removal
- return actionable validation errors for missing policy references

### Validation
- local clean-tree `make verify`
- race-enabled Go and integration suites
- source and promotion CI / CodeQL
- successful multi-architecture staging binary and container publication

Source PR: #182
Staging promotion: #183