### PR TITLE
feat: split diagnostics into investigation workspaces

### DIFF
--- a/web/management/e2e/diagnostics.spec.ts
+++ b/web/management/e2e/diagnostics.spec.ts
@@ -72,6 +72,7 @@ test("exposes window state and safely discloses exact public-request samples", a
 
   await authenticate(page, testInfo.project.use.baseURL as string);
   await page.goto("/#/monitor/diagnostics");
+  await expect(page).toHaveURL(/#\/monitor\/diagnostics\/overview$/);
 
   const group = page.getByRole("group", { name: "Diagnostics window" });
   await expect(group.getByRole("button")).toHaveCount(4);
@@ -81,7 +82,8 @@ test("exposes window state and safely discloses exact public-request samples", a
       label === "1h" ? "true" : "false",
     );
   }
-  await expect(page.getByRole("combobox", { name: "Sample limit" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Choose an investigation lane", exact: true })).toBeVisible();
+  await expect(page.getByRole("combobox", { name: "Loaded diagnostic sample limit" })).toHaveCount(0);
 
   const request24h = page.waitForRequest((request) => (
     request.url().endsWith("/GetDashboardDiagnostics")
@@ -92,7 +94,21 @@ test("exposes window state and safely discloses exact public-request samples", a
   await expect(group.getByRole("button", { name: "24h", exact: true })).toHaveAttribute("aria-pressed", "true");
   await expect(group.getByRole("button", { name: "1h", exact: true })).toHaveAttribute("aria-pressed", "false");
 
+  await page.getByRole("tab", { name: "Failure map", exact: true }).click();
+  await expect(page).toHaveURL(/#\/monitor\/diagnostics\/failures$/);
+
+  const dimension = page.getByRole("button", { name: new RegExp("direct_proxy_failed") });
+  const dimensionValue = dimension.locator("bdi.dimension-name");
+  await expect(dimensionValue).toHaveText(diagnosticExcerpt(errorKind, 56).text);
+  await expect(dimensionValue).toHaveCSS("unicode-bidi", "isolate");
+  await dimension.click();
+  await expect(page).toHaveURL(/#\/monitor\/diagnostics\/samples$/);
+  await expect(page.getByText("Exact filter · Error kinds", { exact: true })).toBeVisible();
+  await expect(page.getByText("1 of 1 loaded samples", { exact: true })).toBeVisible();
+  await expect(page.getByRole("combobox", { name: "Loaded diagnostic sample limit" })).toBeVisible();
+
   const view = page.getByRole("button", { name: /^View diagnostic sample from / });
+  await expect(view).toHaveCount(1);
   const row = view.locator("xpath=ancestor::tr");
   const excerpts = row.locator(".diagnostic-request-stack bdi.diagnostic-attacker-excerpt");
   await expect(excerpts).toHaveCount(2);
@@ -104,15 +120,6 @@ test("exposes window state and safely discloses exact public-request samples", a
     expect(Array.from((await excerpt.textContent()) ?? "").length).toBeLessThanOrEqual(DIAGNOSTIC_EXCERPT_LIMIT);
   }
   await expect(row.locator("img, script")).toHaveCount(0);
-
-  const dimension = page.getByRole("button", { name: new RegExp("direct_proxy_failed") });
-  const dimensionValue = dimension.locator("bdi.dimension-name");
-  await expect(dimensionValue).toHaveText(diagnosticExcerpt(errorKind, 56).text);
-  await expect(dimensionValue).toHaveCSS("unicode-bidi", "isolate");
-  await dimension.click();
-  await expect(dimension).toHaveAttribute("aria-pressed", "true");
-  await expect(page.getByText("Filtered by Error kinds", { exact: true })).toBeVisible();
-  await expect(view).toHaveCount(1);
 
   await view.click();
   const drawer = page.getByRole("dialog", { name: "Diagnostic sample details" });

--- a/web/management/e2e/management-shell.spec.ts
+++ b/web/management/e2e/management-shell.spec.ts
@@ -234,7 +234,7 @@ test("opens complete mobile navigation, restores focus, and closes after navigat
 
   await menuButton.click();
   await sidebar.getByRole("link", { name: "Diagnostics", exact: true }).click();
-  await expect(page).toHaveURL(/#\/monitor\/diagnostics$/);
+  await expect(page).toHaveURL(/#\/monitor\/diagnostics\/overview$/);
   await expect(sidebar).toBeHidden();
   await expect(menuButton).toHaveAttribute("aria-expanded", "false");
   await expect(page.locator("#management-main")).toBeFocused();

--- a/web/management/e2e/traffic-flow.spec.ts
+++ b/web/management/e2e/traffic-flow.spec.ts
@@ -69,11 +69,11 @@ test("routes monitor traffic and diagnostics subpages", async ({ page }, testInf
   await expect(page.locator(".traffic-flow-shell")).toBeVisible();
 
   await page.locator(".monitor-tabs").getByText("Diagnostics", { exact: true }).click();
-  await expect(page).toHaveURL(/#\/monitor\/diagnostics$/);
+  await expect(page).toHaveURL(/#\/monitor\/diagnostics\/overview$/);
   await expect(monitorNav).toHaveClass(/app-nav__link--active/);
   await expect(page.getByRole("heading", { name: "Diagnostics", exact: true })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Status Codes", exact: true })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Recent Samples", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Choose an investigation lane", exact: true })).toBeVisible();
 });
 
 test("removed legacy traffic and diagnostics URLs show not found", async ({ page }, testInfo) => {
@@ -101,9 +101,9 @@ test("keeps traffic and diagnostics workflows contained on mobile", async ({ pag
   await expect(page.getByText(/Keyboard node list/)).toBeVisible();
   expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(390);
 
-  await page.goto("/#/monitor/diagnostics");
+  await page.goto("/#/monitor/diagnostics/samples");
   await expect(page.getByRole("group", { name: "Diagnostics window" })).toBeVisible();
-  await expect(page.getByRole("combobox", { name: "Sample limit" })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Recent Samples", exact: true })).toBeVisible();
+  await expect(page.getByRole("combobox", { name: "Loaded diagnostic sample limit" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Request samples", exact: true })).toBeVisible();
   expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(390);
 });

--- a/web/management/src/lib/diagnosticsWorkbench.test.ts
+++ b/web/management/src/lib/diagnosticsWorkbench.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import type { DashboardDiagnosticsSample } from "@/gen/proto/p2pstream/v1/management_pb";
+import {
+  DIAGNOSTICS_SECTIONS,
+  filterDiagnosticSamples,
+  normalizeDiagnosticsSection,
+  type DiagnosticDimensionFilter,
+} from "@/lib/diagnosticsWorkbench";
+
+function sample(overrides: Partial<DashboardDiagnosticsSample>): DashboardDiagnosticsSample {
+  return {
+    errorKind: "",
+    listenerLabel: "",
+    routeLabel: "",
+    routeTargetLabel: "",
+    agentLabel: "",
+    retryErrorKind: "",
+    retryFailedAgentLabel: "",
+    ...overrides,
+  } as DashboardDiagnosticsSample;
+}
+
+describe("diagnostics workbench", () => {
+  test("defines stable routed investigation sections", () => {
+    expect(DIAGNOSTICS_SECTIONS.map((section) => section.key)).toEqual([
+      "overview",
+      "retries",
+      "failures",
+      "samples",
+    ]);
+    expect(DIAGNOSTICS_SECTIONS.map((section) => section.path)).toEqual([
+      "/monitor/diagnostics/overview",
+      "/monitor/diagnostics/retries",
+      "/monitor/diagnostics/failures",
+      "/monitor/diagnostics/samples",
+    ]);
+  });
+
+  test("normalizes absent and untrusted section values to overview", () => {
+    expect(normalizeDiagnosticsSection("samples")).toBe("samples");
+    expect(normalizeDiagnosticsSection(["retries", "samples"])).toBe("retries");
+    expect(normalizeDiagnosticsSection("../../settings/api-tokens")).toBe("overview");
+    expect(normalizeDiagnosticsSection(undefined)).toBe("overview");
+  });
+
+  test("applies one visible exact-match filter to loaded samples", () => {
+    const samples = [
+      sample({ errorKind: "agent_server_capacity", agentLabel: "edge-01" }),
+      sample({ errorKind: "agent_server_capacity_extra", agentLabel: "edge-02" }),
+      sample({ errorKind: "agent_server_capacity", agentLabel: "edge-03" }),
+    ];
+    const filter: DiagnosticDimensionFilter = {
+      key: "error",
+      label: "agent_server_capacity",
+      title: "Error kinds",
+    };
+
+    expect(filterDiagnosticSamples(samples, filter).map((row) => row.agentLabel)).toEqual(["edge-01", "edge-03"]);
+    expect(filterDiagnosticSamples(samples, null)).toEqual(samples);
+  });
+
+  test("keeps retry attribution distinct from final agent attribution", () => {
+    const samples = [
+      sample({ agentLabel: "recovered-on", retryFailedAgentLabel: "first-failed" }),
+      sample({ agentLabel: "first-failed", retryFailedAgentLabel: "different-first-failure" }),
+    ];
+    const filter: DiagnosticDimensionFilter = {
+      key: "retry-agent",
+      label: "first-failed",
+      title: "First-failed agent",
+    };
+
+    expect(filterDiagnosticSamples(samples, filter).map((row) => row.agentLabel)).toEqual(["recovered-on"]);
+  });
+});

--- a/web/management/src/lib/diagnosticsWorkbench.ts
+++ b/web/management/src/lib/diagnosticsWorkbench.ts
@@ -1,0 +1,70 @@
+import type { DashboardDiagnosticsSample } from "@/gen/proto/p2pstream/v1/management_pb";
+
+export type DiagnosticsSectionKey = "overview" | "retries" | "failures" | "samples";
+export type DiagnosticDimensionKey = "error" | "listener" | "route" | "target" | "agent" | "retry-error" | "retry-agent";
+export type DiagnosticDimensionFilter = Readonly<{
+  key: DiagnosticDimensionKey;
+  label: string;
+  title: string;
+}>;
+
+export const DIAGNOSTICS_SECTIONS = [
+  {
+    key: "overview",
+    label: "Overview",
+    path: "/monitor/diagnostics/overview",
+    description: "Outcome health and response-code distribution for the selected window.",
+  },
+  {
+    key: "retries",
+    label: "Retry health",
+    path: "/monitor/diagnostics/retries",
+    description: "Retry activation, transport recovery, rules, and first-attempt failures.",
+  },
+  {
+    key: "failures",
+    label: "Failure map",
+    path: "/monitor/diagnostics/failures",
+    description: "Ranked error, listener, route, target, and agent dimensions.",
+  },
+  {
+    key: "samples",
+    label: "Request samples",
+    path: "/monitor/diagnostics/samples",
+    description: "Retained non-success, proxy-failure, and retry request evidence.",
+  },
+] as const satisfies ReadonlyArray<{
+  key: DiagnosticsSectionKey;
+  label: string;
+  path: string;
+  description: string;
+}>;
+
+export function normalizeDiagnosticsSection(value: unknown): DiagnosticsSectionKey {
+  const section = Array.isArray(value) ? value[0] : value;
+  if (section === "retries" || section === "failures" || section === "samples") return section;
+  return "overview";
+}
+
+export function filterDiagnosticSamples<T extends DashboardDiagnosticsSample>(
+  samples: readonly T[],
+  filter: DiagnosticDimensionFilter | null,
+): T[] {
+  if (!filter) return [...samples];
+  return samples.filter((sample) => diagnosticSampleDimensionValue(sample, filter.key) === filter.label);
+}
+
+export function diagnosticSampleDimensionValue(
+  sample: DashboardDiagnosticsSample,
+  key: DiagnosticDimensionKey,
+): string {
+  switch (key) {
+    case "error": return sample.errorKind;
+    case "listener": return sample.listenerLabel;
+    case "route": return sample.routeLabel;
+    case "target": return sample.routeTargetLabel;
+    case "agent": return sample.agentLabel;
+    case "retry-error": return sample.retryErrorKind;
+    case "retry-agent": return sample.retryFailedAgentLabel;
+  }
+}

--- a/web/management/src/lib/managementNavigation.test.ts
+++ b/web/management/src/lib/managementNavigation.test.ts
@@ -41,9 +41,9 @@ describe("managementNavigation", () => {
     const monitor = MANAGEMENT_NAVIGATION[0]?.items[1];
     const traffic = monitor?.children?.[0];
     const diagnostics = monitor?.children?.[1];
-    expect(monitor && isManagementNavigationItemActive(monitor, "/monitor/diagnostics")).toBe(true);
-    expect(traffic && isManagementNavigationItemActive(traffic, "/monitor/diagnostics")).toBe(false);
-    expect(diagnostics && isManagementNavigationItemActive(diagnostics, "/monitor/diagnostics")).toBe(true);
+    expect(monitor && isManagementNavigationItemActive(monitor, "/monitor/diagnostics/samples")).toBe(true);
+    expect(traffic && isManagementNavigationItemActive(traffic, "/monitor/diagnostics/samples")).toBe(false);
+    expect(diagnostics && isManagementNavigationItemActive(diagnostics, "/monitor/diagnostics/samples")).toBe(true);
   });
 
   test("creates group, parent, and leaf breadcrumbs", () => {
@@ -55,6 +55,11 @@ describe("managementNavigation", () => {
     expect(managementBreadcrumbsForPath("/agent/activity")).toEqual([
       { key: "configure", label: "Configure" },
       { key: "agents", label: "Agents", path: "/agent" },
+    ]);
+    expect(managementBreadcrumbsForPath("/monitor/diagnostics/samples")).toEqual([
+      { key: "observe", label: "Observe" },
+      { key: "monitor", label: "Monitor", path: "/monitor/traffic" },
+      { key: "monitor-diagnostics", label: "Diagnostics", path: "/monitor/diagnostics/overview" },
     ]);
   });
 

--- a/web/management/src/lib/managementNavigation.ts
+++ b/web/management/src/lib/managementNavigation.ts
@@ -36,7 +36,12 @@ export const MANAGEMENT_NAVIGATION: readonly ManagementNavigationGroup[] = [
         activePrefix: "/monitor",
         children: [
           { key: "monitor-traffic", label: "Traffic", path: "/monitor/traffic" },
-          { key: "monitor-diagnostics", label: "Diagnostics", path: "/monitor/diagnostics" },
+          {
+            key: "monitor-diagnostics",
+            label: "Diagnostics",
+            path: "/monitor/diagnostics/overview",
+            activePrefix: "/monitor/diagnostics",
+          },
         ],
       },
     ],

--- a/web/management/src/lib/overviewAttention.test.ts
+++ b/web/management/src/lib/overviewAttention.test.ts
@@ -29,7 +29,7 @@ describe("overviewAttention", () => {
     });
 
     expect(items.map((item) => item.key)).toEqual(["proxy-error", "listener-errors"]);
-    expect(items[0]?.actionRoute).toBe("/monitor/diagnostics");
+    expect(items[0]?.actionRoute).toBe("/monitor/diagnostics/overview");
     expect(items[0]?.severity).toBe("error");
     expect(items[0]?.detail.length).toBeLessThanOrEqual(280);
     expect(items[0]?.detail).not.toContain("\u202e");

--- a/web/management/src/lib/overviewAttention.ts
+++ b/web/management/src/lib/overviewAttention.ts
@@ -93,7 +93,7 @@ export function deriveOverviewAttention(input: OverviewAttentionInput): Overview
       title: "Proxy runtime reported an error",
       detail: proxyError ? `Latest error: ${proxyError}` : "The proxy entered an error state.",
       actionLabel: "Open diagnostics",
-      actionRoute: "/monitor/diagnostics",
+      actionRoute: "/monitor/diagnostics/overview",
     }));
   } else if (proxy?.state === ProxyState.STOPPED || (
     input.status !== null && input.status !== undefined &&
@@ -176,8 +176,8 @@ export function deriveOverviewAttention(input: OverviewAttentionInput): Overview
       severity: "error",
       title: "Proxy requests are failing internally",
       detail: `${formatCount(proxyFailures)} internal ${proxyFailures === 1n ? "failure" : "failures"} in the selected window.`,
-      actionLabel: "Open diagnostics",
-      actionRoute: "/monitor/diagnostics",
+      actionLabel: "Open failure map",
+      actionRoute: "/monitor/diagnostics/failures",
     }));
   }
 

--- a/web/management/src/router.ts
+++ b/web/management/src/router.ts
@@ -24,7 +24,12 @@ const routes = [
     redirect: '/monitor/traffic',
     children: [
       { path: 'traffic', name: 'monitor-traffic', component: Traffic },
-      { path: 'diagnostics', name: 'monitor-diagnostics', component: Diagnostics },
+      { path: 'diagnostics', redirect: '/monitor/diagnostics/overview' },
+      {
+        path: 'diagnostics/:section(overview|retries|failures|samples)',
+        name: 'monitor-diagnostics',
+        component: Diagnostics,
+      },
       { path: ':pathMatch(.*)*', redirect: '/monitor/traffic' },
     ],
   },

--- a/web/management/src/views/Diagnostics.vue
+++ b/web/management/src/views/Diagnostics.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, h, onMounted, ref, watch } from "vue";
-import { NAlert, NButton, NButtonGroup, NDataTable, NDrawer, NDrawerContent, NEmpty, NSkeleton } from "naive-ui";
+import { useRoute, useRouter } from "vue-router";
+import { NAlert, NButton, NButtonGroup, NDataTable, NDrawer, NDrawerContent, NEmpty, NSkeleton, NTab, NTabs, NTag } from "naive-ui";
 import type { DataTableColumns } from "naive-ui";
 import RetryHealthPanel from "@/components/RetryHealthPanel.vue";
 import AccessibleSelect from "@/components/ui/AccessibleSelect.vue";
@@ -19,14 +20,23 @@ import {
   statusTone,
 } from "@/lib/dashboardStats";
 import { diagnosticExcerpt, diagnosticInspectionText } from "@/lib/diagnosticText";
+import {
+  DIAGNOSTICS_SECTIONS,
+  filterDiagnosticSamples,
+  normalizeDiagnosticsSection,
+  type DiagnosticDimensionFilter,
+  type DiagnosticDimensionKey,
+  type DiagnosticsSectionKey,
+} from "@/lib/diagnosticsWorkbench";
 import { editorDrawerWidth } from "@/lib/naiveUi";
 
 type WindowLabel = "5m" | "1h" | "24h" | "30d";
-type DimensionKey = "error" | "listener" | "route" | "target" | "agent" | "retry-error" | "retry-agent";
-type DimensionFilter = Readonly<{ key: DimensionKey; label: string; title: string }>;
 
 const managementClient = useManagementClient();
+const route = useRoute();
+const router = useRouter();
 const windowLabels: WindowLabel[] = ["5m", "1h", "24h", "30d"];
+const diagnosticsSections = DIAGNOSTICS_SECTIONS;
 const sampleOptions = [25, 50, 100];
 const sampleSelectOptions = sampleOptions.map((option) => ({
   label: `${option.toString()} samples`,
@@ -40,16 +50,20 @@ const isLoading = ref(false);
 const error = ref("");
 const selectedSample = ref<DashboardDiagnosticsSample | null>(null);
 const isSampleDetailsOpen = ref(false);
-const selectedDimension = ref<DimensionFilter | null>(null);
+const selectedDimension = ref<DiagnosticDimensionFilter | null>(null);
 let requestSequence = 0;
 
+const activeDiagnosticsSection = computed<DiagnosticsSectionKey>(() => normalizeDiagnosticsSection(route.params.section));
+const activeDiagnosticsSectionMeta = computed(() =>
+  diagnosticsSections.find((section) => section.key === activeDiagnosticsSection.value) ?? diagnosticsSections[0],
+);
 const outcome = computed(() => diagnostics.value?.outcome);
 const statusCodes = computed(() => diagnostics.value?.statusCodes ?? []);
 const recentSamples = computed(() => diagnostics.value?.recentSamples ?? []);
-const filteredRecentSamples = computed(() => {
-  const filter = selectedDimension.value;
-  if (!filter) return recentSamples.value;
-  return recentSamples.value.filter((sample) => sampleDimensionValue(sample, filter.key) === filter.label);
+const filteredRecentSamples = computed(() => filterDiagnosticSamples(recentSamples.value, selectedDimension.value));
+const sampleFilterSummary = computed(() => {
+  if (!selectedDimension.value) return `${recentSamples.value.length.toString()} loaded samples`;
+  return `${filteredRecentSamples.value.length.toString()} of ${recentSamples.value.length.toString()} loaded samples`;
 });
 const isInitialLoading = computed(() => isLoading.value && !diagnostics.value);
 const generatedAtLabel = computed(() => diagnostics.value ? formatSampleTime(diagnostics.value.generatedAtUnixMillis) : "Not loaded");
@@ -214,8 +228,12 @@ async function loadDiagnostics(clearCurrent = false) {
   }
 }
 
-watch([selectedWindowLabel, sampleLimit], () => {
+watch(selectedWindowLabel, () => {
   selectedDimension.value = null;
+  void loadDiagnostics(true);
+});
+
+watch(sampleLimit, () => {
   void loadDiagnostics(true);
 });
 
@@ -267,30 +285,25 @@ function openSampleDetails(sample: DashboardDiagnosticsSample) {
   isSampleDetailsOpen.value = true;
 }
 
-function selectDimension(key: DimensionKey, row: DashboardProxyDimensionSummary, title: string) {
-  selectDimensionLabel(key, row.label, title);
+async function selectDiagnosticsSection(value: string | number) {
+  const section = diagnosticsSections.find((item) => item.key === value);
+  if (!section || section.key === activeDiagnosticsSection.value) return;
+  await router.push(section.path);
 }
 
-function selectDimensionLabel(key: DimensionKey, label: string, title: string) {
-  const next = { key, label, title };
-  const current = selectedDimension.value;
-  selectedDimension.value = current?.key === next.key && current.label === next.label ? null : next;
+async function inspectDimension(key: DiagnosticDimensionKey, row: DashboardProxyDimensionSummary, title: string) {
+  await inspectDimensionLabel(key, row.label, title);
 }
 
-function dimensionSelected(key: DimensionKey, label: string): boolean {
-  return selectedDimension.value?.key === key && selectedDimension.value.label === label;
-}
-
-function sampleDimensionValue(sample: DashboardDiagnosticsSample, key: DimensionKey): string {
-  switch (key) {
-    case "error": return sample.errorKind;
-    case "listener": return sample.listenerLabel;
-    case "route": return sample.routeLabel;
-    case "target": return sample.routeTargetLabel;
-    case "agent": return sample.agentLabel;
-    case "retry-error": return sample.retryErrorKind;
-    case "retry-agent": return sample.retryFailedAgentLabel;
+async function inspectDimensionLabel(key: DiagnosticDimensionKey, label: string, title: string) {
+  selectedDimension.value = { key, label, title };
+  if (activeDiagnosticsSection.value !== "samples") {
+    await router.push("/monitor/diagnostics/samples");
   }
+}
+
+function dimensionSelected(key: DiagnosticDimensionKey, label: string): boolean {
+  return selectedDimension.value?.key === key && selectedDimension.value.label === label;
 }
 
 function attackerCell(value: string, limit = 72) {
@@ -368,7 +381,7 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
     <section class="diagnostics-header">
       <div>
         <h3>Diagnostics</h3>
-        <p>Proxy outcomes, response distribution, failure dimensions, and recent failure or retry samples.</p>
+        <p>{{ activeDiagnosticsSectionMeta.description }}</p>
       </div>
       <div class="header-controls">
         <NButtonGroup class="window-tabs" role="group" aria-label="Diagnostics window" size="small">
@@ -383,18 +396,26 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
             {{ label }}
           </NButton>
         </NButtonGroup>
-        <AccessibleSelect
-          v-model:value="sampleLimit"
-          accessible-label="Sample limit"
-          class="sample-select"
-          size="small"
-          :options="sampleSelectOptions"
-        />
         <NButton secondary size="small" attr-type="button" :loading="isLoading && Boolean(diagnostics)" @click="loadDiagnostics(false)">
           Refresh
         </NButton>
       </div>
     </section>
+
+    <NTabs
+      class="diagnostics-section-tabs"
+      type="line"
+      :value="activeDiagnosticsSection"
+      aria-label="Diagnostics sections"
+      @update:value="selectDiagnosticsSection"
+    >
+      <NTab
+        v-for="section in diagnosticsSections"
+        :key="section.key"
+        :name="section.key"
+        :tab="section.label"
+      />
+    </NTabs>
 
     <NAlert v-if="error" :type="diagnostics ? 'warning' : 'error'" :show-icon="false">
       <div class="diagnostics-alert">
@@ -431,7 +452,7 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
       <p v-if="isLoading" class="diagnostics-refresh-state" role="status">
         Refreshing from the server. Values below remain the snapshot generated {{ generatedAtLabel }} until a new response arrives.
       </p>
-      <section class="incident-summary" :aria-busy="isLoading">
+      <section v-if="activeDiagnosticsSection === 'overview'" class="incident-summary" :aria-busy="isLoading">
         <div class="incident-summary__lead">
           <div class="incident-summary__eyebrow">
             <span>Incident snapshot</span>
@@ -470,6 +491,7 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
       </section>
 
       <RetryHealthPanel
+        v-if="activeDiagnosticsSection === 'retries'"
         :retry-health="diagnostics.retryHealth"
         :retry-trend="diagnostics.retryTrend"
         :retry-rules="diagnostics.retryRules"
@@ -478,10 +500,10 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
         :generated-at-unix-millis="diagnostics.generatedAtUnixMillis"
         :window-label="selectedWindowLabel"
         :selected-filter="selectedDimension"
-        @select-dimension="selectDimensionLabel"
+        @select-dimension="inspectDimensionLabel"
       />
 
-      <section class="diagnostics-panel">
+      <section v-if="activeDiagnosticsSection === 'overview'" class="diagnostics-panel">
         <div class="panel-heading">
           <div>
             <h4>Status Codes</h4>
@@ -508,11 +530,58 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
         <NEmpty v-else size="small" description="No status codes in this window." />
       </section>
 
-      <section class="breakdown-section" aria-labelledby="failure-dimensions-heading">
+      <section v-if="activeDiagnosticsSection === 'overview'" class="investigation-section" aria-labelledby="investigation-lanes-heading">
+        <div class="panel-heading">
+          <div>
+            <h4 id="investigation-lanes-heading">Choose an investigation lane</h4>
+            <p>Each workspace has one job and keeps its own controls close to the evidence they affect.</p>
+          </div>
+        </div>
+        <div class="investigation-grid">
+          <RouterLink class="investigation-lane investigation-lane--retry" to="/monitor/diagnostics/retries">
+            <span class="investigation-lane__index">01</span>
+            <div>
+              <strong>Retry health</strong>
+              <p>Decide whether retries recovered transport failures or merely delayed exhaustion.</p>
+            </div>
+            <dl>
+              <div><dt>Matched</dt><dd>{{ formatNumber(diagnostics.retryHealth?.matchedRequests) }}</dd></div>
+              <div><dt>Exhausted</dt><dd>{{ formatNumber(diagnostics.retryHealth?.exhaustedRequests) }}</dd></div>
+            </dl>
+            <span class="investigation-lane__action">Open retry health →</span>
+          </RouterLink>
+          <RouterLink class="investigation-lane investigation-lane--failures" to="/monitor/diagnostics/failures">
+            <span class="investigation-lane__index">02</span>
+            <div>
+              <strong>Failure map</strong>
+              <p>Rank the exact errors, listeners, routes, targets, and agents involved.</p>
+            </div>
+            <dl>
+              <div><dt>Proxy failures</dt><dd>{{ formatNumber(outcome?.proxyFailure) }}</dd></div>
+              <div><dt>Error kinds</dt><dd>{{ diagnostics.errorKinds.length.toString() }}</dd></div>
+            </dl>
+            <span class="investigation-lane__action">Explore dimensions →</span>
+          </RouterLink>
+          <RouterLink class="investigation-lane investigation-lane--samples" to="/monitor/diagnostics/samples">
+            <span class="investigation-lane__index">03</span>
+            <div>
+              <strong>Request samples</strong>
+              <p>Inspect concrete request evidence after the aggregate signal points somewhere.</p>
+            </div>
+            <dl>
+              <div><dt>Loaded</dt><dd>{{ recentSamples.length.toString() }}</dd></div>
+              <div><dt>Window</dt><dd>{{ selectedWindowLabel }}</dd></div>
+            </dl>
+            <span class="investigation-lane__action">Inspect requests →</span>
+          </RouterLink>
+        </div>
+      </section>
+
+      <section v-if="activeDiagnosticsSection === 'failures'" class="breakdown-section" aria-labelledby="failure-dimensions-heading">
         <div class="panel-heading">
           <div>
             <h4 id="failure-dimensions-heading">Ranked failure dimensions</h4>
-            <p>Select a row to filter the request samples by that exact value.</p>
+            <p>Select a row to open request samples filtered by that exact value.</p>
           </div>
         </div>
         <div class="breakdown-grid">
@@ -527,7 +596,7 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
                   class="dimension-row"
                   :class="{ 'dimension-row--selected': dimensionSelected(section.key, row.label) }"
                   :aria-pressed="dimensionSelected(section.key, row.label)"
-                  @click="selectDimension(section.key, row, section.title)"
+                  @click="inspectDimension(section.key, row, section.title)"
                 >
                   <span class="dimension-rank">{{ index + 1 }}</span>
                   <bdi class="dimension-name" dir="ltr" :title="inspectionValue(row.label)">{{ diagnosticExcerpt(row.label, 56).text }}</bdi>
@@ -536,6 +605,7 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
                     <span>{{ formatNumber(dimensionNonSuccess(row)) }} non-success</span>
                     <span>{{ formatNumber(dimensionProxyFailures(row)) }} failures</span>
                   </span>
+                  <span class="dimension-action">Inspect samples →</span>
                 </button>
               </li>
             </ol>
@@ -544,17 +614,31 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
         </div>
       </section>
 
-      <section class="diagnostics-panel diagnostics-panel--table">
+      <section v-if="activeDiagnosticsSection === 'samples'" class="diagnostics-panel diagnostics-panel--table">
         <div class="panel-heading diagnostics-samples-heading">
           <div>
-            <h4>Recent Samples</h4>
-            <p>Newest non-success responses, proxy failures, and requests with retry activity.</p>
+            <h4>Request samples</h4>
+            <p>Newest retained non-success, proxy-failure, and retry requests. Filters are exact matches against this loaded sample set; they do not change the server-wide aggregates.</p>
           </div>
-          <div v-if="selectedDimension" class="sample-filter">
-            <span>Filtered by {{ selectedDimension.title }}</span>
-            <bdi dir="ltr">{{ inspectionValue(selectedDimension.label) }}</bdi>
-            <NButton quaternary size="small" attr-type="button" @click="selectedDimension = null">Clear filter</NButton>
+          <div class="sample-controls">
+            <NTag size="small" :bordered="false" :type="selectedDimension ? 'info' : 'default'">{{ sampleFilterSummary }}</NTag>
+            <AccessibleSelect
+              v-model:value="sampleLimit"
+              accessible-label="Loaded diagnostic sample limit"
+              class="sample-select"
+              size="small"
+              :options="sampleSelectOptions"
+            />
           </div>
+        </div>
+        <div v-if="selectedDimension" class="sample-filter" role="status">
+          <span>Exact filter · {{ selectedDimension.title }}</span>
+          <bdi dir="ltr">{{ inspectionValue(selectedDimension.label) }}</bdi>
+          <NButton quaternary size="small" attr-type="button" @click="selectedDimension = null">Show all loaded samples</NButton>
+        </div>
+        <div v-else class="sample-filter-guide">
+          <span>No exact-match filter is active.</span>
+          <p>Open <RouterLink to="/monitor/diagnostics/failures">Failure map</RouterLink> or <RouterLink to="/monitor/diagnostics/retries">Retry health</RouterLink>, then choose a dimension to inspect its matching samples here.</p>
         </div>
         <div v-if="filteredRecentSamples.length" class="diagnostics-table-shell">
           <NDataTable
@@ -636,10 +720,28 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
 
 .header-controls {
   display: grid;
-  grid-template-columns: auto 11rem auto;
+  grid-template-columns: auto auto;
   align-items: center;
   gap: 0.5rem;
   justify-content: end;
+}
+
+.diagnostics-section-tabs {
+  min-width: 0;
+  margin-top: -0.5rem;
+}
+
+.diagnostics-section-tabs :deep(.n-tabs-nav) {
+  margin-bottom: 0;
+}
+
+.diagnostics-section-tabs :deep(.n-tabs-tab) {
+  padding: 0.625rem 0.125rem 0.75rem;
+  font-size: 0.875rem;
+}
+
+.diagnostics-section-tabs :deep(.n-tabs-tab + .n-tabs-tab) {
+  margin-left: 1.25rem;
 }
 
 .window-tabs {
@@ -657,6 +759,122 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
 
 .sample-select {
   width: 11rem;
+}
+
+.investigation-section {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.investigation-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.investigation-lane {
+  position: relative;
+  display: grid;
+  min-width: 0;
+  gap: 0.85rem;
+  overflow: hidden;
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
+  background: var(--app-panel-muted);
+  padding: 1rem;
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 140ms ease, box-shadow 140ms ease, transform 140ms ease;
+}
+
+.investigation-lane::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--lane-accent, var(--app-accent));
+  content: "";
+}
+
+.investigation-lane--retry {
+  --lane-accent: var(--app-warning);
+}
+
+.investigation-lane--failures {
+  --lane-accent: var(--app-error);
+}
+
+.investigation-lane--samples {
+  --lane-accent: var(--app-accent);
+}
+
+.investigation-lane:hover,
+.investigation-lane:focus-visible {
+  border-color: color-mix(in srgb, var(--lane-accent) 58%, var(--app-border));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--lane-accent) 22%, transparent);
+  transform: translateY(-1px);
+}
+
+.investigation-lane:focus-visible {
+  outline: 2px solid var(--app-accent);
+  outline-offset: 2px;
+}
+
+.investigation-lane__index {
+  color: var(--lane-accent);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+}
+
+.investigation-lane strong {
+  color: var(--app-text);
+  font-size: 0.95rem;
+}
+
+.investigation-lane p {
+  margin-top: 0.25rem;
+  color: var(--app-text-muted);
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.investigation-lane dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 0;
+  border-block: 1px solid var(--app-border-subtle);
+  padding-block: 0.6rem;
+}
+
+.investigation-lane dl > div {
+  min-width: 0;
+}
+
+.investigation-lane dl > div + div {
+  border-left: 1px solid var(--app-border-subtle);
+  padding-left: 0.65rem;
+}
+
+.investigation-lane dt {
+  color: var(--app-text-muted);
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.investigation-lane dd {
+  margin: 0.2rem 0 0;
+  color: var(--app-text);
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  font-weight: 750;
+}
+
+.investigation-lane__action {
+  color: var(--lane-accent);
+  font-size: 0.72rem;
+  font-weight: 700;
 }
 
 .breakdown-grid {
@@ -1004,6 +1222,14 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
   font-size: 0.72rem;
 }
 
+.dimension-action {
+  grid-column: 2;
+  margin-top: 0.1rem;
+  color: var(--app-accent);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
 .dimension-list {
   margin: 0;
   padding: 0;
@@ -1029,6 +1255,13 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
 
 .diagnostics-samples-heading {
   align-items: center;
+}
+
+.sample-controls {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .sample-filter {
@@ -1062,6 +1295,30 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
 .sample-filter :deep(.n-button) {
   grid-column: 2;
   grid-row: 1 / span 2;
+}
+
+.sample-filter-guide {
+  display: grid;
+  gap: 0.2rem;
+  border-left: 3px solid var(--app-border);
+  background: var(--app-panel);
+  padding: 0.6rem 0.75rem;
+}
+
+.sample-filter-guide > span {
+  color: var(--app-text);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.sample-filter-guide p {
+  color: var(--app-text-muted);
+  font-size: 0.72rem;
+}
+
+.sample-filter-guide a {
+  color: var(--app-accent);
+  font-weight: 700;
 }
 
 .diagnostic-request-stack,
@@ -1227,6 +1484,10 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
     width: 100%;
   }
 
+  .investigation-grid {
+    grid-template-columns: 1fr;
+  }
+
   .status-row {
     grid-template-columns: 1fr;
   }
@@ -1250,6 +1511,12 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
 
   .diagnostics-samples-heading {
     display: grid;
+  }
+
+  .sample-controls {
+    display: grid;
+    grid-template-columns: 1fr;
+    width: 100%;
   }
 
   .sample-filter {
@@ -1278,6 +1545,11 @@ function sampleRowKey(sample: DashboardDiagnosticsSample): string {
   .sample-filter :deep(.n-button),
   .diagnostics-table-shell :deep(.n-button),
   .diagnostic-sample-drawer :deep(.n-base-close) {
+    min-height: 44px;
+  }
+
+  .diagnostics-section-tabs :deep(.n-tabs-tab),
+  .investigation-lane {
     min-height: 44px;
   }
 }

--- a/web/management/src/views/Monitor.vue
+++ b/web/management/src/views/Monitor.vue
@@ -15,7 +15,7 @@ const monitorSections = [
   {
     key: "diagnostics",
     label: "Diagnostics",
-    path: "/monitor/diagnostics",
+    path: "/monitor/diagnostics/overview",
   },
 ] as const;
 
@@ -39,6 +39,7 @@ async function selectSection(value: string | number) {
       type="line"
       animated
       :value="activeSection"
+      aria-label="Monitor sections"
       @update:value="selectSection"
     >
       <NTab

--- a/web/management/src/views/Overview.vue
+++ b/web/management/src/views/Overview.vue
@@ -349,7 +349,7 @@ function hotspotRowKey(row: DashboardProxyDimensionSummary): string {
           <h3>No urgent signals</h3>
           <p>The proxy, enabled listeners, connected agents, and traffic policy checks look healthy.</p>
         </div>
-        <router-link to="/monitor/diagnostics" class="attention-row__action">
+        <router-link to="/monitor/diagnostics/overview" class="attention-row__action">
           Open diagnostics
           <ArrowRightIcon aria-hidden="true" />
         </router-link>
@@ -402,7 +402,7 @@ function hotspotRowKey(row: DashboardProxyDimensionSummary): string {
             <p>Selected window plus last-hour error kinds.</p>
           </div>
           <div class="panel-actions">
-            <router-link to="/monitor/diagnostics" class="diagnostics-link">View diagnostics</router-link>
+            <router-link to="/monitor/diagnostics/overview" class="diagnostics-link">View diagnostics</router-link>
             <span class="signal-pill" :class="selectedWindow?.proxySlowRequests ? 'warn' : ''">
               {{ formatNumber(selectedWindow?.proxySlowRequests) }} slow
             </span>


### PR DESCRIPTION
## Summary
- split `/monitor/diagnostics` into routed Overview, Retry health, Failure map, and Request samples workspaces
- keep the time window global while moving sample-limit controls to the evidence page they affect
- make dimension filtering explicit: exact matches against loaded samples only, with visible match counts and clear aggregate-vs-sample scope
- route overview incident signals and ranked dimensions directly to the relevant investigation workspace
- update navigation, breadcrumbs, responsive behavior, unit coverage, and Playwright workflows

## Verification
- `bun run test` (202 pass)
- `bun run typecheck`
- `bun run build`
- `bunx playwright test e2e/diagnostics.spec.ts e2e/traffic-flow.spec.ts e2e/management-shell.spec.ts --list`
- `git diff --check`

## Visual QA note
A live browser pass was attempted, but no user-run local UI server was available and the existing HTTPS endpoint presents a self-signed certificate. The implementation was verified structurally, responsively, through typechecking, production build, and updated Playwright flows; CI will execute the browser suite.
