### PR TITLE
fix: repair startup migrations and update overview

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"os"
@@ -74,9 +75,11 @@ var serverCmd = &cobra.Command{
 		}
 		if cfg.AgentUpdatesEnabled {
 			authority, authorityErr := server.InitializeAgentUpdateManagementAuthority(context.Background(), database, cfg.AgentUpdateAuthorityKeyFile)
-			app.SetAgentUpdateManagementAuthority(authority, authorityErr)
 			if authorityErr != nil {
+				app.SetAgentUpdateManagementAuthority(nil, authorityErr)
 				log.Error().Err(authorityErr).Msg("Managed update authority unavailable; reverse proxy remains available but managed update enrollment and progression are disabled")
+			} else {
+				app.SetAgentUpdateManagementAuthority(authority, nil)
 			}
 		}
 		updateCatalog, err := newAgentUpdateCatalog(cfg)
@@ -87,9 +90,11 @@ var serverCmd = &cobra.Command{
 			log.Error().Err(err).Msg("Trusted agent update catalog unavailable; reverse proxy remains available but managed update enrollment and campaign creation are disabled")
 			updateCatalog = nil
 		}
-		app.TrustedAgentUpdates = updateCatalog
-		app.AgentUpdateBootstrap = updateCatalog
 		if updateCatalog != nil {
+			// A typed nil catalog assigned to either interface would appear
+			// available and panic when a management request calls it.
+			app.TrustedAgentUpdates = updateCatalog
+			app.AgentUpdateBootstrap = updateCatalog
 			primeCtx, cancelPrime := context.WithTimeout(context.Background(), time.Duration(cfg.AgentUpdateHTTPTimeoutMillis)*time.Millisecond)
 			if err := primeAgentUpdateCatalog(primeCtx, updateCatalog); err != nil {
 				log.Warn().Err(err).Msg("Trusted agent update catalog is temporarily unavailable; campaign creation remains fail-closed")
@@ -102,7 +107,7 @@ var serverCmd = &cobra.Command{
 				log.Warn().Err(err).Msg("Failed to close GeoIP runtime")
 			}
 		}()
-		if err := app.LoadPublicGeoRuntime(); err != nil && !os.IsNotExist(err) {
+		if err := app.LoadPublicGeoRuntime(); err != nil && !errors.Is(err, os.ErrNotExist) {
 			log.Warn().Err(err).Msg("Failed to load the existing GeoIP country database")
 		}
 

--- a/internal/agentupdatecatalog/catalog.go
+++ b/internal/agentupdatecatalog/catalog.go
@@ -136,6 +136,9 @@ func loopbackTestOrigin(raw string) bool {
 // good release survives a transient network failure only while its manifest
 // expiry is still in the future.
 func (c *Catalog) Latest(ctx context.Context) (*agentupdate.VerifiedCatalog, error) {
+	if c == nil {
+		return nil, errors.New("agent update catalog is unavailable")
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/internal/agentupdatecatalog/catalog_test.go
+++ b/internal/agentupdatecatalog/catalog_test.go
@@ -17,6 +17,20 @@ import (
 	"p2pstream/internal/agentupdate"
 )
 
+func TestUnavailableCatalogRejectsManagementRequests(t *testing.T) {
+	var catalog *Catalog
+	ctx := context.Background()
+	if targets, err := catalog.ListTrustedAgentUpdateTargets(ctx); err == nil || len(targets) != 0 {
+		t.Fatalf("unavailable targets = %v, err = %v", targets, err)
+	}
+	if target, err := catalog.ResolveTrustedAgentUpdateTarget(ctx, strings.Repeat("a", 64)); err == nil || target != nil {
+		t.Fatalf("unavailable target = %v, err = %v", target, err)
+	}
+	if repository, err := catalog.AgentUpdateBootstrapConfig(ctx); err == nil || repository != "" {
+		t.Fatalf("unavailable bootstrap = %q, err = %v", repository, err)
+	}
+}
+
 func TestCatalogAuthenticatesPersistsAndUsesBoundedStaleFallback(t *testing.T) {
 	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
 	bundle := newCatalogBundle(t, now, "v1.2.3", 10203)

--- a/internal/agentupdatecatalog/server_adapter.go
+++ b/internal/agentupdatecatalog/server_adapter.go
@@ -12,6 +12,9 @@ import (
 // AgentUpdateBootstrapConfig implements server.AgentUpdateBootstrapProvider.
 // It returns the fixed GitHub repository identifier, not a URL.
 func (c *Catalog) AgentUpdateBootstrapConfig(context.Context) (string, error) {
+	if c == nil {
+		return "", errors.New("agent update catalog is unavailable")
+	}
 	return c.options.Repository, nil
 }
 

--- a/internal/db/managed_updates_migration_test.go
+++ b/internal/db/managed_updates_migration_test.go
@@ -1,0 +1,148 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+
+	"p2pstream/internal/db/migrations"
+)
+
+func TestManagedUpdateMigrationRepairsEmptyVersion16Schemas(t *testing.T) {
+	wantDB := openSchemaParityDB(t, "schema.db")
+	applySchemaSQL(t, wantDB)
+	want := readNormalizedSchema(t, wantDB)
+	for _, fixture := range []string{"managed_updates_early.sql", "managed_updates_signed.sql"} {
+		t.Run(fixture, func(t *testing.T) {
+			database := seedManagedUpdateVersion16(t, fixture)
+			for i := 0; i < 2; i++ {
+				if err := runEmbeddedMigrations(database); err != nil {
+					t.Fatalf("migrate version 16 (run %d): %v", i, err)
+				}
+				assertSchemaParity(t, fixture, readNormalizedSchema(t, database), want)
+			}
+			var name, keyID string
+			if err := database.QueryRow(`SELECT name FROM agents WHERE public_id='existing-agent'`).Scan(&name); err != nil || name != "Existing agent" {
+				t.Fatalf("agent changed during migration: name=%q, err=%v", name, err)
+			}
+			if err := database.QueryRow(`SELECT key_id FROM agent_update_management_authority WHERE id=1`).Scan(&keyID); err != nil || keyID != "existing-pin" {
+				t.Fatalf("authority pin changed during migration: key=%q, err=%v", keyID, err)
+			}
+			var version int64
+			if err := database.QueryRow(`SELECT MAX(version_id) FROM goose_db_version WHERE is_applied=1`).Scan(&version); err != nil || version != 17 {
+				t.Fatalf("migration version=%d, err=%v", version, err)
+			}
+			rows, err := database.Query(`PRAGMA foreign_key_check`)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer rows.Close()
+			if rows.Next() || rows.Err() != nil {
+				t.Fatalf("foreign key check failed: %v", rows.Err())
+			}
+		})
+	}
+}
+
+func TestManagedUpdateMigrationPreservesPopulatedIncompatibleSchema(t *testing.T) {
+	database := seedManagedUpdateVersion16(t, "managed_updates_early.sql")
+	if _, err := database.Exec(`INSERT INTO agent_updater_enrollment_tokens (agent_id,token_hash,expires_at) SELECT id,'existing-token',CURRENT_TIMESTAMP FROM agents WHERE public_id='existing-agent'`); err != nil {
+		t.Fatal(err)
+	}
+	before := readNormalizedSchema(t, database)
+	err := runEmbeddedMigrations(database)
+	if err == nil || !strings.Contains(err.Error(), "automatic repair requires empty managed-update tables") {
+		t.Fatalf("populated incompatible schema error = %v", err)
+	}
+	assertSchemaParity(t, "unchanged incompatible schema", readNormalizedSchema(t, database), before)
+	var token string
+	if err := database.QueryRow(`SELECT token_hash FROM agent_updater_enrollment_tokens`).Scan(&token); err != nil || token != "existing-token" {
+		t.Fatalf("existing token changed: token=%q, err=%v", token, err)
+	}
+	var version int64
+	if err := database.QueryRow(`SELECT MAX(version_id) FROM goose_db_version WHERE is_applied=1`).Scan(&version); err != nil || version != 16 {
+		t.Fatalf("failed migration must not advance version: version=%d, err=%v", version, err)
+	}
+}
+
+func TestManagedUpdateMigrationLeavesPopulatedCurrentSchemaIntact(t *testing.T) {
+	database := seedManagedUpdateVersion16(t, "")
+	if _, err := database.Exec(`INSERT INTO agent_updater_enrollment_tokens (agent_id,token_hash,pinned_repository,authority_key_id,authority_epoch,enrollment_generation,expires_at) SELECT id,'existing-token','owner/repo','existing-pin',1,1,CURRENT_TIMESTAMP FROM agents WHERE public_id='existing-agent'`); err != nil {
+		t.Fatal(err)
+	}
+	before := readNormalizedSchema(t, database)
+	if err := runEmbeddedMigrations(database); err != nil {
+		t.Fatal(err)
+	}
+	assertSchemaParity(t, "unchanged current schema", readNormalizedSchema(t, database), before)
+	var token string
+	if err := database.QueryRow(`SELECT token_hash FROM agent_updater_enrollment_tokens`).Scan(&token); err != nil || token != "existing-token" {
+		t.Fatalf("existing token changed: token=%q, err=%v", token, err)
+	}
+}
+
+func seedManagedUpdateVersion16(t *testing.T, fixture string) *sql.DB {
+	t.Helper()
+	database := openSchemaParityDB(t, "version16.db")
+	database.SetMaxOpenConns(1)
+	if _, err := database.Exec(`PRAGMA foreign_keys=ON`); err != nil {
+		t.Fatal(err)
+	}
+	provider, err := goose.NewProvider(goose.DialectSQLite3, database, migrations.FS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := provider.UpTo(context.Background(), 15); err != nil {
+		t.Fatal(err)
+	}
+	var data []byte
+	if fixture == "" {
+		data, err = migrations.FS.ReadFile("00016_managed_agent_updates.sql")
+	} else {
+		data, err = os.ReadFile(filepath.Join("testdata", fixture))
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	up, _, _ := strings.Cut(string(data), "-- +goose Down")
+	if _, err := database.Exec(up); err != nil {
+		t.Fatal(err)
+	}
+	// Preserve the independent authority pin when present; early builds did not
+	// create this table, so also exercise its missing-table upgrade separately.
+	if _, err := database.Exec(`
+		CREATE TABLE IF NOT EXISTS agent_update_management_authority (
+			id INTEGER PRIMARY KEY CHECK(id = 1),
+			key_id TEXT NOT NULL UNIQUE,
+			public_key BLOB NOT NULL CHECK(length(public_key) = 32),
+			epoch INTEGER NOT NULL CHECK(epoch > 0),
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		INSERT INTO agent_update_management_authority (id,key_id,public_key,epoch) VALUES (1,'existing-pin',zeroblob(32),1);
+		INSERT INTO agents (public_id,name,token_hash) VALUES ('existing-agent','Existing agent','agent-token');
+		INSERT INTO goose_db_version (version_id,is_applied) VALUES (16,1);
+	`); err != nil {
+		t.Fatal(err)
+	}
+	return database
+}
+
+func TestManagedUpdateMigrationCreatesMissingAuthorityTable(t *testing.T) {
+	database := seedManagedUpdateVersion16(t, "managed_updates_early.sql")
+	if _, err := database.Exec(`DROP TABLE agent_update_management_authority`); err != nil {
+		t.Fatal(err)
+	}
+	if err := runEmbeddedMigrations(database); err != nil {
+		t.Fatal(err)
+	}
+	var count int
+	if err := database.QueryRow(`SELECT COUNT(*) FROM agent_update_management_authority`).Scan(&count); err != nil || count != 0 {
+		t.Fatalf("authority table count=%d, err=%v", count, err)
+	}
+}

--- a/internal/db/migrate_managed_updates.go
+++ b/internal/db/migrate_managed_updates.go
@@ -1,0 +1,81 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"p2pstream/internal/db/migrations"
+)
+
+// Migration 16 was changed during managed-update development without advancing
+// its version. Migration 17 repairs empty installations of those older schemas.
+// Populated incompatible schemas need an explicit migration of their authority
+// and receipt data; never discard that data or invent missing trust bindings.
+func repairEmptyManagedUpdateSchema(ctx context.Context, tx *sql.Tx) error {
+	checks := []struct {
+		table    string
+		required []string
+		obsolete []string
+	}{
+		{"agent_update_management_authority", []string{"key_id", "public_key", "epoch"}, nil},
+		{"agent_updater_identities", []string{"pinned_repository", "authority_key_id", "authority_epoch", "enrollment_generation", "enrollment_receipt_payload", "enrollment_receipt_signature", "last_command_sequence", "last_root_action_counter"}, []string{"trusted_root_sha256", "trusted_root_version", "last_activation_counter"}},
+		{"agent_updater_enrollment_tokens", []string{"pinned_repository", "authority_key_id", "authority_epoch", "enrollment_generation", "receipt_expires_at", "receipt_payload", "receipt_signature"}, []string{"trusted_root_sha256", "trusted_root_version"}},
+		{"agent_update_campaigns", []string{"manifest_sha256"}, []string{"root_version"}},
+		{"agent_update_assignments", []string{"authorization_action", "command_sequence", "root_action_completed_at", "root_result_kind", "root_result_artifact_sha256", "observed_version", "observed_commit"}, []string{"root_result_root_version"}},
+		{"agent_update_events", []string{"assignment_id"}, nil},
+	}
+	needsRepair := false
+	existing := make(map[string]bool)
+	for _, check := range checks {
+		columns, err := sqliteTxTableColumns(tx, check.table)
+		if err != nil {
+			return err
+		}
+		existing[check.table] = len(columns) > 0
+		for _, column := range check.required {
+			if !sqliteColumnExists(columns, column) {
+				needsRepair = true
+			}
+		}
+		for _, column := range check.obsolete {
+			if sqliteColumnExists(columns, column) {
+				needsRepair = true
+			}
+		}
+	}
+	if !needsRepair {
+		return nil
+	}
+
+	// Child tables come first so foreign-key enforcement stays enabled. Preserve
+	// an existing management authority pin even when all other tables are empty.
+	tables := []string{"agent_update_events", "agent_update_assignments", "agent_update_campaigns", "agent_updater_enrollment_tokens", "agent_updater_identities"}
+	for _, table := range tables {
+		if !existing[table] {
+			continue
+		}
+		var count int64
+		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM `+table).Scan(&count); err != nil {
+			return err
+		}
+		if count != 0 {
+			return fmt.Errorf("incompatible managed-update schema: %s contains %d rows; automatic repair requires empty managed-update tables; preserve the database and migrate existing enrollment/campaign state explicitly", table, count)
+		}
+	}
+	for _, table := range tables {
+		if _, err := tx.ExecContext(ctx, `DROP TABLE IF EXISTS `+table); err != nil {
+			return err
+		}
+	}
+	// Treat this embedded schema as immutable from now on; subsequent changes
+	// must use new migration versions instead of editing migration 16 again.
+	data, err := migrations.FS.ReadFile("00016_managed_agent_updates.sql")
+	if err != nil {
+		return err
+	}
+	up, _, _ := strings.Cut(string(data), "-- +goose Down")
+	_, err = tx.ExecContext(ctx, up)
+	return err
+}

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -16,7 +16,8 @@ func runEmbeddedMigrations(database *sql.DB) error {
 	if err := adoptEmbeddedMigrationBaseline(database); err != nil {
 		return err
 	}
-	provider, err := goose.NewProvider(goose.DialectSQLite3, database, migrations.FS)
+	provider, err := goose.NewProvider(goose.DialectSQLite3, database, migrations.FS,
+		goose.WithGoMigrations(goose.NewGoMigration(17, &goose.GoFunc{RunTx: repairEmptyManagedUpdateSchema}, nil)))
 	if err != nil {
 		return fmt.Errorf("configure db migrations: %w", err)
 	}

--- a/internal/db/testdata/managed_updates_early.sql
+++ b/internal/db/testdata/managed_updates_early.sql
@@ -1,0 +1,86 @@
+-- Early development schema that was already stamped as Goose version 16.
+CREATE TABLE agent_update_assignments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    campaign_id INTEGER NOT NULL REFERENCES agent_update_campaigns(id) ON DELETE CASCADE,
+    agent_id INTEGER NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    state TEXT NOT NULL CHECK(state IN ('pending','staging','staged','cordoned','activating','awaiting_tunnel','healthy_dwell','succeeded','failed','cancelled','blocked')),
+    desired_action TEXT NOT NULL CHECK(desired_action IN ('none','stage','activate','rollback')),
+    generation INTEGER NOT NULL DEFAULT 1 CHECK(generation > 0),
+    cordoned INTEGER NOT NULL DEFAULT 0 CHECK(cordoned IN (0,1)),
+    failure_code TEXT NOT NULL DEFAULT '',
+    failure_detail TEXT NOT NULL DEFAULT '',
+    attested_manifest_sha256 TEXT NOT NULL DEFAULT '',
+    attested_binary_sha256 TEXT NOT NULL DEFAULT '',
+    attested_activation_counter INTEGER NOT NULL DEFAULT 0 CHECK(attested_activation_counter >= 0),
+    activation_nonce_hash TEXT NOT NULL DEFAULT '',
+    running_version TEXT NOT NULL DEFAULT '',
+    running_commit TEXT NOT NULL DEFAULT '',
+    activated_at DATETIME,
+    fresh_tunnel_at DATETIME,
+    healthy_at DATETIME,
+    last_report_at DATETIME,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(campaign_id, agent_id)
+);
+
+CREATE TABLE agent_update_campaigns (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    state TEXT NOT NULL CHECK(state IN ('running','paused','cancelled','completed')),
+    generation INTEGER NOT NULL DEFAULT 1 CHECK(generation > 0),
+    target_version TEXT NOT NULL,
+    target_commit TEXT NOT NULL,
+    manifest_sha256 TEXT NOT NULL,
+    release_sequence INTEGER NOT NULL CHECK(release_sequence >= 0),
+    security_epoch INTEGER NOT NULL DEFAULT 0 CHECK(security_epoch >= 0),
+    minimum_updater_version TEXT NOT NULL DEFAULT '',
+    minimum_tunnel_protocol INTEGER NOT NULL DEFAULT 0 CHECK(minimum_tunnel_protocol >= 0),
+    maximum_tunnel_protocol INTEGER NOT NULL DEFAULT 0 CHECK(maximum_tunnel_protocol >= 0),
+    artifacts_json TEXT NOT NULL,
+    max_unavailable INTEGER NOT NULL CHECK(max_unavailable > 0),
+    minimum_eligible_agents_per_route INTEGER NOT NULL CHECK(minimum_eligible_agents_per_route > 0),
+    canary_count INTEGER NOT NULL CHECK(canary_count > 0),
+    wave_size INTEGER NOT NULL CHECK(wave_size > 0),
+    healthy_dwell_millis INTEGER NOT NULL CHECK(healthy_dwell_millis >= 0),
+    created_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at DATETIME
+);
+
+CREATE TABLE agent_update_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    campaign_id INTEGER NOT NULL REFERENCES agent_update_campaigns(id) ON DELETE CASCADE,
+    assignment_id INTEGER REFERENCES agent_update_assignments(id) ON DELETE CASCADE,
+    agent_id INTEGER REFERENCES agents(id) ON DELETE SET NULL,
+    kind TEXT NOT NULL,
+    detail TEXT NOT NULL DEFAULT '',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE agent_updater_enrollment_tokens (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_id INTEGER NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    token_hash TEXT NOT NULL UNIQUE,
+    expires_at DATETIME NOT NULL,
+    used_at DATETIME,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE agent_updater_identities (
+    agent_id INTEGER PRIMARY KEY REFERENCES agents(id) ON DELETE CASCADE,
+    updater_key_id TEXT NOT NULL UNIQUE,
+    updater_public_key BLOB NOT NULL CHECK(length(updater_public_key) = 32),
+    activator_key_id TEXT NOT NULL UNIQUE,
+    activator_public_key BLOB NOT NULL CHECK(length(activator_public_key) = 32),
+    os TEXT NOT NULL,
+    arch TEXT NOT NULL,
+    updater_version TEXT NOT NULL,
+    enabled INTEGER NOT NULL DEFAULT 1 CHECK(enabled IN (0, 1)),
+    last_counter INTEGER NOT NULL DEFAULT 0 CHECK(last_counter >= 0),
+    last_activation_counter INTEGER NOT NULL DEFAULT 0 CHECK(last_activation_counter >= 0),
+    enrolled_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_seen_at DATETIME,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/internal/db/testdata/managed_updates_signed.sql
+++ b/internal/db/testdata/managed_updates_signed.sql
@@ -1,0 +1,151 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS agent_update_management_authority (
+    id INTEGER PRIMARY KEY CHECK(id = 1),
+    key_id TEXT NOT NULL UNIQUE,
+    public_key BLOB NOT NULL CHECK(length(public_key) = 32),
+    epoch INTEGER NOT NULL CHECK(epoch > 0),
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE IF NOT EXISTS agent_updater_identities (
+    agent_id INTEGER PRIMARY KEY REFERENCES agents(id) ON DELETE CASCADE,
+    updater_key_id TEXT NOT NULL UNIQUE,
+    updater_public_key BLOB NOT NULL CHECK(length(updater_public_key) = 32),
+    activator_key_id TEXT NOT NULL UNIQUE,
+    activator_public_key BLOB NOT NULL CHECK(length(activator_public_key) = 32),
+    os TEXT NOT NULL,
+    arch TEXT NOT NULL,
+    updater_version TEXT NOT NULL,
+    trusted_root_sha256 TEXT NOT NULL,
+    trusted_root_version INTEGER NOT NULL CHECK(trusted_root_version > 0),
+    pinned_repository TEXT NOT NULL,
+    authority_key_id TEXT NOT NULL,
+    authority_epoch INTEGER NOT NULL CHECK(authority_epoch > 0),
+    enrollment_generation INTEGER NOT NULL CHECK(enrollment_generation > 0),
+    enrollment_receipt_payload BLOB NOT NULL,
+    enrollment_receipt_signature BLOB NOT NULL CHECK(length(enrollment_receipt_signature) = 64),
+    enabled INTEGER NOT NULL DEFAULT 1 CHECK(enabled IN (0, 1)),
+    last_counter INTEGER NOT NULL DEFAULT 0 CHECK(last_counter >= 0),
+    last_command_sequence INTEGER NOT NULL DEFAULT 0 CHECK(last_command_sequence >= 0),
+    last_root_action_counter INTEGER NOT NULL DEFAULT 0 CHECK(last_root_action_counter >= 0),
+    enrolled_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_seen_at DATETIME,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE IF NOT EXISTS agent_updater_enrollment_tokens (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_id INTEGER NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    token_hash TEXT NOT NULL UNIQUE,
+    trusted_root_sha256 TEXT NOT NULL,
+    trusted_root_version INTEGER NOT NULL CHECK(trusted_root_version > 0),
+    pinned_repository TEXT NOT NULL,
+    authority_key_id TEXT NOT NULL,
+    authority_epoch INTEGER NOT NULL CHECK(authority_epoch > 0),
+    enrollment_generation INTEGER NOT NULL CHECK(enrollment_generation > 0),
+    expires_at DATETIME NOT NULL,
+    used_at DATETIME,
+    receipt_expires_at DATETIME,
+    updater_key_id TEXT NOT NULL DEFAULT '',
+    activator_key_id TEXT NOT NULL DEFAULT '',
+    os TEXT NOT NULL DEFAULT '',
+    arch TEXT NOT NULL DEFAULT '',
+    updater_version TEXT NOT NULL DEFAULT '',
+    receipt_payload BLOB NOT NULL DEFAULT X'',
+    receipt_signature BLOB NOT NULL DEFAULT X'',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_agent_updater_enrollment_tokens_agent ON agent_updater_enrollment_tokens(agent_id,expires_at);
+CREATE TABLE IF NOT EXISTS agent_update_campaigns (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    state TEXT NOT NULL CHECK(state IN ('running','paused','cancelled','completed')),
+    generation INTEGER NOT NULL DEFAULT 1 CHECK(generation > 0),
+    target_version TEXT NOT NULL,
+    target_commit TEXT NOT NULL,
+    manifest_sha256 TEXT NOT NULL,
+    release_sequence INTEGER NOT NULL CHECK(release_sequence >= 0),
+    root_version INTEGER NOT NULL CHECK(root_version > 0),
+    security_epoch INTEGER NOT NULL DEFAULT 0 CHECK(security_epoch >= 0),
+    minimum_updater_version TEXT NOT NULL DEFAULT '',
+    minimum_tunnel_protocol INTEGER NOT NULL DEFAULT 0 CHECK(minimum_tunnel_protocol >= 0),
+    maximum_tunnel_protocol INTEGER NOT NULL DEFAULT 0 CHECK(maximum_tunnel_protocol >= 0),
+    artifacts_json TEXT NOT NULL,
+    max_unavailable INTEGER NOT NULL CHECK(max_unavailable > 0),
+    minimum_eligible_agents_per_route INTEGER NOT NULL CHECK(minimum_eligible_agents_per_route > 0),
+    canary_count INTEGER NOT NULL CHECK(canary_count > 0),
+    wave_size INTEGER NOT NULL CHECK(wave_size > 0),
+    healthy_dwell_millis INTEGER NOT NULL CHECK(healthy_dwell_millis >= 0),
+    created_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at DATETIME
+);
+CREATE TABLE IF NOT EXISTS agent_update_assignments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    campaign_id INTEGER NOT NULL REFERENCES agent_update_campaigns(id) ON DELETE CASCADE,
+    agent_id INTEGER NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    state TEXT NOT NULL CHECK(state IN ('pending','staging','staged','cordoned','activating','awaiting_tunnel','healthy_dwell','succeeded','failed','cancelled','blocked')),
+    desired_action TEXT NOT NULL CHECK(desired_action IN ('none','stage','activate','rollback')),
+    generation INTEGER NOT NULL DEFAULT 1 CHECK(generation > 0),
+    cordoned INTEGER NOT NULL DEFAULT 0 CHECK(cordoned IN (0,1)),
+    failure_code TEXT NOT NULL DEFAULT '',
+    failure_detail TEXT NOT NULL DEFAULT '',
+    attested_manifest_sha256 TEXT NOT NULL DEFAULT '',
+    attested_binary_sha256 TEXT NOT NULL DEFAULT '',
+    attested_activation_counter INTEGER NOT NULL DEFAULT 0 CHECK(attested_activation_counter >= 0),
+    activation_nonce_hash TEXT NOT NULL DEFAULT '',
+    authorization_action TEXT NOT NULL DEFAULT '' CHECK(authorization_action IN ('','activate','rollback')),
+    authorization_server_version TEXT NOT NULL DEFAULT '',
+    command_sequence INTEGER NOT NULL DEFAULT 0 CHECK(command_sequence >= 0),
+    authorization_nonce BLOB NOT NULL DEFAULT X'',
+    authorization_sha256 TEXT NOT NULL DEFAULT '',
+    authorization_payload BLOB NOT NULL DEFAULT X'',
+    authorization_signature BLOB NOT NULL DEFAULT X'',
+    authorization_issued_at DATETIME,
+    authorization_expires_at DATETIME,
+    root_action_counter INTEGER NOT NULL DEFAULT 0 CHECK(root_action_counter >= 0),
+    root_action_receipt_payload BLOB NOT NULL DEFAULT X'',
+    root_action_receipt_signature BLOB NOT NULL DEFAULT X'',
+    root_action_completed_at DATETIME,
+    root_result_kind TEXT NOT NULL DEFAULT '' CHECK(root_result_kind IN ('','signed_release','bootstrap')),
+    root_result_root_version INTEGER NOT NULL DEFAULT 0 CHECK(root_result_root_version >= 0),
+    root_result_manifest_sha256 TEXT NOT NULL DEFAULT '',
+    root_result_version TEXT NOT NULL DEFAULT '',
+    root_result_commit TEXT NOT NULL DEFAULT '',
+    root_result_release_sequence INTEGER NOT NULL DEFAULT 0 CHECK(root_result_release_sequence >= 0),
+    root_result_security_epoch INTEGER NOT NULL DEFAULT 0 CHECK(root_result_security_epoch >= 0),
+    root_result_os TEXT NOT NULL DEFAULT '',
+    root_result_arch TEXT NOT NULL DEFAULT '',
+    root_result_artifact_name TEXT NOT NULL DEFAULT '',
+    root_result_artifact_size INTEGER NOT NULL DEFAULT 0 CHECK(root_result_artifact_size >= 0),
+    root_result_artifact_sha256 TEXT NOT NULL DEFAULT '',
+    running_version TEXT NOT NULL DEFAULT '',
+    running_commit TEXT NOT NULL DEFAULT '',
+    observed_version TEXT NOT NULL DEFAULT '',
+    observed_commit TEXT NOT NULL DEFAULT '',
+    activated_at DATETIME,
+    fresh_tunnel_at DATETIME,
+    healthy_at DATETIME,
+    last_report_at DATETIME,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(campaign_id, agent_id)
+);
+CREATE INDEX IF NOT EXISTS idx_agent_update_assignments_agent_state ON agent_update_assignments(agent_id,state);
+CREATE INDEX IF NOT EXISTS idx_agent_update_assignments_campaign_state ON agent_update_assignments(campaign_id,state);
+CREATE INDEX IF NOT EXISTS idx_agent_update_assignments_cordoned ON agent_update_assignments(agent_id) WHERE cordoned=1;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_update_assignments_one_active_agent ON agent_update_assignments(agent_id) WHERE state NOT IN ('succeeded','failed','cancelled') OR (state='failed' AND desired_action='rollback');
+CREATE TABLE IF NOT EXISTS agent_update_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    campaign_id INTEGER NOT NULL REFERENCES agent_update_campaigns(id) ON DELETE CASCADE,
+    assignment_id INTEGER REFERENCES agent_update_assignments(id) ON DELETE CASCADE,
+    agent_id INTEGER REFERENCES agents(id) ON DELETE SET NULL,
+    kind TEXT NOT NULL,
+    detail TEXT NOT NULL DEFAULT '',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_agent_update_events_assignment ON agent_update_events(assignment_id,id DESC);
+
+-- +goose Down
+-- Managed update state is security/audit data. Runtime downgrades are unsupported.
+SELECT 1;

--- a/internal/server/geoip_country.go
+++ b/internal/server/geoip_country.go
@@ -84,7 +84,7 @@ func (s *GeoIPCountryStore) Load() error {
 	if s.isClosed() {
 		return ErrGeoIPCountryStoreClosed
 	}
-	if err := hardenGeoIPCountryDatabasePath(s.path); err != nil && !os.IsNotExist(err) {
+	if err := hardenGeoIPCountryDatabasePath(s.path); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 	reader, info, err := openGeoIPCountryDatabase(s.path)

--- a/internal/server/geoip_country_test.go
+++ b/internal/server/geoip_country_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -74,6 +75,30 @@ func TestGeoIPCountryStoreLoadLookupAndSpecialAddresses(t *testing.T) {
 	info, ready := store.Info()
 	if !ready || info.DatabaseType != "GeoLite2-Country" || info.Path != databasePath || info.SizeBytes != int64(len(database)) {
 		t.Fatalf("info = %#v, ready = %v", info, ready)
+	}
+}
+
+func TestGeoIPCountryStoreLoadMissingDatabase(t *testing.T) {
+	for _, directoryExists := range []bool{false, true} {
+		t.Run(fmt.Sprint(directoryExists), func(t *testing.T) {
+			directory := filepath.Join(t.TempDir(), "geoip")
+			if directoryExists {
+				if err := os.Mkdir(directory, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			store, err := NewGeoIPCountryStore(filepath.Join(directory, GeoIPCountryDatabaseFilename), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Close()
+			if err := store.Load(); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("missing database error = %v, want os.ErrNotExist", err)
+			}
+			if _, ready := store.Info(); ready {
+				t.Fatal("missing database must not make GeoIP ready")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
The development server could panic when the update overview called an unavailable catalog, and databases stamped with an older version of migration 16 repeatedly failed managed-update maintenance queries. Missing optional GeoIP files also produced a misleading startup warning.

Keep unavailable catalog and authority dependencies nil, return errors for nil catalog calls, recognize wrapped missing-file errors, and add migration 17 to repair empty incompatible managed-update tables. Preserve existing authority pins and refuse to discard populated incompatible enrollment or campaign data.

Validation: all tests in `internal/db`, `internal/agentupdatecatalog`, `internal/server`, and `cmd` pass. The running development server applied migration 17, and the authenticated update overview, dashboard, and proxy configuration APIs returned HTTP 200.
