### PR TITLE
Fix agent setup, token workflows, and deletion with history

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ Full self-hosting and operations documentation is available at <https://kirari04
 
 ## Agent Install
 
-Create an agent from **Agents** in the management UI. The **Agent Setup** modal gives you an `AGENT_ID` and one-time `AGENT_TOKEN`, then provides Linux install, Docker Compose, and CLI snippets.
+Create an agent from **Agents** in the management UI. The **Install Agent** modal gives you an `AGENT_ID` and one-time `AGENT_TOKEN`, then provides Linux install, Docker Compose, and CLI snippets.
 
-Linux setup requires an exact `vX.Y.Z` release or `vX.Y.Z-staging.N` prerelease, a locally supplied versioned installer, and a locally supplied raw agent binary. Verify those files independently before running the generated command; the installer never pipes mutable repository code into root or downloads executable content.
+Copy the Linux command and run it on the agent host. It includes the issued credentials, downloads the installer and architecture-specific binary from the selected GitHub release, and verifies their SHA-256 checksums before installation. No token prompts or local file paths are required. Advanced options support independently verified local files. Managed updates pin an exact release or prerelease; other installs can resolve `latest` once to an exact release.
 
-Linux/systemd agents can also enroll in **Agents → Updates**. Enrollment uses a separate short-lived updater token and does not rotate or expose the tunnel token. Managed campaigns verify exact GitHub releases and SHA-256 manifests, stage without draining traffic, preserve route quorum while activating, require a privileged-helper artifact attestation plus a fresh exact-build tunnel, and automatically roll back locally when activation fails. See [Managed agent updates](docs/operations/managed-agent-updates.md).
+Existing Linux agents have **More → Reinstall / Repair**, which reuses their host token and includes managed-update setup when available. **Agents → Updates → Enable managed updates** performs the one-time enrollment while keeping the existing tunnel running. **Rotate token** remains a separate credential action. All setup actions share a dialog with an editable Management URL. Remote environments use their saved address when the server advertises localhost. Managed campaigns verify exact GitHub releases and SHA-256 manifests, preserve route quorum during activation, and roll back locally on failure. See [Managed agent updates](docs/operations/managed-agent-updates.md).
 
-Agents connect through `MANAGEMENT_URL`, usually `https://your-server:8081`. The server's `MANAGEMENT_PUBLIC_URL` supplies that URL to generated setup snippets. If p2pstream generated the management TLS certificate, use the CA material from the **Agent Setup** modal so the agent can verify management HTTPS.
+Agents connect through `MANAGEMENT_URL`, usually `https://your-server:8081`. The server's `MANAGEMENT_PUBLIC_URL` supplies that URL to generated setup snippets. If p2pstream generated the management TLS certificate, use the CA material from the **Install Agent** modal so the agent can verify management HTTPS.
 
 For shell-installed agents, uninstall and full-purge commands are documented in the [systemd operations guide](https://kirari04.github.io/p2pstream/operations/systemd#uninstall-agent).
 

--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -40,7 +40,7 @@ By default, agents reject insecure HTTP management URLs and verify HTTPS certifi
 | `MANAGEMENT_CA_FILE` | Path to a PEM CA bundle on the agent host. |
 | `MANAGEMENT_CA_PEM_BASE64` | Base64-encoded PEM CA bundle, useful for generated snippets. |
 
-The **Agent Setup** modal can generate a one-line Linux systemd installer, a Docker Compose service, or a direct CLI command. Each generated form configures writable durable management trust; Docker uses a named state volume and direct CLI runs use a local state directory. Linux setup deliberately accepts only a locally supplied installer file, an exact SemVer release or prerelease identity, and a locally supplied raw binary. Staging builds automatically pin the isolated `staging` managed-update channel. The installer never pipes mutable repository code into root or downloads executable content. After independently verifying those two files, the command writes `/etc/p2pstream/agent.env`, enables `p2pstream-agent.service`, and restarts it. After token rotation, run the generated Linux reinstall command on the existing agent host so the new token and TLS material are loaded by a fresh process.
+The **Install Agent** modal can generate a one-line Linux systemd installer, a Docker Compose service, or a direct CLI command. Each generated form configures writable durable management trust; Docker uses a named state volume and direct CLI runs use a local state directory. The Linux command includes the issued credentials and automatically downloads the matching installer and binary from the selected GitHub release, verifying their SHA-256 checksums before installation. Optional local file overrides are available under advanced options. Staging builds pin the isolated `staging` managed-update channel. The command writes `/etc/p2pstream/agent.env`, enables `p2pstream-agent.service`, and restarts it. Use **More → Reinstall / Repair** to reuse the existing host token and include managed-update enrollment. **Rotate token** instead generates a credential-only command that preserves the installed software and settings, then restarts the connection. All setup actions share an editable Management URL; a remote server advertising localhost defaults to the saved environment address.
 
 If management requires agent client certificates, configure:
 
@@ -51,7 +51,7 @@ AGENT_TLS_KEY_FILE=/etc/p2pstream/agent.key.pem
 
 ## Common Mistakes
 
-- Reusing an old token after rotating it in management instead of running the generated reinstall command on the agent host.
+- Reusing an old token after rotating it in management instead of applying the generated token-change command on the agent host.
 - Setting `MANAGEMENT_URL` to a public listener instead of management.
 - Putting management behind a reverse proxy that blocks HTTP/1.1 upgrade streaming for `p2pstream-yamux` or closes idle upgraded connections too aggressively.
 - Forgetting CA material when management uses the auto-generated local CA.

--- a/docs/guides/expose-a-home-lab-app.md
+++ b/docs/guides/expose-a-home-lab-app.md
@@ -30,28 +30,16 @@ Example:
    | Name | `home-lab` |
    | Enabled | On |
 
-   After creation, the **Agent Setup** modal shows the generated `AGENT_ID` and one-time `AGENT_TOKEN`.
+   After creation, the **Install Agent** modal shows the generated `AGENT_ID` and one-time `AGENT_TOKEN`.
 
    <figure class="doc-screenshot">
      <img src="../assets/new/new_agent_modal_setup.png" alt="p2pstream Agent Setup modal showing generated agent identity, a one-time token, advanced options, and Linux, Docker Compose, and CLI tabs">
      <figcaption>The Agent Setup modal shows the one-time token and generated installer snippets. Copy the command before selecting Done because the token is not shown again.</figcaption>
    </figure>
 
-2. Obtain the exact versioned installer and raw agent binary through an independently trusted channel, verify them locally, and enter their absolute paths in the **Agent Setup** modal. The generated local-only command has this shape:
+2. Select **Linux install**, copy the generated command, and paste it into a terminal on the agent host. The command already includes the agent token and, when enabled, the updater enrollment token. It downloads the installer and binary for the selected release and host architecture, then verifies their SHA-256 checksums before installation. No local file paths or separate token entry are required.
 
-   ```bash
-   sudo env \
-     MANAGEMENT_URL='https://proxy.example.com:8081' \
-     MANAGEMENT_CA_PEM_BASE64='...' \
-     AGENT_ID='agent-...' \
-     AGENT_TOKEN='...' \
-     P2PSTREAM_REPOSITORY='Kirari04/p2pstream' \
-     P2PSTREAM_VERSION='v1.2.3' \
-     P2PSTREAM_AGENT_BINARY_FILE='/srv/pinned/p2pstream_v1.2.3_linux_amd64' \
-     bash '/srv/pinned/install-agent-v1.2.3.sh'
-   ```
-
-   The installer refuses stdin/piped execution, mutable release names, symlinked binaries, and remote checksum bootstrap. It creates `/usr/local/bin/p2pstream`, `/etc/p2pstream/agent.env`, and `p2pstream-agent.service`, then restarts the agent service. You can run the generated Linux command again after token rotation with independently verified local files.
+   The installer creates `/usr/local/bin/p2pstream`, `/etc/p2pstream/agent.env`, and `p2pstream-agent.service`, then restarts the agent service. For an existing host, use **More → Reinstall / Repair** to keep its token and enable managed updates. After explicit token rotation, run the separate token-change command. Independently verified local files can still be selected under **Advanced setup options**.
 
 3. Check the agent service:
 

--- a/docs/operations/managed-agent-updates.md
+++ b/docs/operations/managed-agent-updates.md
@@ -85,10 +85,18 @@ configuration; enabling updates on the parent does not configure the remote.
 
 ## Enroll hosts once
 
-Open **Agents → Updates**. An unenrolled host has a **Bootstrap** action. The UI
-presents a secret-free command and short-lived token as separate copy steps.
-The command prompts for the token so it is not placed in shell history or
-process arguments. The handoff contains:
+Open **Agents → Updates**. An unenrolled host has an **Enable managed updates** action. The UI
+uses the same setup dialog as **Install Agent** and **Reinstall / Repair**, with
+an editable Management URL, release details, and optional local files.
+Enrollment preserves the host's existing management CA and agent configuration.
+A remote server advertising localhost defaults to its saved environment
+address. Enter the address reachable from the agent host.
+
+The dialog provides one complete command with the short-lived enrollment token
+included. Copy it and run it on the agent host; no separate token entry or file
+downloads are needed. It fetches and verifies the selected release's installer
+and architecture-specific binary before execution. Treat the copied command
+as a credential. The handoff contains:
 
 - the management HTTPS origin and agent public ID;
 - a short-lived, single-use updater enrollment token;

--- a/docs/operations/systemd.md
+++ b/docs/operations/systemd.md
@@ -4,7 +4,7 @@ Run the p2pstream release binary as a Linux systemd service, or operate an agent
 
 ## Use This When
 
-Use systemd when you install the release binary directly on a host, or when managing an agent installed from the **Agent Setup** modal opened from **Agents**.
+Use systemd when you install the release binary directly on a host, or when managing an agent installed from the **Install Agent** modal opened from **Agents**.
 
 ## Prerequisites
 
@@ -93,9 +93,15 @@ sudo systemctl restart p2pstream-agent
 sudo journalctl -u p2pstream-agent -f
 ```
 
-After rotating an agent token, run the generated Linux reinstall command on the existing agent host. The installer rewrites `/etc/p2pstream/agent.env`, refreshes installer-managed management CA material, and restarts `p2pstream-agent` so the new token and TLS settings are loaded. A locally configured `AGENT_ALLOW_TARGETS` or `AGENT_ALLOW_ANY_TARGET` policy is preserved when the reinstall command does not provide a replacement. If the existing environment file cannot be read or contains unsupported or multiline assignment syntax, the reinstall stops instead of risking a policy change; provide a replacement explicitly or add `AGENT_CLEAR_ALLOW_TARGETS=true` to discard the old policy and revert to loopback-only.
+Use **Agents → More → Reinstall / Repair** for an existing Linux host. This shares the install/enrollment dialog, including the Management URL, TLS, release, and optional local-file fields. When the selected remote server advertises localhost, the saved environment address supplies the default; edit it if hosts use another address.
 
-The generated Linux command requires an exact `P2PSTREAM_VERSION=vX.Y.Z` release or `vX.Y.Z-staging.N` prerelease plus `P2PSTREAM_AGENT_BINARY_FILE=/absolute/path/to/raw-binary`, and invokes a locally supplied absolute installer path. Mutable `latest` and `staging`, remote installer pipes, symlinked installer/binary files, and implicit downloads are rejected. Managed prerelease installs pin `P2PSTREAM_AGENT_UPDATE_CHANNEL=staging`; final releases pin `stable`. The explicit management-trust repair mode is separate and does not require a binary or version.
+Reinstall reads the existing host credential through systemd's `EnvironmentFile` parser, checks that its agent ID matches the selected agent, and runs the verified installer with that token. It does not rotate the token on the server. It refreshes configuration and restarts the agent, and includes managed-update enrollment when authority and a trusted release are available. An active update campaign blocks preparation. Existing destination and capacity settings are preserved unless explicitly replaced.
+
+**Rotate token** is a separate action that immediately revokes the old credential. Its Linux command atomically appends the new effective `AGENT_TOKEN` assignment to the existing environment file, preserves its ownership, permissions and other settings, and restarts the connection. It does not download or reinstall software. Both existing-host commands verify the agent identity before modifying the host.
+
+The generated Linux command includes the issued tokens, downloads the versioned installer and architecture-specific binary from the selected GitHub release, and checks them against that release's `checksums.txt`. It runs the verified installer by absolute path with `P2PSTREAM_AGENT_BINARY_FILE` pointing to the verified local binary. Temporary downloads are cleaned up on success or failure. No separate token prompt or manual path editing is required. Independently verified local files remain optional advanced overrides.
+
+Managed updates require an exact release or prerelease. Other installs can use `latest`, which the command resolves once before fetching any release assets. Mutable `staging` aliases remain rejected. Managed prerelease installs pin `P2PSTREAM_AGENT_UPDATE_CHANNEL=staging`; final releases pin `stable`. The installer continues to reject piped execution and symlinked installer/binary files. The explicit management-trust repair mode is separate and does not require a binary or version.
 
 The installer also creates `/var/lib/p2pstream-agent/management-ca.pem` as the service-owned durable trust bundle. Management certificate rotation updates this file atomically. If forced activation strands an otherwise current agent, use the trust-repair command shown under **Settings → Management TLS**. If the agent version is incompatible or its configuration is damaged, rerun the full generated install command instead.
 
@@ -105,17 +111,9 @@ Use this only for agents installed with the generated Linux systemd installer. D
 
 The full-purge uninstall removes the agent service, service drop-ins, `/etc/p2pstream`, `/var/lib/p2pstream-agent`, `/usr/local/bin/p2pstream`, and the `p2pstream` service user and group. Do not run it on a host where those paths or that user are shared with a p2pstream server or another install you want to keep.
 
-First obtain and independently verify the versioned uninstaller as a local file. The UI deliberately does not pipe mutable remote code into root. Generated command:
+Open the agent row's **More** menu and select **Show uninstall command**. Copy the generated command and run it on the agent host. It downloads the selected release's source archive, verifies its SHA-256 checksum, and runs the extracted uninstaller with `P2PSTREAM_UNINSTALL_CONFIRM=full-purge`.
 
-```bash
-sudo env P2PSTREAM_UNINSTALL_CONFIRM=full-purge bash /path/to/p2pstream-uninstall-agent.sh
-```
-
-Preview without changing the host:
-
-```bash
-env P2PSTREAM_UNINSTALL_DRY_RUN=true P2PSTREAM_UNINSTALL_CONFIRM=full-purge bash /path/to/p2pstream-uninstall-agent.sh
-```
+For a preview, add `P2PSTREAM_UNINSTALL_DRY_RUN=true` immediately after `sudo env` in the copied command. An independently verified local uninstaller remains supported as an optional override.
 
 Uninstalling the host service does not remove the management record. After the remote host is removed, open the agent row's **More** menu under **Agents** and delete or disable the management record.
 
@@ -134,7 +132,7 @@ sudo systemctl status p2pstream-agent
 | Symptom | Check |
 | --- | --- |
 | Server cannot bind low ports | Run as root or use capabilities/high ports. |
-| Agent fails after token rotation | Run the generated Linux reinstall command on the existing agent host. |
+| Agent fails after token rotation | Apply the generated token-change command on the existing agent host. |
 | Uninstall refuses to run | Set `P2PSTREAM_UNINSTALL_CONFIRM=full-purge`; unsafe paths are intentionally rejected. |
 
 ## Next Steps

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -83,6 +83,10 @@ type Querier interface {
 	DeletePublicWafRule(ctx context.Context, id int64) error
 	DeleteStalePublicAccessSessions(ctx context.Context) (int64, error)
 	DeleteUserAgentLabelsByAgent(ctx context.Context, agentID int64) error
+	DetachAgentConnectionHistory(ctx context.Context, agentID sql.NullInt64) error
+	DetachAgentRequestHistory(ctx context.Context, agentID sql.NullInt64) error
+	DetachAgentRetryHistory(ctx context.Context, retryFailedAgentID sql.NullInt64) error
+	DetachAgentStatsHistory(ctx context.Context, agentID sql.NullInt64) error
 	GetActiveConnection(ctx context.Context) (GetActiveConnectionRow, error)
 	GetActiveManagementAccessTokenByHash(ctx context.Context, tokenHash string) (ManagementAccessToken, error)
 	GetActivePublicAccessSession(ctx context.Context, arg GetActivePublicAccessSessionParams) (GetActivePublicAccessSessionRow, error)

--- a/internal/db/query.sql.go
+++ b/internal/db/query.sql.go
@@ -2226,6 +2226,42 @@ func (q *Queries) DeleteUserAgentLabelsByAgent(ctx context.Context, agentID int6
 	return err
 }
 
+const detachAgentConnectionHistory = `-- name: DetachAgentConnectionHistory :exec
+UPDATE connections SET agent_id = NULL WHERE agent_id = ?
+`
+
+func (q *Queries) DetachAgentConnectionHistory(ctx context.Context, agentID sql.NullInt64) error {
+	_, err := q.db.ExecContext(ctx, detachAgentConnectionHistory, agentID)
+	return err
+}
+
+const detachAgentRequestHistory = `-- name: DetachAgentRequestHistory :exec
+UPDATE proxy_request_events SET agent_id = NULL WHERE agent_id = ?
+`
+
+func (q *Queries) DetachAgentRequestHistory(ctx context.Context, agentID sql.NullInt64) error {
+	_, err := q.db.ExecContext(ctx, detachAgentRequestHistory, agentID)
+	return err
+}
+
+const detachAgentRetryHistory = `-- name: DetachAgentRetryHistory :exec
+UPDATE proxy_request_events SET retry_failed_agent_id = NULL WHERE retry_failed_agent_id = ?
+`
+
+func (q *Queries) DetachAgentRetryHistory(ctx context.Context, retryFailedAgentID sql.NullInt64) error {
+	_, err := q.db.ExecContext(ctx, detachAgentRetryHistory, retryFailedAgentID)
+	return err
+}
+
+const detachAgentStatsHistory = `-- name: DetachAgentStatsHistory :exec
+UPDATE agent_stats SET agent_id = NULL WHERE agent_id = ?
+`
+
+func (q *Queries) DetachAgentStatsHistory(ctx context.Context, agentID sql.NullInt64) error {
+	_, err := q.db.ExecContext(ctx, detachAgentStatsHistory, agentID)
+	return err
+}
+
 const getActiveConnection = `-- name: GetActiveConnection :one
 SELECT id, connected_at, disconnected_at
 FROM connections

--- a/internal/server/agent_deletion_test.go
+++ b/internal/server/agent_deletion_test.go
@@ -1,0 +1,170 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	p2pstreamv1 "p2pstream/gen/proto/p2pstream/v1"
+	"p2pstream/internal/db"
+)
+
+func TestDeleteAgentPreservesHistory(t *testing.T) {
+	for _, blocked := range []bool{false, true} {
+		t.Run(fmt.Sprintf("blocked=%t", blocked), func(t *testing.T) {
+			ctx := context.Background()
+			database := newAgentRegistryTestDB(t)
+			app := NewApp(nil, database)
+			header := createTestAdminSession(t, app)
+			agent := createAgentRegistryTestAgent(t, database, "old-agent", "Old Agent", "old-token")
+			other := createAgentRegistryTestAgent(t, database, "other-agent", "Other Agent", "other-token")
+			seedAgentDeletionHistory(t, database, agent.ID, other.ID)
+			if _, err := database.Exec(`UPDATE agents SET enabled = 0 WHERE id = ?`, agent.ID); err != nil {
+				t.Fatal(err)
+			}
+			if blocked {
+				// A failure at the final DELETE must roll back all history changes.
+				if _, err := database.Exec(`CREATE TABLE deletion_blocker (agent_id INTEGER REFERENCES agents(id));
+					INSERT INTO deletion_blocker (agent_id) VALUES (?)`, agent.ID); err != nil {
+					t.Fatal(err)
+				}
+			}
+			req := connect.NewRequest(&p2pstreamv1.DeleteAgentRequest{Id: agent.ID})
+			req.Header().Set("Cookie", header.Get("Cookie"))
+			_, err := app.DeleteAgent(ctx, req)
+			if blocked {
+				if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+					t.Fatalf("blocked deletion = %v, want failed_precondition", err)
+				}
+				if _, err := database.GetAgent(ctx, agent.ID); err != nil {
+					t.Fatalf("blocked deletion removed agent: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("delete agent with history: %v", err)
+				}
+				if _, err := database.GetAgent(ctx, agent.ID); !errors.Is(err, sql.ErrNoRows) {
+					t.Fatalf("deleted agent lookup = %v, want no rows", err)
+				}
+			}
+			if _, err := database.GetAgent(ctx, other.ID); err != nil {
+				t.Fatalf("unrelated agent changed: %v", err)
+			}
+
+			for _, ref := range []struct {
+				table, column string
+				oldCount      int
+			}{
+				{"connections", "agent_id", 1},
+				{"agent_stats", "agent_id", 1},
+				{"proxy_request_events", "agent_id", 2},
+				{"proxy_request_events", "retry_failed_agent_id", 2},
+			} {
+				var oldRefs, nullRefs, otherRefs int
+				query := fmt.Sprintf(`SELECT COUNT(CASE WHEN %[1]s = ? THEN 1 END),
+					COUNT(CASE WHEN %[1]s IS NULL THEN 1 END),
+					COUNT(CASE WHEN %[1]s = ? THEN 1 END) FROM %[2]s`, ref.column, ref.table)
+				if err := database.QueryRow(query, agent.ID, other.ID).Scan(&oldRefs, &nullRefs, &otherRefs); err != nil {
+					t.Fatal(err)
+				}
+				wantOld, wantNull := 0, ref.oldCount
+				if blocked {
+					wantOld, wantNull = ref.oldCount, 0
+				}
+				if oldRefs != wantOld || nullRefs != wantNull || otherRefs != 1 {
+					t.Errorf("%s.%s references = old:%d null:%d other:%d, want %d/%d/1",
+						ref.table, ref.column, oldRefs, nullRefs, otherRefs, wantOld, wantNull)
+				}
+			}
+			for query, want := range map[string]int{
+				`SELECT COUNT(*) FROM connections WHERE disconnected_at IS NOT NULL`: 2,
+				`SELECT SUM(bytes_rx) FROM agent_stats`:                              246,
+				`SELECT SUM(duration_ms) FROM proxy_request_events`:                  60,
+			} {
+				var got int
+				if err := database.QueryRow(query).Scan(&got); err != nil || got != want {
+					t.Errorf("history query %q = %d, %v; want %d", query, got, err, want)
+				}
+			}
+			for _, table := range []string{"public_agent_labels", "management_agent_trust_reports", "agent_updater_enrollment_tokens"} {
+				var got int
+				if err := database.QueryRow("SELECT COUNT(*) FROM "+table+" WHERE agent_id = ?", agent.ID).Scan(&got); err != nil {
+					t.Fatal(err)
+				}
+				want := 0
+				if blocked {
+					want = 1
+				}
+				if got != want {
+					t.Errorf("%s owned records = %d, want %d", table, got, want)
+				}
+			}
+			rows, err := database.Query(`PRAGMA foreign_key_check`)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer rows.Close()
+			if rows.Next() || rows.Err() != nil {
+				t.Fatalf("invalid foreign keys after deletion: %v", rows.Err())
+			}
+		})
+	}
+}
+
+func TestDeleteAgentRejectsConnectedOrUnauthenticatedRequests(t *testing.T) {
+	for _, connected := range []bool{false, true} {
+		t.Run(fmt.Sprintf("connected=%t", connected), func(t *testing.T) {
+			ctx := context.Background()
+			database := newAgentRegistryTestDB(t)
+			app := NewApp(nil, database)
+			agent := createAgentRegistryTestAgent(t, database, "protected-agent", "Protected Agent", "token")
+			req := connect.NewRequest(&p2pstreamv1.DeleteAgentRequest{Id: agent.ID})
+			wantCode := connect.CodeUnauthenticated
+			if connected {
+				header := createTestAdminSession(t, app)
+				req.Header().Set("Cookie", header.Get("Cookie"))
+				if err := app.AgentHub.connect(agentRegistryTestConn(agent)); err != nil {
+					t.Fatal(err)
+				}
+				wantCode = connect.CodeFailedPrecondition
+			}
+			if _, err := app.DeleteAgent(ctx, req); connect.CodeOf(err) != wantCode {
+				t.Fatalf("delete agent = %v, want %v", err, wantCode)
+			}
+			if _, err := database.GetAgent(ctx, agent.ID); err != nil {
+				t.Fatalf("rejected deletion removed agent: %v", err)
+			}
+		})
+	}
+}
+
+func seedAgentDeletionHistory(t *testing.T, database *db.DB, agentID, otherID int64) {
+	t.Helper()
+	for _, id := range []int64{agentID, otherID} {
+		for _, query := range []string{
+			`INSERT INTO connections (agent_id, disconnected_at) VALUES (?, CURRENT_TIMESTAMP)`,
+			`INSERT INTO agent_stats (agent_id, memory_mb, goroutines, req_success, req_client_error, req_server_error, bytes_rx, bytes_tx)
+			 VALUES (?, 12, 3, 4, 5, 6, 123, 456)`,
+			`INSERT INTO public_agent_labels (agent_id, key, value, source) VALUES (?, 'region', 'test', 'user')`,
+			`INSERT INTO management_agent_trust_reports (agent_id) VALUES (?)`,
+			`INSERT INTO agent_updater_enrollment_tokens (agent_id, token_hash, pinned_repository, authority_key_id, authority_epoch, enrollment_generation, expires_at)
+			 VALUES (?, lower(hex(randomblob(32))), 'owner/repo', 'authority', 1, 1, CURRENT_TIMESTAMP)`,
+		} {
+			if _, err := database.Exec(query, id); err != nil {
+				t.Fatalf("seed history: %v", err)
+			}
+		}
+	}
+	// Cover successful use, a failed retry through the deleted agent, and both
+	// references on one event without clearing references to another agent.
+	for _, ids := range [][2]int64{{agentID, otherID}, {otherID, agentID}, {agentID, agentID}} {
+		if _, err := database.Exec(`INSERT INTO proxy_request_events (agent_id, retry_failed_agent_id, status_code, duration_ms)
+			VALUES (?, ?, 502, 20)`, ids[0], ids[1]); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/internal/server/agent_registry.go
+++ b/internal/server/agent_registry.go
@@ -190,13 +190,41 @@ func (a *App) DeleteAgent(
 	if _, err := a.requireAdmin(ctx, req.Header()); err != nil {
 		return nil, err
 	}
+	// Serialize the connected check and deletion with tunnel registration.
+	unlock := a.lockAgentAuth(req.Msg.Id)
+	defer unlock()
+
 	if a.AgentHub.connectedByID(req.Msg.Id) != nil {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("connected agent cannot be deleted"))
 	}
 	if err := a.ensureAgentCanBeDisabled(ctx, req.Msg.Id); err != nil {
 		return nil, err
 	}
-	if err := a.DB.DeleteAgent(ctx, req.Msg.Id); err != nil {
+	tx, err := a.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, publicDBError(err)
+	}
+	defer tx.Rollback()
+	qtx := a.DB.WithTx(tx)
+
+	// Historical records outlive the agent. These nullable foreign keys predate
+	// ON DELETE actions, so detach them atomically with the registry deletion.
+	// Agent-owned labels, trust reports, and updater state already cascade.
+	agentID := sql.NullInt64{Int64: req.Msg.Id, Valid: true}
+	for _, detach := range []func(context.Context, sql.NullInt64) error{
+		qtx.DetachAgentConnectionHistory,
+		qtx.DetachAgentStatsHistory,
+		qtx.DetachAgentRequestHistory,
+		qtx.DetachAgentRetryHistory,
+	} {
+		if err := detach(ctx, agentID); err != nil {
+			return nil, publicDBError(err)
+		}
+	}
+	if err := qtx.DeleteAgent(ctx, req.Msg.Id); err != nil {
+		return nil, publicDBError(err)
+	}
+	if err := tx.Commit(); err != nil {
 		return nil, publicDBError(err)
 	}
 	if a.AgentTransports != nil {

--- a/sql/query.sql
+++ b/sql/query.sql
@@ -959,6 +959,18 @@ WHERE id = ?;
 DELETE FROM agents
 WHERE id = ?;
 
+-- name: DetachAgentConnectionHistory :exec
+UPDATE connections SET agent_id = NULL WHERE agent_id = ?;
+
+-- name: DetachAgentStatsHistory :exec
+UPDATE agent_stats SET agent_id = NULL WHERE agent_id = ?;
+
+-- name: DetachAgentRequestHistory :exec
+UPDATE proxy_request_events SET agent_id = NULL WHERE agent_id = ?;
+
+-- name: DetachAgentRetryHistory :exec
+UPDATE proxy_request_events SET retry_failed_agent_id = NULL WHERE retry_failed_agent_id = ?;
+
 -- name: ListAgentLabels :many
 SELECT agent_id, key, value, source, created_at, updated_at
 FROM public_agent_labels

--- a/web/management/e2e/agent-label-target.spec.ts
+++ b/web/management/e2e/agent-label-target.spec.ts
@@ -128,7 +128,7 @@ test("protects an uncopied one-time agent setup command", async ({ page, context
     page.getByRole("button", { name: "Create Agent", exact: true }).click(),
   ]);
 
-  await expect(page.getByRole("heading", { name: "Agent Setup", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Install Agent", exact: true })).toBeVisible();
   const advancedSetup = page.locator("details.agent-advanced-options");
   await expect(advancedSetup).not.toHaveAttribute("open", "");
   await expect(page.getByLabel("GitHub Repository")).not.toBeVisible();
@@ -148,12 +148,12 @@ test("protects an uncopied one-time agent setup command", async ({ page, context
   await page.getByRole("button", { name: "Done", exact: true }).click();
   await expect(page.getByText("Close Without Copying?", { exact: true })).toBeVisible();
   await page.getByRole("button", { name: "Cancel", exact: true }).click();
-  await expect(page.getByRole("heading", { name: "Agent Setup", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Install Agent", exact: true })).toBeVisible();
 
   await page.getByRole("button", { name: "Copy install command", exact: true }).click();
   await expect(page.getByRole("button", { name: "Copied", exact: true })).toBeVisible();
   await page.getByRole("button", { name: "Done", exact: true }).click();
-  await expect(page.getByRole("heading", { name: "Agent Setup", exact: true })).toBeHidden();
+  await expect(page.getByRole("heading", { name: "Install Agent", exact: true })).toBeHidden();
 
   const cfg = await connectRPC<GetPublicProxyConfigResponse>(page.request, baseURL, "GetPublicProxyConfig", {});
   const createdAgent = cfg.agents.find((agent) => agent.name === agentName);

--- a/web/management/e2e/agent-setup.spec.ts
+++ b/web/management/e2e/agent-setup.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "@playwright/test";
+
+// Mount the actual fleet/update views with a fake management client. These
+// checks never create agents, rotate credentials, or enroll production hosts.
+test("shares editable remote setup across install, repair, and updates", async ({ page, context }, testInfo) => {
+  test.skip(testInfo.project.name !== "vite-direct", "The isolated component fixture uses Vite source modules.");
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  await page.route("**/p2pstream.v1.AgentManagementService/**", (route) => { errors.push("Unexpected live management request"); return route.abort(); });
+  await page.goto("/e2e/fixtures/agent-setup.html#/agent");
+  await page.getByRole("button", { name: "Add Agent", exact: true }).click();
+  await page.getByTestId("agent-editor-form").locator("input").first().fill("Fixture Agent");
+  await page.getByRole("button", { name: "Create Agent", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Install Agent", exact: true })).toBeVisible();
+  await expect(page.getByRole("textbox", { name: "Management URL", exact: true })).toHaveValue("https://remote.example.test:8443");
+  let command = await page.locator(".agent-setup-command code").innerText();
+  expect(command).toContain("AGENT_TOKEN='fixture-agent-token'");
+  expect(command).toContain("P2PSTREAM_UPDATER_ENROLLMENT_TOKEN='fixture-updater-token'");
+  expect(command).not.toContain("/path/to");
+  await page.getByRole("button", { name: "Copy install command", exact: true }).click();
+  expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(command);
+  await page.getByRole("button", { name: "Done", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Install Agent", exact: true })).toBeHidden();
+
+  await page.getByRole("button", { name: /More actions for agent/ }).click();
+  await page.getByRole("menuitem", { name: /Reinstall or repair/ }).click();
+  await expect(page.getByRole("heading", { name: "Reinstall / Repair Agent", exact: true })).toBeVisible();
+  const address = page.getByRole("textbox", { name: "Management URL", exact: true });
+  await expect(address).toBeEnabled();
+  await expect(address).toHaveValue("https://remote.example.test:8443");
+  await address.fill("https://agents.example.test:9443");
+  command = await page.locator(".agent-setup-command code").innerText();
+  expect(command).toContain("MANAGEMENT_URL='https://agents.example.test:9443'");
+  expect(command).toContain("P2PSTREAM_UPDATER_ENROLLMENT_TOKEN='fixture-bootstrap-token'");
+  expect(command).toContain("EnvironmentFile=$environment_file");
+  expect(command).not.toContain("AGENT_TOKEN='fixture");
+  expect(await page.evaluate(() => (window as unknown as {setupCalls:string[]}).setupCalls)).toEqual(["enrollment"]);
+  await page.getByRole("button", { name: "Copy command", exact: true }).click();
+  await page.getByRole("button", { name: "Done", exact: true }).click();
+
+  await page.getByRole("button", { name: /More actions for agent/ }).click();
+  await page.getByRole("menuitem", { name: /Rotate token/ }).click();
+  await page.getByRole("button", { name: "Rotate Token", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Apply Rotated Token", exact: true })).toBeVisible();
+  command = await page.locator(".agent-setup-command code").innerText();
+  expect(command).toContain("AGENT_TOKEN='fixture-rotated-token'");
+  expect(command).toContain("systemctl restart p2pstream-agent");
+  expect(command).not.toContain("curl");
+  expect(command).not.toContain("install-agent.sh");
+  await page.getByRole("button", { name: "Copy command", exact: true }).click();
+  await page.getByRole("button", { name: "Done", exact: true }).click();
+
+  await page.goto("/e2e/fixtures/agent-setup.html#/agent/updates");
+  await page.getByRole("button", { name: "Enable managed updates", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Enable Managed Updates", exact: true })).toBeVisible();
+  await expect(address).toBeEnabled();
+  await expect(address).toHaveValue("https://remote.example.test:8443");
+  await address.fill("https://agents.example.test:9443");
+  command = await page.locator(".agent-setup-command code").innerText();
+  expect(command).toContain("MANAGEMENT_URL='https://agents.example.test:9443'");
+  expect(command).toContain("P2PSTREAM_UPDATER_ENROLLMENT_TOKEN='fixture-bootstrap-token'");
+  expect(command).not.toContain("AGENT_TOKEN=");
+  expect(command).not.toContain("/path/to");
+  await page.getByRole("button", { name: "Copy command", exact: true }).click();
+  expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(command);
+  await address.fill("https://changed.example.test:9443");
+  await expect(page.getByRole("button", { name: "Copy command", exact: true })).toBeVisible();
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(address).toBeVisible();
+  await page.getByText("Advanced setup options", { exact: false }).click();
+  const scroller = page.locator(".n-modal.n-card > .n-card-content");
+  expect(await scroller.evaluate((element) => element.scrollWidth <= element.clientWidth + 1)).toBe(true);
+  await page.getByRole("button", { name: "Copy command", exact: true }).click();
+  await expect(page.getByRole("button", { name: "Copied", exact: true })).toBeVisible();
+  await scroller.evaluate((element) => { element.scrollTop = 0; });
+  await expect(address).toBeVisible();
+  await page.screenshot({ path: testInfo.outputPath("shared-agent-setup-mobile.png") });
+  await page.getByRole("button", { name: "Done", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Enable Managed Updates", exact: true })).toBeHidden();
+  expect(errors).toEqual([]);
+});

--- a/web/management/e2e/fixtures/agent-setup.html
+++ b/web/management/e2e/fixtures/agent-setup.html
@@ -1,0 +1,33 @@
+<div id="app"></div>
+<script type="module">
+import { createApp, h, computed } from 'vue';
+import { createRouter, createWebHashHistory, RouterView } from 'vue-router';
+import { NDialogProvider, NConfigProvider } from 'naive-ui';
+import { create } from '@bufbuild/protobuf';
+import * as schemas from '/src/gen/proto/p2pstream/v1/management_pb.ts';
+import * as keys from '/src/composables/managementContextKeys.ts';
+import AgentHealth from '/src/views/AgentHealth.vue';
+import AgentUpdates from '/src/views/AgentUpdates.vue';
+import '/src/styles.css';
+const agent = create(schemas.AgentSchema, { id: 1n, publicId: 'fixture-agent', name: 'Fixture Agent', enabled: true, connected: true, version: 'v0.1.52', commit: 'b'.repeat(40) });
+const authority = { publicKey: new Uint8Array(32), keyId: 'a'.repeat(64), epoch: 1n };
+window.setupCalls = [];
+const fakeClient = {
+  createAgent: async () => ({ agent, token: 'fixture-agent-token', updaterEnrollmentToken: 'fixture-updater-token', updaterPinnedRepository: 'Kirari04/p2pstream', updaterManagementAuthority: authority }),
+  rotateAgentToken: async () => { window.setupCalls.push('rotate'); return { agent, token: 'fixture-rotated-token' }; },
+  getAgentUpdateOverview: async () => create(schemas.GetAgentUpdateOverviewResponseSchema, { agents: [{ agentId: 1n, agentPublicId: agent.publicId, name: agent.name, connected: true, tunnelVersion: agent.version, tunnelCommit: agent.commit }], trustedTargets: [{ version: 'v0.1.53-staging.84', manifestSha256: 'c'.repeat(64) }], managementAuthority: authority }),
+  listAgentUpdateCampaigns: async () => ({ campaigns: [] }),
+  generateAgentUpdaterEnrollmentToken: async () => { window.setupCalls.push('enrollment'); return { token: 'fixture-bootstrap-token', pinnedRepository: 'Kirari04/p2pstream', managementAuthority: authority, expiresAtUnixMillis: BigInt(Date.now()+600000) }; },
+};
+const router = createRouter({ history: createWebHashHistory(), routes: [{path:'/agent',component:AgentHealth}, {path:'/agent/updates',component:AgentUpdates}] });
+const app = createApp({ render: () => h(NConfigProvider, null, {default: () => h(NDialogProvider, null, {default: () => h(RouterView)})}) });
+app.provide(keys.managementClientKey, fakeClient);
+app.provide(keys.dashboardKey, computed(() => create(schemas.GetDashboardResponseSchema, { status: {version:'v0.1.53-staging.84'}, managementSecurity: {defaultManagementUrl:'https://localhost:8081',managementCaPem:'fixture-ca'} })));
+app.provide(keys.publicProxyConfigKey, computed(() => create(schemas.GetPublicProxyConfigResponseSchema, {agents:[agent]})));
+app.provide(keys.environmentsKey, computed(() => [{id:7n, managementUrl:'https://remote.example.test:8443'}]));
+app.provide(keys.selectedEnvironmentIdKey, computed(() => '7'));
+app.provide(keys.runManagementActionKey, async (action) => {await action(); return true});
+app.use(router);
+await router.isReady();
+app.mount('#app');
+</script>

--- a/web/management/package.json
+++ b/web/management/package.json
@@ -5,7 +5,7 @@
   "packageManager": "bun@1.2.18",
   "scripts": {
     "dev": "bun run --bun vite --host 127.0.0.1 --port 5173 --strictPort",
-    "test": "bun test src",
+    "test": "bun test src tests",
     "build": "vue-tsc --noEmit && bun run --bun vite build",
     "docs:screenshots": "playwright test -c playwright.docs-screenshots.config.ts",
     "e2e": "playwright test",

--- a/web/management/src/components/AgentSetupModal.vue
+++ b/web/management/src/components/AgentSetupModal.vue
@@ -1,0 +1,261 @@
+<script setup lang="ts">
+import { computed, inject, onUnmounted, ref, watch } from "vue";
+import { NAlert, NButton, NCheckbox, NInput, NModal, NSpin, NTab, NTabs } from "naive-ui";
+import { dashboardKey, environmentsKey, selectedEnvironmentIdKey } from "@/composables/managementContextKeys";
+import { useManagementClient } from "@/composables/useManagementClient";
+import { useConfirmDialog } from "@/composables/useConfirmDialog";
+import { agentSetupManagementUrl, agentSetupReleaseVersion, cliSnippet, dockerComposeSnippet, dockerImageForRepository, FALLBACK_RELEASE_REPOSITORY, isLocalManagementUrl, linuxInstallSnippet, linuxManagedUpdaterBootstrapSnippet, linuxRotateAgentTokenSnippet, normalizeManagementUrl } from "@/lib/agentSetupSnippets";
+import { prepareExistingAgentSetup, type AgentSetupMode, type AgentSetupSubject, type ManagedAgentSetup } from "@/lib/agentSetupFlow";
+import { diagnosticExcerpt, diagnosticInspectionText } from "@/lib/diagnosticText";
+import { messageFromError } from "@/lib/errors";
+import { modalCardStyle, modalScrollableContentStyle } from "@/lib/naiveUi";
+import type { CreatedAgentSetup } from "@/types/agentSetup";
+
+const client = useManagementClient();
+const dashboard = inject(dashboardKey, computed(() => null));
+const environments = inject(environmentsKey, computed(() => []));
+const selectedEnvironmentId = inject(selectedEnvironmentIdKey, computed(() => "0"));
+const discardDialog = useConfirmDialog();
+const session = ref<{ agent: AgentSetupSubject; mode: AgentSetupMode; token: string; remote: boolean } | null>(null);
+const managed = ref<ManagedAgentSetup | null>(null);
+const alreadyEnrolled = ref(false);
+const managedUpdates = ref(false);
+const managementUrl = ref("");
+const releaseVersion = ref("");
+const repository = ref("");
+const installerPath = ref("");
+const binaryPath = ref("");
+const allowTargets = ref("");
+const allowAnyTarget = ref(false);
+const caBase64 = ref("");
+const caFile = ref("");
+const certRequired = ref(false);
+const certFile = ref("/etc/p2pstream/agent.crt.pem");
+const keyFile = ref("/etc/p2pstream/agent.key.pem");
+const allowInsecure = ref(false);
+const dockerImage = ref("");
+const dockerImageTouched = ref(false);
+const tab = ref<"install" | "docker" | "cli">("install");
+const loading = ref(false);
+const preparationError = ref("");
+const notice = ref("");
+const copied = ref(false);
+const copyError = ref("");
+const advancedOpen = ref(false);
+let generation = 0;
+
+const mode = computed(() => session.value?.mode ?? "create");
+const titles: Record<AgentSetupMode, string> = { create: "Install Agent", reinstall: "Reinstall / Repair Agent", "enable-updates": "Enable Managed Updates", rotate: "Apply Rotated Token" };
+const descriptions: Record<AgentSetupMode, string> = {
+  create: "Install this agent with one command. Managed updates are included when available.",
+  reinstall: "Reuse the token stored on this host, refresh its configuration, and restart the agent. Managed updates are included when available.",
+  "enable-updates": "Enable future updates from this UI. This one-time setup keeps the current tunnel running and preserves its token.",
+  rotate: "Apply the new token on the existing host and restart its connection. The installed software and other settings are preserved.",
+};
+const usesTLS = computed(() => normalizeManagementUrl(managementUrl.value).startsWith("https://"));
+const connectionOptionsVisible = computed(() => mode.value !== "rotate" || tab.value !== "install");
+const fullInstallOptionsVisible = computed(() => mode.value === "create" || mode.value === "reinstall");
+const canSelectFormat = computed(() => mode.value === "create" || mode.value === "rotate");
+const copyLabel = computed(() => copied.value ? "Copied" : mode.value === "create" && tab.value === "install" ? "Copy install command" : "Copy command");
+
+function begin(agent: AgentSetupSubject, nextMode: AgentSetupMode, token = "") {
+  generation += 1;
+  const environment = environments.value.find((item) => item.id.toString() === selectedEnvironmentId.value);
+  const security = dashboard.value?.managementSecurity;
+  session.value = { agent: { ...agent }, mode: nextMode, token, remote: Boolean(environment) };
+  managementUrl.value = agentSetupManagementUrl(security?.defaultManagementUrl, environment?.managementUrl, window.location.origin);
+  releaseVersion.value = agentSetupReleaseVersion(dashboard.value?.status?.version, import.meta.env.VITE_RELEASE_REF);
+  repository.value = import.meta.env.VITE_RELEASE_REPOSITORY?.trim() || FALLBACK_RELEASE_REPOSITORY;
+  managed.value = null;
+  managedUpdates.value = false;
+  alreadyEnrolled.value = false;
+  installerPath.value = "";
+  binaryPath.value = "";
+  allowTargets.value = "";
+  allowAnyTarget.value = false;
+  caBase64.value = security?.managementCaPem ? btoa(security.managementCaPem) : "";
+  caFile.value = "";
+  certRequired.value = Boolean(security?.agentClientCertificateRequired);
+  certFile.value = "/etc/p2pstream/agent.crt.pem";
+  keyFile.value = "/etc/p2pstream/agent.key.pem";
+  allowInsecure.value = false;
+  tab.value = "install";
+  dockerImageTouched.value = false;
+  dockerImage.value = dockerImageForRepository(repository.value, releaseVersion.value);
+  preparationError.value = "";
+  notice.value = "";
+  copied.value = false;
+  copyError.value = "";
+  loading.value = false;
+  advancedOpen.value = certRequired.value || !usesTLS.value;
+  return generation;
+}
+
+function useManagedSetup(value: ManagedAgentSetup | null) {
+  managed.value = value;
+  managedUpdates.value = Boolean(value?.updaterEnrollmentToken);
+  if (value?.updaterPinnedRepository) repository.value = value.updaterPinnedRepository;
+}
+
+function openCreated(payload: CreatedAgentSetup) {
+  if (!payload.agent) return;
+  begin(payload.agent, "create", payload.token);
+  useManagedSetup(payload.updaterEnrollmentToken ? payload : null);
+}
+
+function openRotated(agent: AgentSetupSubject, token: string) { begin(agent, "rotate", token); }
+
+async function openExisting(agent: AgentSetupSubject, nextMode: "reinstall" | "enable-updates") {
+  const request = begin(agent, nextMode);
+  loading.value = true;
+  try {
+    const prepared = await prepareExistingAgentSetup(client, agent, nextMode, () => request === generation && Boolean(session.value));
+    if (request !== generation || !session.value) return;
+    useManagedSetup(prepared.managed);
+    alreadyEnrolled.value = prepared.enrolled;
+    notice.value = prepared.notice;
+    if (prepared.version) releaseVersion.value = prepared.version;
+    if (prepared.liveVersion) session.value.agent.version = prepared.liveVersion;
+    if (prepared.liveCommit) session.value.agent.commit = prepared.liveCommit;
+  } catch (error) {
+    if (request === generation) preparationError.value = messageFromError(error);
+  } finally {
+    if (request === generation) loading.value = false;
+  }
+}
+
+const commandResult = computed(() => {
+  if (!session.value || loading.value) return { command: "", error: "" };
+  if (preparationError.value) return { command: "", error: preparationError.value };
+  const { agent, token } = session.value;
+  try {
+    if (mode.value === "rotate" && tab.value === "install") return { command: linuxRotateAgentTokenSnippet({agentId: agent.publicId, agentToken: token}), error: "" };
+    const url = new URL(managementUrl.value.trim());
+    if (!["https:", "http:"].includes(url.protocol) || url.username || url.password || url.search || url.hash) throw new Error("Enter a management HTTP(S) URL without credentials, a query, or a fragment.");
+    if (managedUpdates.value && tab.value === "install" && (url.protocol !== "https:" || url.pathname !== "/")) throw new Error("Managed updates require an HTTPS origin without a path.");
+    const input = {
+      managementUrl: url.toString(), agentId: agent.publicId, agentToken: token,
+      reuseExistingToken: mode.value === "reinstall",
+      enableManagedUpdates: managedUpdates.value && tab.value === "install",
+      updaterEnrollmentToken: managed.value?.updaterEnrollmentToken,
+      agentUpdateAuthorityPublicKeyBase64: managed.value?.updaterManagementAuthorityPublicKeyBase64,
+      agentUpdateAuthorityKeyId: managed.value?.updaterManagementAuthorityKeyId,
+      agentUpdateAuthorityEpoch: managed.value?.updaterManagementAuthorityEpoch,
+      repository: repository.value, version: releaseVersion.value, installerPath: installerPath.value, agentBinaryPath: binaryPath.value,
+      dockerImage: dockerImage.value,
+      allowTargets: allowAnyTarget.value ? [] : allowTargets.value.split(/[\s,]+/).filter(Boolean), allowAnyTarget: allowAnyTarget.value,
+      tls: { enabled: usesTLS.value, managementCAPEMBase64: usesTLS.value ? caBase64.value : "", managementCAFile: caFile.value, agentTLSCertFile: certRequired.value ? certFile.value : "", agentTLSKeyFile: certRequired.value ? keyFile.value : "", allowInsecureManagement: allowInsecure.value },
+    };
+    let command: string;
+    if (mode.value === "enable-updates") command = linuxManagedUpdaterBootstrapSnippet({ ...input, updaterEnrollmentToken: input.updaterEnrollmentToken ?? "", agentUpdateAuthorityPublicKeyBase64: input.agentUpdateAuthorityPublicKeyBase64 ?? "", agentUpdateAuthorityKeyId: input.agentUpdateAuthorityKeyId ?? "", agentUpdateAuthorityEpoch: input.agentUpdateAuthorityEpoch ?? 0n, currentTunnelVersion: agent.version ?? "", currentTunnelCommit: agent.commit ?? "" });
+    else if (tab.value === "docker") command = dockerComposeSnippet(input);
+    else if (tab.value === "cli") command = cliSnippet(input);
+    else command = linuxInstallSnippet(input);
+    return { command, error: "" };
+  } catch (error) { return { command: "", error: messageFromError(error) }; }
+});
+
+watch([repository, releaseVersion], () => {
+  if (!dockerImageTouched.value) {
+    try { dockerImage.value = dockerImageForRepository(repository.value, releaseVersion.value); } catch { /* The command error describes the invalid input. */ }
+  }
+});
+watch(() => commandResult.value.command, () => { copied.value = false; copyError.value = ""; });
+
+async function copyCommand() {
+  if (!commandResult.value.command) return;
+  try { await navigator.clipboard.writeText(commandResult.value.command); copied.value = true; }
+  catch { copyError.value = "Clipboard access failed. Select and copy the command below."; }
+}
+
+async function close() {
+  if (!copied.value && (session.value?.token || managed.value?.updaterEnrollmentToken)) {
+    if (!await discardDialog.confirm("Close Without Copying?", "Closing now discards the one-time credentials in this command.", "Discard Credentials")) return;
+  }
+  generation += 1;
+  session.value = null;
+  managed.value = null;
+  loading.value = false;
+}
+
+onUnmounted(() => { generation += 1; });
+defineExpose({ openCreated, openExisting, openRotated });
+</script>
+
+<template>
+  <NModal :show="Boolean(session)" preset="card" :title="titles[mode]" :style="modalCardStyle('48rem')" :content-style="modalScrollableContentStyle()" :bordered="false" :mask-closable="false" :close-on-esc="false" @update:show="(show) => { if (!show) void close(); }">
+    <div v-if="session" class="agent-setup-dialog layout-grid space-lg">
+      <div class="agent-setup-identity">
+        <strong><bdi dir="ltr" :title="diagnosticInspectionText(session.agent.name)">{{ diagnosticExcerpt(session.agent.name, 72).text }}</bdi></strong>
+        <code><bdi dir="ltr">{{ diagnosticInspectionText(session.agent.publicId) }}</bdi></code>
+      </div>
+      <p class="copy-sm muted-text">{{ descriptions[mode] }}</p>
+      <NSpin v-if="loading" size="small"><span class="copy-sm">Preparing setup for this environment…</span></NSpin>
+      <NAlert v-if="notice" type="info" :bordered="false">{{ notice }}</NAlert>
+      <NAlert v-if="copied" type="success" :bordered="false">Command copied. Run it on this agent's host.</NAlert>
+      <label v-if="connectionOptionsVisible" class="agent-setup-field">
+        <span>Management URL</span>
+        <NInput v-model:value="managementUrl" :input-props="{ 'aria-label': 'Management URL' }" :disabled="loading" placeholder="https://management.example.com:8081" />
+        <small>Use an address reachable from the agent host.</small>
+      </label>
+      <NAlert v-if="connectionOptionsVisible && session.remote && isLocalManagementUrl(managementUrl)" type="warning" :bordered="false">This address points to the agent host itself. Enter the remote management server's reachable address.</NAlert>
+      <NCheckbox v-if="managed && fullInstallOptionsVisible" v-model:checked="managedUpdates" :disabled="alreadyEnrolled || loading">Enable managed updates with this installation</NCheckbox>
+      <NTabs v-if="canSelectFormat" v-model:value="tab" class="agent-setup-tabs" type="segment" size="small">
+        <NTab name="install" :tab="mode === 'rotate' ? 'Linux token change' : 'Linux install'" />
+        <NTab name="docker" tab="Docker Compose" />
+        <NTab name="cli" tab="CLI" />
+      </NTabs>
+      <details v-if="connectionOptionsVisible" class="agent-advanced-options" :open="advancedOpen" @toggle="advancedOpen = ($event.target as HTMLDetailsElement).open">
+        <summary>Advanced setup options<small>Release, TLS, and optional local files</small></summary>
+        <div class="agent-advanced-options__body">
+          <div class="layout-grid space-md mq-md-cols-two">
+            <label class="agent-setup-field">GitHub Repository<NInput v-model:value="repository" size="small" :disabled="loading || Boolean(managed && managedUpdates)" /></label>
+            <label class="agent-setup-field">Release Version<NInput v-model:value="releaseVersion" size="small" :disabled="loading || Boolean(managed && managedUpdates)" placeholder="latest or vX.Y.Z" /></label>
+            <label v-if="tab === 'install'" class="agent-setup-field">Installer file (optional)<NInput v-model:value="installerPath" size="small" placeholder="Download automatically" /></label>
+            <label v-if="tab === 'install'" class="agent-setup-field">Agent binary (optional)<NInput v-model:value="binaryPath" size="small" placeholder="Download automatically" /></label>
+            <label v-if="tab === 'docker'" class="agent-setup-field">Docker image<NInput v-model:value="dockerImage" size="small" @update:value="dockerImageTouched = true" /></label>
+          </div>
+          <div v-if="fullInstallOptionsVisible" class="layout-grid space-md">
+            <label class="agent-setup-field">Agent destination allowlist<NInput v-model:value="allowTargets" size="small" :disabled="allowAnyTarget" placeholder="app.internal:443, 10.0.5.0/24:8080" /><small>Blank keeps the existing host policy on reinstall and uses loopback-only defaults on a new host.</small></label>
+            <NCheckbox v-model:checked="allowAnyTarget">Allow any destination reachable by this agent</NCheckbox>
+          </div>
+          <p v-if="mode === 'enable-updates'" class="copy-xs muted-text">Uses the management CA already installed on this host.</p>
+          <div v-else-if="usesTLS" class="layout-grid space-md mq-md-cols-two">
+            <div v-if="caBase64" class="copy-xs muted-text">The management CA is included in this command.</div>
+            <label v-else class="agent-setup-field">Management CA file<NInput v-model:value="caFile" size="small" placeholder="/etc/p2pstream/management-ca.pem" /></label>
+            <label v-if="certRequired" class="agent-setup-field">Agent certificate<NInput v-model:value="certFile" size="small" /></label>
+            <label v-if="certRequired" class="agent-setup-field">Agent key<NInput v-model:value="keyFile" size="small" /></label>
+          </div>
+          <NCheckbox v-else v-model:checked="allowInsecure">Allow insecure HTTP for local development</NCheckbox>
+        </div>
+      </details>
+      <details v-if="session.token || managed?.updaterEnrollmentToken" class="agent-setup-credentials">
+        <summary>Credentials included in the command</summary>
+        <div v-if="session.token"><span>Agent token</span><code>{{ session.token }}</code></div>
+        <div v-if="managed?.updaterEnrollmentToken"><span>Updater enrollment token</span><code>{{ managed.updaterEnrollmentToken }}</code><small v-if="managed.updaterEnrollmentExpiresAtUnixMillis">Expires {{ new Date(Number(managed.updaterEnrollmentExpiresAtUnixMillis)).toLocaleString() }}</small></div>
+      </details>
+      <p v-if="mode !== 'rotate'" class="copy-xs muted-text">The command downloads the matching release and verifies its SHA-256 checksums before installation. Copy it and run it on the agent host.</p>
+      <NAlert v-if="commandResult.error || copyError" type="error" :bordered="false">{{ commandResult.error || copyError }}</NAlert>
+      <pre v-if="commandResult.command" class="agent-setup-command"><code>{{ commandResult.command }}</code></pre>
+      <div class="layout-row mq-sm-end space-md">
+        <NButton secondary @click="close">Done</NButton>
+        <NButton type="primary" :disabled="!commandResult.command || loading" @click="copyCommand">{{ copyLabel }}</NButton>
+      </div>
+    </div>
+  </NModal>
+</template>
+
+<style scoped>
+.agent-setup-identity { display: grid; gap: .25rem; min-width: 0; }
+.agent-setup-identity code { color: var(--app-text-muted); font-size: .75rem; overflow-wrap: anywhere; }
+.agent-setup-field { display: grid; gap: .4rem; min-width: 0; font-size: .8125rem; font-weight: 500; }
+.agent-setup-field small { color: var(--app-text-muted); font-size: .75rem; font-weight: 400; }
+.agent-advanced-options { border: 1px solid var(--app-border); border-radius: 6px; overflow: hidden; }
+.agent-advanced-options summary, .agent-setup-credentials summary { cursor: pointer; padding: .8rem 1rem; font-size: .8125rem; }
+.agent-advanced-options summary small { display: block; margin-top: .2rem; color: var(--app-text-muted); font-size: .75rem; }
+.agent-advanced-options__body { display: grid; gap: 1rem; padding: 1rem; border-top: 1px solid var(--app-border); }
+.agent-setup-credentials { background: var(--app-panel-muted); border-radius: 6px; }
+.agent-setup-credentials div { display: grid; gap: .3rem; padding: .6rem 1rem; font-size: .75rem; }
+.agent-setup-credentials code { overflow-wrap: anywhere; }
+.agent-setup-command { max-height: 14rem; overflow: auto; padding: 1rem; border: 1px solid var(--app-border); border-radius: 6px; background: var(--app-panel-muted); font-size: .75rem; }
+</style>

--- a/web/management/src/lib/agentSetupFlow.test.ts
+++ b/web/management/src/lib/agentSetupFlow.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { create } from "@bufbuild/protobuf";
+import type { ManagementClient } from "@/api/managementClient";
+import { GetAgentUpdateOverviewResponseSchema, type GetAgentUpdateOverviewResponse } from "@/gen/proto/p2pstream/v1/management_pb";
+import { prepareExistingAgentSetup } from "./agentSetupFlow";
+
+const agent = { id: 1n, publicId: "agent-a", name: "Agent A" };
+function overview() {
+  return create(GetAgentUpdateOverviewResponseSchema, {
+    trustedTargets: [{ version: "v1.2.3-staging.84" }],
+    managementAuthority: { keyId: "a".repeat(64), publicKey: new Uint8Array(32), epoch: 1n },
+    agents: [{ agentId: 1n, agentPublicId: agent.publicId, tunnelVersion: "v1.2.2", tunnelCommit: "b".repeat(40) }],
+  });
+}
+function clientFor(value: GetAgentUpdateOverviewResponse) {
+  const calls: string[] = [];
+  const client = {
+    getAgentUpdateOverview: async () => { calls.push("overview"); return value; },
+    generateAgentUpdaterEnrollmentToken: async (request: {agentId: bigint}) => {
+      expect(request.agentId).toBe(agent.id);
+      calls.push("enrollment");
+      return { token: "updater-token", pinnedRepository: "Example/p2pstream", expiresAtUnixMillis: 123n, managementAuthority: value.managementAuthority };
+    },
+    rotateAgentToken: async () => { throw new Error("Unexpected tunnel token rotation"); },
+  } as unknown as ManagementClient;
+  return { client, calls };
+}
+
+describe("shared agent setup preparation", () => {
+  test("reinstall includes update enrollment without rotating the tunnel token", async () => {
+    const { client, calls } = clientFor(overview());
+    const result = await prepareExistingAgentSetup(client, agent, "reinstall");
+    expect(result.managed?.updaterEnrollmentToken).toBe("updater-token");
+    expect(result.managed?.updaterPinnedRepository).toBe("Example/p2pstream");
+    expect(result.version).toBe("v1.2.3-staging.84");
+    expect(calls).toEqual(["overview", "enrollment"]);
+  });
+
+  test("enrollment uses the live tunnel identity reported by the selected environment", async () => {
+    const { client } = clientFor(overview());
+    const result = await prepareExistingAgentSetup(client, agent, "enable-updates");
+    expect(result.liveVersion).toBe("v1.2.2");
+    expect(result.liveCommit).toBe("b".repeat(40));
+  });
+
+  test("a campaign in progress prevents reinstall enrollment", async () => {
+    const value = overview();
+    value.agents[0]!.activeAssignmentId = 4n;
+    const { client, calls } = clientFor(value);
+    await expect(prepareExistingAgentSetup(client, agent, "reinstall")).rejects.toThrow("campaign");
+    expect(calls).toEqual(["overview"]);
+  });
+
+  test("an unknown tunnel build cannot enable updates", async () => {
+    const value = overview();
+    value.agents[0]!.tunnelCommit = "";
+    const { client, calls } = clientFor(value);
+    await expect(prepareExistingAgentSetup(client, agent, "enable-updates")).rejects.toThrow("Connect this agent");
+    expect(calls).toEqual(["overview"]);
+  });
+
+  test("unmanaged repair remains available when update authority is unavailable", async () => {
+    const value = overview();
+    value.managementAuthority = undefined;
+    const { client, calls } = clientFor(value);
+    const result = await prepareExistingAgentSetup(client, agent, "reinstall");
+    expect(result.managed).toBeNull();
+    expect(result.notice).toContain("Managed updates are unavailable");
+    expect(calls).toEqual(["overview"]);
+    value.agents[0]!.updaterEnrolled = true;
+    await expect(prepareExistingAgentSetup(client, agent, "reinstall")).rejects.toThrow("No trusted update release");
+  });
+
+  test("closing setup before preparation completes does not issue an enrollment token", async () => {
+    const { client, calls } = clientFor(overview());
+    await expect(prepareExistingAgentSetup(client, agent, "reinstall", () => false)).rejects.toThrow("Setup was closed");
+    expect(calls).toEqual(["overview"]);
+  });
+
+  test("stale agent identity from another environment is rejected before token issuance", async () => {
+    const value = overview();
+    value.agents[0]!.agentPublicId = "another-environments-agent";
+    const { client, calls } = clientFor(value);
+    await expect(prepareExistingAgentSetup(client, agent, "reinstall")).rejects.toThrow("selected environment");
+    expect(calls).toEqual(["overview"]);
+  });
+
+  test("switching environments while loading never issues a token on the new environment", async () => {
+    const original = clientFor(overview());
+    const other = clientFor(overview());
+    let current = original.client;
+    const routed = new Proxy({} as ManagementClient, { get: (_target, key) => Reflect.get(current, key) });
+    const preparing = prepareExistingAgentSetup(routed, agent, "reinstall");
+    current = other.client;
+    await preparing;
+    expect(original.calls).toEqual(["overview", "enrollment"]);
+    expect(other.calls).toEqual([]);
+  });
+});

--- a/web/management/src/lib/agentSetupFlow.ts
+++ b/web/management/src/lib/agentSetupFlow.ts
@@ -1,0 +1,41 @@
+import type { ManagementClient } from "@/api/managementClient";
+import type { CreatedAgentSetup } from "@/types/agentSetup";
+
+export type AgentSetupSubject = { id: bigint; publicId: string; name: string; version?: string; commit?: string };
+export type AgentSetupMode = "create" | "reinstall" | "enable-updates" | "rotate";
+export type ManagedAgentSetup = Pick<CreatedAgentSetup, "updaterEnrollmentToken" | "updaterEnrollmentExpiresAtUnixMillis" | "updaterPinnedRepository" | "updaterManagementAuthorityPublicKeyBase64" | "updaterManagementAuthorityKeyId" | "updaterManagementAuthorityEpoch">;
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  return btoa(Array.from(bytes, (byte) => String.fromCharCode(byte)).join(""));
+}
+
+export async function prepareExistingAgentSetup(client: ManagementClient, agent: AgentSetupSubject, mode: "reinstall" | "enable-updates", isCurrent: () => boolean = () => true) {
+  // Capture both methods before awaiting: a routed client must not switch the
+  // token issuer halfway through preparation when the environment changes.
+  const getOverview = client.getAgentUpdateOverview.bind(client);
+  const generateToken = client.generateAgentUpdaterEnrollmentToken.bind(client);
+  const overview = await getOverview({});
+  const target = overview.trustedTargets[0];
+  const existing = overview.agents.find((candidate) => candidate.agentId === agent.id);
+  if (!existing || existing.agentPublicId !== agent.publicId) throw new Error("This agent no longer belongs to the selected environment. Refresh the fleet and try again.");
+  if (existing.activeAssignmentId) throw new Error("Finish or cancel this agent's update campaign before changing its installation.");
+  if (!target || !overview.managementAuthority) {
+    const reason = overview.managementAuthorityWarning || "No trusted update release is available.";
+    if (mode === "enable-updates" || existing?.updaterEnrolled) throw new Error(reason);
+    return { managed: null, version: "", enrolled: false, notice: `Managed updates are unavailable: ${reason} This command will repair the agent using its existing token.` };
+  }
+  if (mode === "enable-updates" && (!existing?.tunnelVersion || !existing.tunnelCommit)) {
+    throw new Error("Connect this agent so management can identify the running build before enabling updates.");
+  }
+  if (!isCurrent()) throw new Error("Setup was closed before enrollment preparation completed.");
+  const response = await generateToken({ agentId: agent.id, ttlMillis: 600000n });
+  const managed: ManagedAgentSetup = {
+    updaterEnrollmentToken: response.token,
+    updaterEnrollmentExpiresAtUnixMillis: response.expiresAtUnixMillis,
+    updaterPinnedRepository: response.pinnedRepository,
+    updaterManagementAuthorityPublicKeyBase64: bytesToBase64(response.managementAuthority?.publicKey ?? new Uint8Array()),
+    updaterManagementAuthorityKeyId: response.managementAuthority?.keyId ?? "",
+    updaterManagementAuthorityEpoch: response.managementAuthority?.epoch ?? 0n,
+  };
+  return { managed, version: target.version, enrolled: Boolean(existing?.updaterEnrolled), notice: "", liveVersion: existing?.tunnelVersion, liveCommit: existing?.tunnelCommit };
+}

--- a/web/management/src/lib/agentSetupSnippets.test.ts
+++ b/web/management/src/lib/agentSetupSnippets.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   agentSetupManagementUrl,
+  agentSetupReleaseVersion,
   cliSnippet,
   dockerComposeSnippet,
   dockerImageForRepository,
@@ -39,6 +40,18 @@ describe("agentSetupSnippets", () => {
   test("local bootstrap retains development and deployed management origins", () => {
     expect(agentSetupManagementUrl(undefined, undefined, "http://127.0.0.1:5173")).toBe("https://127.0.0.1:8081");
     expect(agentSetupManagementUrl("", undefined, "https://management.example.test")).toBe("https://management.example.test");
+  });
+
+  test("remote setup replaces advertised loopback and wildcard addresses with the saved environment", () => {
+    for (const configured of ["https://localhost:8081", "https://localhost.:8081", "https://127.0.0.1:8081", "https://127.1:8081", "https://[::1]:8081", "https://0.0.0.0:8081", "https://[::]:8081"]) {
+      expect(agentSetupManagementUrl(configured, "https://remote.example.test:8443/", "http://127.0.0.1:5173")).toBe("https://remote.example.test:8443");
+    }
+  });
+
+  test("setup release defaults to the selected server before the UI build", () => {
+    expect(agentSetupReleaseVersion("v1.2.3-staging.84", "v1.2.3-staging.83")).toBe("v1.2.3-staging.84");
+    expect(agentSetupReleaseVersion("dev", "v1.2.3")).toBe("v1.2.3");
+    expect(agentSetupReleaseVersion("dev", "dev")).toBe("latest");
   });
 
   test("quotes shell values safely", () => {
@@ -82,18 +95,17 @@ describe("agentSetupSnippets", () => {
   test("builds one-line Linux installer snippet", () => {
     const snippet = linuxInstallSnippet(baseInput);
 
-    expect(snippet).toStartWith("{ read -r -s -p 'Agent token: '");
+    expect(snippet).toStartWith("sudo env ");
     expect(snippet).toContain("MANAGEMENT_URL='https://mgmt.example.test'");
     expect(snippet).toContain("AGENT_ID='agent-mfrggzdfmztwq2lkmmxgg33nna'");
-    expect(snippet).not.toContain(baseInput.agentToken);
-    expect(snippet).toContain("IFS= read -r AGENT_TOKEN");
-    expect(snippet).toContain("export AGENT_TOKEN");
+    expect(snippet).toContain(`AGENT_TOKEN=${shellQuote(baseInput.agentToken)}`);
+    expect(snippet).not.toContain("read -r");
     expect(snippet).not.toContain("AGENT_ALLOW_TARGETS");
     expect(snippet).toContain("P2PSTREAM_REPOSITORY='ExampleUser/p2pstream'");
     expect(snippet).toContain("P2PSTREAM_VERSION='v1.2.3'");
-    expect(snippet).toContain("P2PSTREAM_AGENT_BINARY_FILE='/path/to/p2pstream-agent-vX.Y.Z-linux-ARCH'");
-    expect(snippet).toEndWith("p2pstream-installer '/path/to/p2pstream-install-agent.sh'");
-    expect(snippet).not.toContain("curl");
+    expect(snippet).not.toContain("/path/to");
+    expect(snippet).toContain("sha256sum --check");
+    expect(snippet).toContain("curl --proto");
     expect(snippet).not.toContain("\n");
   });
 
@@ -108,14 +120,12 @@ describe("agentSetupSnippets", () => {
     });
 
     expect(snippet).toContain("P2PSTREAM_ENABLE_MANAGED_UPDATES=true");
-    expect(snippet).not.toContain("p2puet_separate-root-owned-bootstrap");
-    expect(snippet).toContain("Updater enrollment token: ");
-    expect(snippet).toContain("IFS= read -r P2PSTREAM_UPDATER_ENROLLMENT_TOKEN");
+    expect(snippet).toContain("P2PSTREAM_UPDATER_ENROLLMENT_TOKEN='p2puet_separate-root-owned-bootstrap'");
     expect(snippet).toContain("P2PSTREAM_AGENT_UPDATE_AUTHORITY_PUBLIC_KEY_BASE64='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='");
     expect(snippet).toContain(`P2PSTREAM_AGENT_UPDATE_AUTHORITY_KEY_ID='${"a".repeat(64)}'`);
     expect(snippet).toContain("P2PSTREAM_AGENT_UPDATE_AUTHORITY_EPOCH='1'");
     expect(snippet).toContain("P2PSTREAM_AGENT_UPDATE_CHANNEL='stable'");
-    expect(snippet).toContain("IFS= read -r AGENT_TOKEN; IFS= read -r P2PSTREAM_UPDATER_ENROLLMENT_TOKEN");
+    expect(snippet).not.toContain("read -r");
     expect(dockerComposeSnippet({ ...baseInput, enableManagedUpdates: true, updaterEnrollmentToken: "p2puet_unused" }))
       .not.toContain("P2PSTREAM_UPDATER_ENROLLMENT_TOKEN");
     expect(cliSnippet({ ...baseInput, enableManagedUpdates: true, updaterEnrollmentToken: "p2puet_unused" }))
@@ -147,9 +157,8 @@ describe("agentSetupSnippets", () => {
     expect(snippet).toContain("MANAGEMENT_URL='https://mgmt.example.test:8081'");
     expect(snippet).toContain("AGENT_ID='agent-existing'");
     expect(snippet).toContain("P2PSTREAM_ENABLE_MANAGED_UPDATES=true");
-    expect(snippet).not.toContain("p2puet_one-time");
-    expect(snippet).toContain("Updater enrollment token: ");
-    expect(snippet).toContain("IFS= read -r P2PSTREAM_UPDATER_ENROLLMENT_TOKEN");
+    expect(snippet).toContain("P2PSTREAM_UPDATER_ENROLLMENT_TOKEN='p2puet_one-time'");
+    expect(snippet).not.toContain("read -r");
     expect(snippet).toContain("P2PSTREAM_AGENT_UPDATE_AUTHORITY_EPOCH='9'");
 	expect(snippet).toContain("P2PSTREAM_EXISTING_TUNNEL_VERSION='v1.0.0'");
 	expect(snippet).toContain(`P2PSTREAM_EXISTING_TUNNEL_COMMIT='${"b".repeat(40)}'`);
@@ -222,10 +231,12 @@ describe("agentSetupSnippets", () => {
     }
   });
 
-  test("builds Linux uninstall snippet from a local pinned file", () => {
+  test("downloads the versioned Linux uninstaller automatically", () => {
     const snippet = linuxUninstallSnippet({});
 
-    expect(snippet).toBe("sudo env P2PSTREAM_UNINSTALL_CONFIRM=full-purge bash '/path/to/p2pstream-uninstall-agent.sh'");
+    expect(snippet).toStartWith("sudo env P2PSTREAM_UNINSTALL_CONFIRM=full-purge bash -c ");
+    expect(snippet).toContain("uninstall-agent.sh");
+    expect(snippet).not.toContain("/path/to");
     expect(snippet).not.toContain("\n");
   });
 

--- a/web/management/src/lib/agentSetupSnippets.ts
+++ b/web/management/src/lib/agentSetupSnippets.ts
@@ -11,6 +11,8 @@ export type AgentSetupSnippetInput = {
   managementUrl: string;
   agentId: string;
   agentToken: string;
+  reuseExistingToken?: boolean;
+  agentEnvironmentPath?: string;
   updaterEnrollmentToken?: string;
   agentUpdateAuthorityPublicKeyBase64?: string;
   agentUpdateAuthorityKeyId?: string;
@@ -48,21 +50,35 @@ const RELEASE_REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const RELEASE_VERSION_PATTERN = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 const SCRIPT_REF_PATTERN = /^(main|[A-Fa-f0-9]{7,40})$/;
 const LOCAL_PATH_PATTERN = /^\/[^\r\n\0]+$/;
-export const DEFAULT_LOCAL_INSTALLER_PATH = "/path/to/p2pstream-install-agent.sh";
-export const DEFAULT_LOCAL_AGENT_BINARY_PATH = "/path/to/p2pstream-agent-vX.Y.Z-linux-ARCH";
-export const DEFAULT_LOCAL_UNINSTALLER_PATH = "/path/to/p2pstream-uninstall-agent.sh";
+// Empty overrides select verified downloads from the chosen GitHub release.
+export const DEFAULT_LOCAL_INSTALLER_PATH = "";
+export const DEFAULT_LOCAL_AGENT_BINARY_PATH = "";
+export const DEFAULT_LOCAL_UNINSTALLER_PATH = "";
 
 export function normalizeManagementUrl(value: string): string {
   return value.trim().replace(/\/+$/, "");
 }
 
 export function agentSetupManagementUrl(configuredUrl: string | undefined, environmentUrl: string | undefined, browserOrigin: string): string {
-  const selectedUrl = configuredUrl?.trim() || environmentUrl?.trim();
+  const configured = configuredUrl?.trim();
+  const environment = environmentUrl?.trim();
+  const selectedUrl = environment && (!configured || isLocalManagementUrl(configured)) ? environment : configured;
   if (selectedUrl) return normalizeManagementUrl(selectedUrl);
   const url = new URL(browserOrigin);
   if (url.port === "5173") url.port = "8081";
   url.protocol = "https:";
   return normalizeManagementUrl(url.toString());
+}
+
+export function isLocalManagementUrl(value: string): boolean {
+  try {
+    const host = new URL(value).hostname.toLowerCase().replace(/\.$/, "");
+    return host === "localhost" || host.endsWith(".localhost") || host === "0.0.0.0" || host === "[::]" || host === "[::1]" || host.startsWith("127.");
+  } catch { return true; }
+}
+
+export function agentSetupReleaseVersion(runningVersion?: string, configuredVersion?: string): string {
+  return [runningVersion, configuredVersion].map((value) => value?.trim() ?? "").find(isValidReleaseVersion) || "latest";
 }
 
 export function normalizeRepository(value: string | undefined): string {
@@ -112,26 +128,57 @@ export function dockerImageForRepository(repository: string | undefined, version
 export function linuxInstallSnippet(input: AgentSetupSnippetInput): string {
   const repository = normalizeRepository(input.repository);
   const version = normalizeReleaseVersion(input.version);
-  requirePinnedLinuxVersion(version);
+  if (input.enableManagedUpdates) requirePinnedLinuxVersion(version);
   const installerPath = normalizeLocalPath(input.installerPath, DEFAULT_LOCAL_INSTALLER_PATH, "Installer");
   const agentBinaryPath = normalizeLocalPath(input.agentBinaryPath, DEFAULT_LOCAL_AGENT_BINARY_PATH, "Agent binary");
   const parts = [
     `MANAGEMENT_URL=${shellQuote(normalizeManagementUrl(input.managementUrl))}`,
     ...installTLSParts(input.tls),
     `AGENT_ID=${shellQuote(input.agentId)}`,
+    ...(input.reuseExistingToken ? [] : [`AGENT_TOKEN=${shellQuote(input.agentToken)}`]),
     ...managedUpdateInstallParts(input),
     ...shellAgentDestinationPolicyParts(input),
     `P2PSTREAM_REPOSITORY=${shellQuote(repository)}`,
     `P2PSTREAM_VERSION=${shellQuote(version)}`,
-    `P2PSTREAM_AGENT_BINARY_FILE=${shellQuote(agentBinaryPath)}`,
   ];
-  const secrets: PromptedInstallerSecret[] = [
-    { prompt: "Agent token", inputVariable: "P2PSTREAM_AGENT_TOKEN_INPUT", environmentVariable: "AGENT_TOKEN" },
-  ];
-  if (input.enableManagedUpdates) {
-    secrets.push({ prompt: "Updater enrollment token", inputVariable: "P2PSTREAM_UPDATER_TOKEN_INPUT", environmentVariable: "P2PSTREAM_UPDATER_ENROLLMENT_TOKEN" });
-  }
-  return promptedInstallerCommand(parts, installerPath, secrets);
+  return releaseInstallerCommand(parts, repository, version, "install-agent.sh", installerPath, agentBinaryPath, input.reuseExistingToken ? normalizeLocalPath(input.agentEnvironmentPath, "/etc/p2pstream/agent.env", "Agent environment") : "");
+}
+
+export function linuxRotateAgentTokenSnippet(input: Pick<AgentSetupSnippetInput, "agentId" | "agentToken" | "agentEnvironmentPath">): string {
+  const environmentPath = normalizeLocalPath(input.agentEnvironmentPath, "/etc/p2pstream/agent.env", "Agent environment");
+  const parts = [`AGENT_ID=${shellQuote(input.agentId)}`, `AGENT_TOKEN=${shellQuote(input.agentToken)}`];
+  // systemd parses its own EnvironmentFile format. No shell sourcing/eval and no
+  // retrieval of the current tunnel secret by the management server or browser.
+  const script = [
+    "set -euo pipefail",
+    `environment_file=${shellQuote(environmentPath)}`,
+    existingEnvironmentCheck,
+    existingAgentCommand(["AGENT_TOKEN"], `bash -c ${shellQuote(rotateTokenScript)} p2pstream-token "$environment_file"`),
+  ].join("; ");
+  return `sudo env ${parts.join(" ")} bash -c ${shellQuote(script)}`;
+}
+
+const existingEnvironmentCheck = '[ -f "$environment_file" ] && [ ! -L "$environment_file" ] || { echo "Existing agent environment is missing or unsafe; use new-agent setup on a fresh host" >&2; exit 1; }';
+const rotateTokenScript = [
+  'set -euo pipefail; environment_file=$1',
+  existingEnvironmentCheck,
+  'tmp=$(mktemp "${environment_file}.XXXXXX")',
+  'trap \'rm -f -- "$tmp"\' EXIT',
+  'cp --preserve=mode,ownership -- "$environment_file" "$tmp"',
+  'token=${AGENT_TOKEN//\\\\/\\\\\\\\}; token=${token//\\\"/\\\\\\\"}',
+  'printf \'\\n\\nAGENT_TOKEN="%s"\\n\' "$token" >> "$tmp"',
+  'mv -f -- "$tmp" "$environment_file"',
+  'systemctl restart p2pstream-agent',
+].join("; ");
+
+function existingAgentCommand(environmentNames: string[], command: string): string {
+  const clearDestinationPolicy = environmentNames.some((name) => name === "AGENT_ALLOW_TARGETS" || name === "AGENT_ALLOW_ANY_TARGET") ? "unset AGENT_ALLOW_TARGETS AGENT_ALLOW_ANY_TARGET; " : "";
+  const check = 'set -euo pipefail; [ "${AGENT_ID:-}" = "$1" ] && [ -n "${AGENT_TOKEN:-}" ] || { echo "This host does not contain the selected agent identity and token" >&2; exit 1; }; shift; ' + clearDestinationPolicy + 'exec env "$@"';
+  const overrides = environmentNames.map((name) => `${name}="$${name}"`).join(" ");
+  // Escape dollars at the systemd ExecStart boundary (also supported by older
+  // systemd releases), so shell code and literal credential values arrive intact.
+  const escapeArguments = 'for index in "${!service_args[@]}"; do service_args[$index]=${service_args[$index]//\\$/\\$\\$}; done';
+  return `service_args=(bash -c ${shellQuote(check)} p2pstream-existing "$AGENT_ID" ${overrides} ${command}); ${escapeArguments}; systemd-run --quiet --wait --pipe --collect --property=Type=exec --property="EnvironmentFile=$environment_file" "${'$'}{service_args[@]}"`;
 }
 
 function managedUpdateInstallParts(input: AgentSetupSnippetInput): string[] {
@@ -145,6 +192,7 @@ function managedUpdateInstallParts(input: AgentSetupSnippetInput): string[] {
   }
   return [
     "P2PSTREAM_ENABLE_MANAGED_UPDATES=true",
+    `P2PSTREAM_UPDATER_ENROLLMENT_TOKEN=${shellQuote(enrollmentToken)}`,
     `P2PSTREAM_AGENT_UPDATE_CHANNEL=${shellQuote(releaseChannelForVersion(normalizeReleaseVersion(input.version)))}`,
     `P2PSTREAM_AGENT_UPDATE_AUTHORITY_PUBLIC_KEY_BASE64=${shellQuote(authorityPublicKey)}`,
     `P2PSTREAM_AGENT_UPDATE_AUTHORITY_KEY_ID=${shellQuote(authorityKeyId)}`,
@@ -152,9 +200,9 @@ function managedUpdateInstallParts(input: AgentSetupSnippetInput): string[] {
   ];
 }
 
-export function linuxUninstallSnippet(input: Pick<AgentSetupSnippetInput, "installerPath" | "repository">): string {
+export function linuxUninstallSnippet(input: Pick<AgentSetupSnippetInput, "installerPath" | "repository" | "version">): string {
   const path = normalizeLocalPath(input.installerPath, DEFAULT_LOCAL_UNINSTALLER_PATH, "Uninstaller");
-  return `sudo env P2PSTREAM_UNINSTALL_CONFIRM=full-purge bash ${shellQuote(path)}`;
+  return releaseInstallerCommand(["P2PSTREAM_UNINSTALL_CONFIRM=full-purge"], normalizeRepository(input.repository), normalizeReleaseVersion(input.version), "uninstall-agent.sh", path);
 }
 
 export function linuxManagedUpdaterBootstrapSnippet(input: ManagedUpdaterBootstrapSnippetInput): string {
@@ -178,6 +226,7 @@ export function linuxManagedUpdaterBootstrapSnippet(input: ManagedUpdaterBootstr
     `MANAGEMENT_URL=${shellQuote(normalizeManagementUrl(input.managementUrl))}`,
     `AGENT_ID=${shellQuote(input.agentId)}`,
     "P2PSTREAM_ENABLE_MANAGED_UPDATES=true",
+    `P2PSTREAM_UPDATER_ENROLLMENT_TOKEN=${shellQuote(enrollmentToken)}`,
     `P2PSTREAM_AGENT_UPDATE_CHANNEL=${shellQuote(releaseChannelForVersion(version))}`,
     `P2PSTREAM_AGENT_UPDATE_AUTHORITY_PUBLIC_KEY_BASE64=${shellQuote(authorityPublicKey)}`,
     `P2PSTREAM_AGENT_UPDATE_AUTHORITY_KEY_ID=${shellQuote(authorityKeyId)}`,
@@ -186,35 +235,47 @@ export function linuxManagedUpdaterBootstrapSnippet(input: ManagedUpdaterBootstr
     `P2PSTREAM_EXISTING_TUNNEL_COMMIT=${shellQuote(currentTunnelCommit)}`,
     `P2PSTREAM_REPOSITORY=${shellQuote(repository)}`,
     `P2PSTREAM_VERSION=${shellQuote(version)}`,
-    `P2PSTREAM_AGENT_BINARY_FILE=${shellQuote(agentBinaryPath)}`,
   ];
-  return promptedInstallerCommand(parts, installerPath, [
-    { prompt: "Updater enrollment token", inputVariable: "P2PSTREAM_UPDATER_TOKEN_INPUT", environmentVariable: "P2PSTREAM_UPDATER_ENROLLMENT_TOKEN" },
-  ]);
+  return releaseInstallerCommand(parts, repository, version, "install-agent.sh", installerPath, agentBinaryPath);
 }
 
-type PromptedInstallerSecret = {
-  prompt: string;
-  inputVariable: string;
-  environmentVariable: string;
-};
-
-function promptedInstallerCommand(parts: string[], installerPath: string, secrets: PromptedInstallerSecret[]): string {
-  const prompts = secrets.flatMap((secret) => [
-    `read -r -s -p ${shellQuote(`${secret.prompt}: `)} ${secret.inputVariable}`,
-    "printf '\\n' >&2",
-  ]);
-  const inputVariables = secrets.map((secret) => `"$${secret.inputVariable}"`).join(" ");
-  const rootReads = secrets.map((secret) => `IFS= read -r ${secret.environmentVariable}`).join("; ");
-  const rootExports = secrets.map((secret) => secret.environmentVariable).join(" ");
-  const clearInputs = secrets.map((secret) => secret.inputVariable).join(" ");
-  const rootScript = `set -eu; ${rootReads}; export ${rootExports}; exec bash "$1"`;
-  return `{ ${prompts.join("; ")}; printf '%s\\n' ${inputVariables}; unset ${clearInputs}; } | sudo env ${parts.join(" ")} bash -c ${shellQuote(rootScript)} p2pstream-installer ${shellQuote(installerPath)}`;
+function releaseInstallerCommand(parts: string[], repository: string, version: string, scriptName: "install-agent.sh" | "uninstall-agent.sh", installerPath: string, agentBinaryPath = "", existingEnvironmentPath = ""): string {
+  const needsBinary = scriptName === "install-agent.sh";
+  if (!existingEnvironmentPath && installerPath && (!needsBinary || (agentBinaryPath && version !== "latest"))) {
+    const binary = needsBinary ? ` P2PSTREAM_AGENT_BINARY_FILE=${shellQuote(agentBinaryPath)}` : "";
+    return `sudo env ${parts.join(" ")}${binary} bash ${shellQuote(installerPath)}`;
+  }
+  // Keep the bootstrap self-contained so it also works with already published
+  // releases. Extract only named, checksummed assets; never execute a curl pipe.
+  const script = [
+    "set -euo pipefail",
+    'repository=$1; version=$2; installer=$3; binary=$4; script_name=$5',
+    ...(existingEnvironmentPath ? [`environment_file=${shellQuote(existingEnvironmentPath)}`, existingEnvironmentCheck] : []),
+    'tmp=$(mktemp -d)',
+    'trap \'rm -rf -- "$tmp"\' EXIT',
+    'download() { curl --proto "=https" --proto-redir "=https" --fail --location --silent --show-error --retry 3 --connect-timeout 15 --max-time 300 --max-filesize 536870912 "$@"; }',
+    'if [ "$version" = latest ]; then resolved=$(download --output /dev/null --write-out "%{url_effective}" "https://github.com/$repository/releases/latest"); prefix="https://github.com/$repository/releases/tag/"; [[ "$resolved" = "$prefix"* ]] || { echo "Cannot resolve latest release" >&2; exit 1; }; version=${resolved#"$prefix"}; [[ "$version" =~ ^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$ ]] || { echo "Invalid release version" >&2; exit 1; }; fi',
+    'export P2PSTREAM_VERSION="$version"',
+    'base="https://github.com/$repository/releases/download/$version"',
+    'if [ -z "$installer" ] || { [ "$script_name" = install-agent.sh ] && [ -z "$binary" ]; }; then download --output "$tmp/checksums.txt" "$base/checksums.txt"; fi',
+    'digest() { awk -v name="$1" \'$2 == name || $2 == "*" name { print $1 }\' "$tmp/checksums.txt"; }',
+    'fetch_verified() { local expected; expected=$(digest "$1"); [[ "$expected" =~ ^[0-9a-fA-F]{64}$ ]] || { echo "Missing or ambiguous checksum for $1" >&2; return 1; }; download --output "$tmp/$1" "$base/$1"; printf "%s  %s\\n" "$expected" "$tmp/$1" | sha256sum --check --status || { echo "Checksum mismatch for $1" >&2; return 1; }; }',
+    'if [ -z "$installer" ]; then source="p2pstream_${version}_source.tar.gz"; fetch_verified "$source"; installer="$tmp/$script_name"; tar -xOf "$tmp/$source" "p2pstream-$version/scripts/$script_name" > "$installer"; fi',
+    ...(needsBinary ? [
+      'if [ -z "$binary" ]; then [ "$(uname -s)" = Linux ] || { echo "Linux is required" >&2; exit 1; }; case "$(uname -m)" in x86_64|amd64) arch=amd64 ;; aarch64|arm64) arch=arm64 ;; *) echo "Unsupported agent architecture" >&2; exit 1 ;; esac; asset="p2pstream_${version}_linux_$arch"; if [ -n "$(digest "$asset")" ]; then fetch_verified "$asset"; binary="$tmp/$asset"; else asset="$asset.tar.gz"; fetch_verified "$asset"; binary="$tmp/p2pstream"; tar -xOf "$tmp/$asset" ./p2pstream > "$binary"; fi; fi',
+      'export P2PSTREAM_AGENT_BINARY_FILE="$binary"',
+    ] : []),
+    ...(existingEnvironmentPath ? [
+      'if [ -e /etc/p2pstream-updater/enrolled.json ] && [ "${P2PSTREAM_ENABLE_MANAGED_UPDATES:-false}" != true ]; then echo "Repairing a managed agent requires its update authority; refresh management and try again" >&2; exit 1; fi',
+      existingAgentCommand([...parts.map((part) => part.split("=")[0]!), "P2PSTREAM_AGENT_BINARY_FILE"], 'bash "$installer"'),
+    ] : ['bash "$installer"']),
+  ].join("; ");
+  return `sudo env ${parts.join(" ")} bash -c ${shellQuote(script)} p2pstream-setup ${[repository, version, installerPath, agentBinaryPath, scriptName].map(shellQuote).join(" ")}`;
 }
 
 function requirePinnedLinuxVersion(version: string): void {
   if (!isValidReleaseVersion(version)) {
-    throw new Error("Linux installation requires an exact SemVer release or prerelease and locally pinned files.");
+    throw new Error("Managed updates require an exact SemVer release or prerelease.");
   }
 }
 
@@ -232,6 +293,7 @@ function isValidReleaseVersion(version: string): boolean {
 
 function normalizeLocalPath(value: string | undefined, fallback: string, label: string): string {
   const result = singleLine(value ?? "").trim() || fallback;
+  if (!result) return "";
   if (!LOCAL_PATH_PATTERN.test(result) || result.includes("//") || result.split("/").some((part) => part === "." || part === "..")) {
     throw new Error(`${label} path must be a clean absolute local path.`);
   }

--- a/web/management/src/views/AgentHealth.vue
+++ b/web/management/src/views/AgentHealth.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, h, inject, nextTick, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
-import { NAlert, NButton, NCheckbox, NDataTable, NDropdown, NInput, NModal, NTab, NTabs, NTag } from "naive-ui";
+import { NButton, NDataTable, NDropdown, NInput, NModal, NTab, NTabs, NTag } from "naive-ui";
 import type { DataTableColumns, DropdownDividerOption, DropdownOption } from "naive-ui";
 import { Ban as BanIcon } from "@lucide/vue";
 import { Check as CheckIcon } from "@lucide/vue";
@@ -18,21 +18,11 @@ import DisabledHint from "@/components/DisabledHint.vue";
 import EmptyState from "@/components/EmptyState.vue";
 import AgentAvailabilityChart from "@/components/AgentAvailabilityChart.vue";
 import AgentEditorModal from "@/components/editors/AgentEditorModal.vue";
+import AgentSetupModal from "@/components/AgentSetupModal.vue";
 import { dashboardKey, isBusyKey, publicProxyConfigKey, runManagementActionKey } from "@/composables/managementContextKeys";
 import { useConfirmDialog } from "@/composables/useConfirmDialog";
 import { AGENT_ID_SYSTEM_LABEL_KEY, userAgentLabelPairs } from "@/lib/agentLabels";
-import {
-  DEFAULT_LOCAL_AGENT_BINARY_PATH,
-  DEFAULT_LOCAL_INSTALLER_PATH,
-  FALLBACK_RELEASE_REPOSITORY,
-  cliSnippet as buildCliSnippet,
-  dockerComposeSnippet as buildDockerComposeSnippet,
-  dockerImageForRepository,
-  linuxInstallSnippet,
-  linuxUninstallSnippet,
-  normalizeManagementUrl as normalizeSetupManagementUrl,
-  normalizeReleaseVersion,
-} from "@/lib/agentSetupSnippets";
+import { agentSetupReleaseVersion, FALLBACK_RELEASE_REPOSITORY, linuxUninstallSnippet } from "@/lib/agentSetupSnippets";
 import {
   agentUptimeSummaryById,
   fleetUptimePercent,
@@ -90,13 +80,11 @@ const runManagementAction = inject(runManagementActionKey);
 const isBusy = inject(isBusyKey, computed(() => false));
 
 const lifecycleDialog = useConfirmDialog();
-const discardSetupDialog = useConfirmDialog();
 const status = computed(() => dashboard?.value?.status ?? null);
 const config = computed(() => publicProxyConfig?.value ?? null);
 const agents = computed(() => publicProxyConfig?.value?.agents ?? []);
 const oneHourWindow = computed(() => dashboard?.value?.windows.find((w) => w.label === "1h"));
 const dayWindow = computed(() => dashboard?.value?.windows.find((w) => w.label === "24h"));
-const managementSecurity = computed(() => dashboard?.value?.managementSecurity ?? null);
 const uptimeSummaries = computed(() => dashboard?.value?.agentUptimeSummaries ?? []);
 const uptimeByAgentId = computed(() => agentUptimeSummaryById(uptimeSummaries.value));
 const recentAgentConnections = computed(() => dashboard?.value?.recentAgentConnections ?? []);
@@ -226,35 +214,7 @@ let availabilityRequestSequence = 0;
 const agentEditor = ref<InstanceType<typeof AgentEditorModal> | null>(null);
 const openAgentActionMenuId = ref("");
 const rotateAgentToConfirm = ref<Agent | null>(null);
-const issuedToken = ref("");
-const issuedAgent = ref<Agent | null>(null);
-const issuedUpdaterEnrollmentToken = ref("");
-const issuedUpdaterAuthorityPublicKeyBase64 = ref("");
-const issuedUpdaterAuthorityKeyId = ref("");
-const issuedUpdaterAuthorityEpoch = ref(0n);
-const setupManagedUpdates = ref(false);
-const setupContext = ref<"create" | "rotate">("create");
-const setupManagementUrl = ref(defaultManagementUrl());
-const setupManagementCAFile = ref("");
-const setupAgentTLSCertFile = ref("/etc/p2pstream/agent.crt.pem");
-const setupAgentTLSKeyFile = ref("/etc/p2pstream/agent.key.pem");
-const setupAllowInsecureManagement = ref(false);
-const setupAgentAllowTargets = ref("");
-const setupAgentAllowAnyTarget = ref(false);
-const setupReleaseRepository = ref(defaultReleaseRepository());
-const setupReleaseVersion = ref(defaultReleaseVersion());
-const setupInstallerPath = ref(DEFAULT_LOCAL_INSTALLER_PATH);
-const setupAgentBinaryPath = ref(DEFAULT_LOCAL_AGENT_BINARY_PATH);
-const setupDockerImage = ref(defaultDockerImage(setupReleaseRepository.value, setupReleaseVersion.value));
-const setupDockerImageTouched = ref(false);
-const setupTab = ref<"install" | "docker" | "cli">("install");
-const setupCopyLabel = ref("Copy");
-const setupSnippetWasCopied = ref(false);
-const issuedTokenWasCopied = ref(false);
-const issuedUpdaterTokenWasCopied = ref(false);
-const issuedTokenCopyLabel = ref("Copy token");
-const issuedUpdaterTokenCopyLabel = ref("Copy token");
-const setupAdvancedOpen = ref(false);
+const setupModal = ref<InstanceType<typeof AgentSetupModal> | null>(null);
 const uninstallAgent = ref<Agent | null>(null);
 const uninstallReleaseRepository = ref(defaultReleaseRepository());
 const uninstallCopyLabel = ref("Copy");
@@ -263,38 +223,6 @@ let uninstallCopyReset: number | undefined;
 const sessionPagination = computed(() => ({ page: sessionPage.value, pageSize: 12 }));
 
 const busyDisabledReason = computed(() => isBusy?.value ? BUSY_REASON : "");
-const normalizedManagementUrl = computed(() => normalizeSetupManagementUrl(setupManagementUrl.value));
-const managementUsesTLS = computed(() => normalizedManagementUrl.value.toLowerCase().startsWith("https://"));
-const agentClientCertificateRequired = computed(() => Boolean(managementSecurity.value?.agentClientCertificateRequired));
-const setupIsRotation = computed(() => setupContext.value === "rotate");
-const setupCredentialCopyComplete = computed(() => setupTab.value !== "install" || (
-  issuedTokenWasCopied.value && (!setupManagedUpdates.value || !issuedUpdaterEnrollmentToken.value || issuedUpdaterTokenWasCopied.value)
-));
-const setupHandoffComplete = computed(() => setupSnippetWasCopied.value && setupCredentialCopyComplete.value);
-const setupModalTitle = computed(() => setupIsRotation.value ? "Agent Reinstall" : "Agent Setup");
-const setupLinuxTabLabel = computed(() => setupIsRotation.value ? "Linux reinstall" : "Linux install");
-const setupTabOptions = computed<Array<{ value: "install" | "docker" | "cli"; label: string }>>(() => [
-  { value: "install", label: setupLinuxTabLabel.value },
-  { value: "docker", label: "Docker Compose" },
-  { value: "cli", label: "CLI" },
-]);
-const embeddedManagementCAPEMBase64 = computed(() => {
-  const pem = managementSecurity.value?.managementCaPem ?? "";
-  if (!pem || !managementUsesTLS.value) return "";
-  return window.btoa(pem);
-});
-const setupSnippetError = computed(() => {
-  try {
-    buildSetupSnippet();
-    return "";
-  } catch (err) {
-    return err instanceof Error ? err.message : "Agent setup values are invalid.";
-  }
-});
-const setupSnippet = computed(() => {
-  if (setupSnippetError.value) return "";
-  return buildSetupSnippet();
-});
 const uninstallSnippetError = computed(() => {
   try {
     buildUninstallSnippet();
@@ -484,35 +412,6 @@ const sessionColumns = computed<DataTableColumns<AgentConnectionSession>>(() => 
     render: (session) => h(NTag, { size: "small", bordered: false, type: session.active ? "success" : "default" }, { default: () => session.active ? "Active" : "Closed" }),
   },
 ]);
-
-function buildSetupSnippet(): string {
-  if (!issuedAgent.value) return "";
-  switch (setupTab.value) {
-    case "docker":
-      return dockerComposeSnippet();
-    case "cli":
-      return cliSnippet();
-    default:
-      return linuxInstallerSnippet();
-  }
-}
-
-watch([setupReleaseRepository, setupReleaseVersion], ([repository, version]) => {
-  if (!setupDockerImageTouched.value) {
-    setupDockerImage.value = defaultDockerImage(repository, version);
-  }
-});
-
-watch(setupSnippet, () => {
-  setupSnippetWasCopied.value = false;
-  setupCopyLabel.value = setupCopyActionLabel();
-});
-
-watch(managementUsesTLS, (usesTLS) => {
-  if (!usesTLS && issuedAgent.value) {
-    setupAdvancedOpen.value = true;
-  }
-});
 
 watch(
   [
@@ -926,6 +825,13 @@ function agentLifecycleOptions(agent: Agent): Array<DropdownOption | DropdownDiv
       },
     },
     {
+      key: "reinstall",
+      label: "Reinstall / Repair",
+      icon: () => h(RefreshIcon, { class: "icon-sm" }),
+      disabled: busy,
+      props: { "aria-label": agentActionLabel("Reinstall or repair", agent) },
+    },
+    {
       key: "rotate",
       label: "Rotate token",
       icon: () => h(RefreshIcon, { class: "icon-sm" }),
@@ -963,6 +869,9 @@ function handleAgentLifecycleAction(agent: Agent, action: string) {
     case "toggle":
       if (!busyDisabledReason.value) void setAgentEnabled(agent, !agent.enabled);
       break;
+    case "reinstall":
+      if (!busyDisabledReason.value) void setupModal.value?.openExisting(agent, "reinstall");
+      break;
     case "rotate":
       if (!busyDisabledReason.value) rotateAgentToken(agent);
       break;
@@ -992,10 +901,6 @@ function handleRotateModalUpdate(show: boolean) {
 
 function handleUninstallModalUpdate(show: boolean) {
   if (!show) closeUninstallModal();
-}
-
-function handleSetupModalUpdate(show: boolean) {
-  if (!show) void requestClearIssuedToken();
 }
 
 function agentRowKey(agent: Agent): string {
@@ -1055,7 +960,7 @@ async function confirmRotateAgentToken() {
   if (!agent) return;
   const ok = await run(async () => {
     const resp = await managementClient.rotateAgentToken({ id: agent.id });
-    openSetupModal(resp.agent ?? agent, resp.token, "rotate");
+    setupModal.value?.openRotated(resp.agent ?? agent, resp.token);
   });
   if (ok) {
     closeRotateAgentModal();
@@ -1074,231 +979,15 @@ async function deleteAgent(agent: Agent) {
   });
 }
 
-function clearIssuedToken() {
-  issuedToken.value = "";
-  issuedAgent.value = null;
-  issuedUpdaterEnrollmentToken.value = "";
-  issuedUpdaterAuthorityPublicKeyBase64.value = "";
-  issuedUpdaterAuthorityKeyId.value = "";
-  issuedUpdaterAuthorityEpoch.value = 0n;
-  setupManagedUpdates.value = false;
-  setupContext.value = "create";
-  setupSnippetWasCopied.value = false;
-  issuedTokenWasCopied.value = false;
-  issuedUpdaterTokenWasCopied.value = false;
-  issuedTokenCopyLabel.value = "Copy token";
-  issuedUpdaterTokenCopyLabel.value = "Copy token";
-  setupAdvancedOpen.value = false;
-  setupCopyLabel.value = setupCopyActionLabel();
-}
-
-async function requestClearIssuedToken() {
-	if (issuedToken.value && !setupHandoffComplete.value) {
-		const missing = [
-			!setupSnippetWasCopied.value ? "setup command" : "",
-			setupTab.value === "install" && !issuedTokenWasCopied.value ? "agent token" : "",
-			setupTab.value === "install" && setupManagedUpdates.value && issuedUpdaterEnrollmentToken.value && !issuedUpdaterTokenWasCopied.value ? "updater token" : "",
-		].filter(Boolean).join(", ");
-    const confirmed = await discardSetupDialog.confirm(
-      "Close Without Copying?",
-			`The ${missing} ${missing.includes(",") ? "have" : "has"} not been copied. Closing now permanently discards the one-time credentials.`,
-			"Discard Credentials",
-    );
-    if (!confirmed) return;
-  }
-  clearIssuedToken();
-}
-
-function openSetupModal(agent: Agent | null, token: string, context: "create" | "rotate" = "create", updater?: Pick<CreatedAgentSetup, "updaterEnrollmentToken" | "updaterPinnedRepository" | "updaterManagementAuthorityPublicKeyBase64" | "updaterManagementAuthorityKeyId" | "updaterManagementAuthorityEpoch">) {
-  if (!agent || !token) return;
-  issuedAgent.value = agent;
-  issuedToken.value = token;
-  issuedUpdaterEnrollmentToken.value = updater?.updaterEnrollmentToken ?? "";
-  issuedUpdaterAuthorityPublicKeyBase64.value = updater?.updaterManagementAuthorityPublicKeyBase64 ?? "";
-  issuedUpdaterAuthorityKeyId.value = updater?.updaterManagementAuthorityKeyId ?? "";
-  issuedUpdaterAuthorityEpoch.value = updater?.updaterManagementAuthorityEpoch ?? 0n;
-  setupManagedUpdates.value = Boolean(issuedUpdaterEnrollmentToken.value && issuedUpdaterAuthorityPublicKeyBase64.value && issuedUpdaterAuthorityKeyId.value && issuedUpdaterAuthorityEpoch.value > 0n && context === "create");
-  setupContext.value = context;
-  setupManagementUrl.value = defaultManagementUrl();
-  setupManagementCAFile.value = "";
-  setupAgentTLSCertFile.value = "/etc/p2pstream/agent.crt.pem";
-  setupAgentTLSKeyFile.value = "/etc/p2pstream/agent.key.pem";
-  setupAllowInsecureManagement.value = false;
-  setupAgentAllowTargets.value = "";
-  setupAgentAllowAnyTarget.value = false;
-  setupReleaseRepository.value = updater?.updaterPinnedRepository || defaultReleaseRepository();
-  setupReleaseVersion.value = defaultReleaseVersion();
-  setupInstallerPath.value = DEFAULT_LOCAL_INSTALLER_PATH;
-  setupAgentBinaryPath.value = DEFAULT_LOCAL_AGENT_BINARY_PATH;
-  setupDockerImage.value = defaultDockerImage(setupReleaseRepository.value, setupReleaseVersion.value);
-  setupDockerImageTouched.value = false;
-  setupTab.value = "install";
-  setupSnippetWasCopied.value = false;
-  issuedTokenWasCopied.value = false;
-  issuedUpdaterTokenWasCopied.value = false;
-  issuedTokenCopyLabel.value = "Copy token";
-  issuedUpdaterTokenCopyLabel.value = "Copy token";
-  setupAdvancedOpen.value = !managementUsesTLS.value || agentClientCertificateRequired.value;
-  setupCopyLabel.value = setupCopyActionLabel();
-}
-
-function handleAgentCreated(payload: CreatedAgentSetup) {
-  openSetupModal(payload.agent, payload.token, "create", payload);
-}
-
-function defaultManagementUrl(): string {
-  const configured = managementSecurity.value?.defaultManagementUrl;
-  if (configured) {
-    return configured.replace(/\/+$/, "");
-  }
-  const url = new URL(window.location.origin);
-  url.protocol = "https:";
-  if (url.port === "5173") {
-    url.port = "8081";
-  } else if (!url.port) {
-    url.port = "8081";
-  }
-  return url.toString().replace(/\/$/, "");
-}
-
 function defaultReleaseRepository(): string {
-  const configured = import.meta.env.VITE_RELEASE_REPOSITORY;
-  return typeof configured === "string" && configured.trim() ? configured.trim() : FALLBACK_RELEASE_REPOSITORY;
-}
-
-function defaultReleaseVersion(): string {
-  const configured = import.meta.env.VITE_RELEASE_REF;
-  const version = typeof configured === "string" ? configured.trim() : "";
-  if (immutableReleaseVersion(version)) return version;
-  const runningVersion = status.value?.version?.trim() ?? "";
-  if (immutableReleaseVersion(runningVersion)) return runningVersion;
-  return "latest";
-}
-
-function immutableReleaseVersion(version: string): boolean {
-  try {
-    return normalizeReleaseVersion(version) === version && version !== "latest";
-  } catch {
-    return false;
-  }
-}
-
-function defaultDockerImage(repository: string, version: string): string {
-  try {
-    return dockerImageForRepository(repository, version);
-  } catch {
-    return dockerImageForRepository(repository);
-  }
-}
-
-function installerScriptRef(): string {
-  const version = setupReleaseVersion.value.trim();
-  return version === "latest" || version === "" ? "main" : version;
-}
-
-function linuxInstallerSnippet(): string {
-  if (!issuedAgent.value) return "";
-  return linuxInstallSnippet(setupSnippetInput());
-}
-
-function dockerComposeSnippet(): string {
-  if (!issuedAgent.value) return "";
-  return buildDockerComposeSnippet(setupSnippetInput());
-}
-
-function cliSnippet(): string {
-  if (!issuedAgent.value) return "";
-  return buildCliSnippet(setupSnippetInput());
+  return import.meta.env.VITE_RELEASE_REPOSITORY?.trim() || FALLBACK_RELEASE_REPOSITORY;
 }
 
 function buildUninstallSnippet(): string {
-  return linuxUninstallSnippet({ repository: uninstallReleaseRepository.value });
+  return linuxUninstallSnippet({ repository: uninstallReleaseRepository.value, version: agentSetupReleaseVersion(status.value?.version, import.meta.env.VITE_RELEASE_REF) });
 }
 
-function setupSnippetInput() {
-  return {
-    managementUrl: normalizedManagementUrl.value,
-    agentId: issuedAgent.value?.publicId ?? "",
-    agentToken: issuedToken.value,
-    updaterEnrollmentToken: issuedUpdaterEnrollmentToken.value,
-    agentUpdateAuthorityPublicKeyBase64: issuedUpdaterAuthorityPublicKeyBase64.value,
-    agentUpdateAuthorityKeyId: issuedUpdaterAuthorityKeyId.value,
-    agentUpdateAuthorityEpoch: issuedUpdaterAuthorityEpoch.value,
-    enableManagedUpdates: setupManagedUpdates.value && setupTab.value === "install",
-    repository: setupReleaseRepository.value,
-    version: setupReleaseVersion.value,
-    scriptRef: installerScriptRef(),
-    dockerImage: setupDockerImage.value,
-    installerPath: setupInstallerPath.value,
-    agentBinaryPath: setupAgentBinaryPath.value,
-    allowTargets: setupAgentAllowAnyTarget.value ? [] : splitSetupAgentAllowTargets(setupAgentAllowTargets.value),
-    allowAnyTarget: setupAgentAllowAnyTarget.value,
-    tls: {
-      enabled: managementUsesTLS.value,
-      managementCAFile: embeddedManagementCAPEMBase64.value ? "" : setupManagementCAFile.value,
-      managementCAPEMBase64: embeddedManagementCAPEMBase64.value,
-      agentTLSCertFile: agentClientCertificateRequired.value ? setupAgentTLSCertFile.value : "",
-      agentTLSKeyFile: agentClientCertificateRequired.value ? setupAgentTLSKeyFile.value : "",
-      allowInsecureManagement: setupAllowInsecureManagement.value,
-    },
-  };
-}
-
-function splitSetupAgentAllowTargets(value: string): string[] {
-  return value.split(/[\s,]+/).map((entry) => entry.trim()).filter(Boolean);
-}
-
-async function copySetupSnippet() {
-  if (setupSnippetError.value) {
-    setupCopyLabel.value = "Invalid";
-    setupSnippetWasCopied.value = false;
-    return;
-  }
-  try {
-    await navigator.clipboard.writeText(setupSnippet.value);
-    setupCopyLabel.value = "Copied";
-    setupSnippetWasCopied.value = true;
-  } catch {
-    setupCopyLabel.value = "Select command";
-    setupSnippetWasCopied.value = false;
-  }
-}
-
-async function copyIssuedCredential(value: string, kind: "agent" | "updater") {
-  try {
-    await navigator.clipboard.writeText(value);
-    if (kind === "agent") {
-      issuedTokenWasCopied.value = true;
-      issuedTokenCopyLabel.value = "Copied";
-    } else {
-      issuedUpdaterTokenWasCopied.value = true;
-      issuedUpdaterTokenCopyLabel.value = "Copied";
-    }
-  } catch {
-    if (kind === "agent") {
-      issuedTokenWasCopied.value = false;
-      issuedTokenCopyLabel.value = "Select token";
-    } else {
-      issuedUpdaterTokenWasCopied.value = false;
-      issuedUpdaterTokenCopyLabel.value = "Select token";
-    }
-  }
-}
-
-function setupCopyActionLabel(): string {
-  switch (setupTab.value) {
-    case "docker":
-      return "Copy Docker Compose";
-    case "cli":
-      return "Copy CLI command";
-    default:
-      return "Copy install command";
-  }
-}
-
-function handleSetupAdvancedToggle(event: Event) {
-  setupAdvancedOpen.value = (event.currentTarget as HTMLDetailsElement).open;
-}
+function handleAgentCreated(payload: CreatedAgentSetup) { setupModal.value?.openCreated(payload); }
 
 async function copyUninstallSnippet() {
   if (uninstallSnippetError.value) {
@@ -1618,231 +1307,11 @@ async function copyUninstallSnippet() {
       </div>
     </NModal>
 
-    <NModal
-      :show="Boolean(issuedToken && issuedAgent)"
-      preset="card"
-      :title="setupModalTitle"
-      :style="modalCardStyle('48rem')"
-      :content-style="modalScrollableContentStyle()"
-      :bordered="false"
-      :mask-closable="false"
-      :close-on-esc="false"
-      @update:show="handleSetupModalUpdate"
-    >
-      <div v-if="issuedAgent" class="layout-grid space-xl">
-        <div class="layout-grid space-md mq-md-cols-two">
-          <div class="layout-grid space-xs">
-            <span class="copy-xs weight-medium label-case letter-wide muted-text">Agent</span>
-            <bdi class="agent-modal-value round-md framed frame-standard muted-bg pad-x-md pad-y-sm copy-sm base-text" dir="ltr" :title="diagnosticInspectionText(issuedAgent.name)">{{ diagnosticExcerpt(issuedAgent.name, 72).text }}</bdi>
-          </div>
-          <div class="layout-grid space-xs">
-            <span class="copy-xs weight-medium label-case letter-wide muted-text">Generated ID</span>
-            <code class="agent-modal-value scroll-x round-md framed frame-standard muted-bg pad-x-md pad-y-sm mono-text copy-xs base-text"><bdi dir="ltr">{{ diagnosticInspectionText(issuedAgent.publicId) }}</bdi></code>
-          </div>
-        </div>
-
-		<NAlert :type="setupHandoffComplete ? 'success' : 'warning'" :show-icon="false">
-		  {{ setupHandoffComplete
-            ? setupTab === 'install'
-			  ? 'Command and required credentials copied. Run the command, then paste each token only into its matching hidden prompt.'
-              : 'Setup command copied. Keep it secure; this configuration contains one-time credentials.'
-			: setupTab === 'install'
-			  ? 'These credentials are shown once. Copy the command and every required token before closing this dialog.'
-			  : 'This setup is shown once. Copy it before closing this dialog.' }}
-        </NAlert>
-
-		<div class="layout-grid space-xs">
-		  <div class="agent-credential-heading layout-row align-center space-sm">
-			<span class="copy-xs weight-medium label-case letter-wide muted-text">One-Time Agent Token</span>
-			<NButton size="tiny" secondary attr-type="button" @click="copyIssuedCredential(issuedToken, 'agent')">{{ issuedTokenCopyLabel }}</NButton>
-		  </div>
-		  <code class="flow-box wrap-anywhere round-md framed frame-standard muted-bg pad-md mono-text copy-xs base-text">{{ issuedToken }}</code>
-		</div>
-
-        <div v-if="setupIsRotation" class="round-md framed frame-standard muted-bg pad-md copy-xs line-normal base-text">
-          <p class="weight-semibold label-case letter-wide">Existing Linux agent</p>
-          <p class="margin-top-xs muted-text">
-            Run the Linux reinstall command on the existing agent host. It rewrites the agent environment, refreshes embedded management CA material, and restarts p2pstream-agent.
-          </p>
-        </div>
-
-        <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
-          Management URL
-          <NInput v-model:value="setupManagementUrl" size="small" required />
-        </label>
-
-        <div class="round-md framed frame-standard muted-bg pad-md">
-          <div class="layout-row align-center space-sm">
-            <NTag size="small" :bordered="false" type="success">Adaptive capacity</NTag>
-            <span class="copy-xs weight-semibold base-text">Default for this setup command</span>
-          </div>
-          <p class="margin-top-xs copy-xs line-normal muted-text">
-            No <code>TUNNEL_MAX_CONCURRENT_REQUESTS</code> value is written. The agent uses available memory normally, begins gradual admission control at 80%, and pauses new streams at 90%.
-          </p>
-          <p v-if="setupIsRotation && setupTab === 'install'" class="margin-top-xs copy-xs line-normal muted-text">
-            A Linux reinstall preserves an existing explicit value in <code>/etc/p2pstream/agent.env</code>; remove that line to return an older fixed installation to adaptive mode.
-          </p>
-        </div>
-
-        <div v-if="issuedUpdaterEnrollmentToken && !setupIsRotation" class="round-md framed frame-standard muted-bg pad-md">
-          <div class="layout-row align-center space-sm">
-            <NTag size="small" :bordered="false" :type="setupManagedUpdates ? 'success' : 'default'">Managed updates</NTag>
-            <span class="copy-xs weight-semibold base-text">Linux/systemd only</span>
-          </div>
-          <NCheckbox v-model:checked="setupManagedUpdates" class="margin-top-md">
-            Enroll this host for route-aware updates
-          </NCheckbox>
-          <p class="margin-top-xs copy-xs line-normal muted-text">
-            Uses a separate single-use updater identity. The tunnel token cannot approve updates, and future releases do not require token rotation.
-          </p>
-          <p class="margin-top-xs copy-xs line-normal muted-text">
-            Release source {{ setupReleaseRepository }} on GitHub · exact versions and SHA-256 digests remain enforced
-          </p>
-          <p class="margin-top-xs copy-xs line-normal muted-text">
-            Management authority epoch {{ issuedUpdaterAuthorityEpoch }} · <code>{{ issuedUpdaterAuthorityKeyId.slice(0, 12) }}…{{ issuedUpdaterAuthorityKeyId.slice(-10) }}</code>
-          </p>
-		  <div v-if="setupManagedUpdates" class="layout-grid space-xs margin-top-md">
-			<div class="agent-credential-heading layout-row align-center space-sm">
-			  <span class="copy-xs weight-medium label-case letter-wide muted-text">Updater Enrollment Token</span>
-			  <NButton size="tiny" secondary attr-type="button" @click="copyIssuedCredential(issuedUpdaterEnrollmentToken, 'updater')">{{ issuedUpdaterTokenCopyLabel }}</NButton>
-			</div>
-			<code class="flow-box wrap-anywhere round-md framed frame-standard base-bg pad-md mono-text copy-xs base-text">{{ issuedUpdaterEnrollmentToken }}</code>
-		  </div>
-        </div>
-
-        <details class="agent-advanced-options" :open="setupAdvancedOpen" @toggle="handleSetupAdvancedToggle">
-          <summary>
-            <span>Advanced setup options</span>
-            <small>Destination policy, repository, release, and TLS</small>
-          </summary>
-          <div class="agent-advanced-options__body">
-            <div class="layout-grid space-md mq-md-cols-two">
-              <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
-                Agent Destination Allowlist
-                <NInput
-                  v-model:value="setupAgentAllowTargets"
-                  size="small"
-                  :disabled="setupAgentAllowAnyTarget"
-                  placeholder="app.internal:443, 10.0.5.0/24:8080"
-                />
-                <small class="normal-text line-normal letter-normal">
-                  Exact hostnames, IPs, or CIDRs with optional ports. Blank uses loopback-only defaults; a Linux reinstall preserves its existing policy.
-                </small>
-              </label>
-              <div class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
-                Destination Scope
-                <NCheckbox v-model:checked="setupAgentAllowAnyTarget">
-                  Allow any destination reachable by this agent
-                </NCheckbox>
-                <small class="normal-text line-normal letter-normal">
-                  Use only when unrestricted network reachability is intentional and documented.
-                </small>
-              </div>
-            </div>
-
-            <div v-if="setupAgentAllowAnyTarget" class="warning-panel pad-md copy-xs line-normal">
-              Unrestricted mode lets management request connections to every destination the agent host can reach.
-            </div>
-
-            <div class="layout-grid space-md mq-md-cols-two">
-              <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
-                GitHub Repository
-                <NInput v-model:value="setupReleaseRepository" size="small" placeholder="Kirari04/p2pstream" required />
-              </label>
-              <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
-                Release Version
-                <NInput v-model:value="setupReleaseVersion" size="small" placeholder="vX.Y.Z" required />
-                <small v-if="setupTab === 'install'" class="normal-text line-normal letter-normal">Linux requires an exact immutable SemVer tag; prereleases use the isolated staging update channel.</small>
-              </label>
-              <label v-if="setupTab === 'install'" class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
-                Pinned Installer File
-                <NInput v-model:value="setupInstallerPath" size="small" placeholder="/path/to/p2pstream-install-agent.sh" required />
-              </label>
-              <label v-if="setupTab === 'install'" class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
-                Pinned Raw Agent Binary
-                <NInput v-model:value="setupAgentBinaryPath" size="small" placeholder="/path/to/p2pstream-agent-vX.Y.Z-linux-amd64" required />
-              </label>
-              <label v-if="setupTab === 'docker'" class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
-                Docker Image
-                <NInput
-                  v-model:value="setupDockerImage"
-                  size="small"
-                  required
-                  @update:value="setupDockerImageTouched = true"
-                />
-              </label>
-            </div>
-
-            <div v-if="!managementUsesTLS" class="warning-panel pad-md copy-xs line-normal">
-              <p class="weight-semibold label-case letter-wide">Insecure management URL</p>
-              <p class="margin-top-xs deemphasized">Agents reject HTTP management URLs by default. Enable the override only for isolated local development.</p>
-              <NCheckbox v-model:checked="setupAllowInsecureManagement" class="margin-top-md">
-                Allow insecure agent management connection
-              </NCheckbox>
-            </div>
-
-            <div v-if="managementUsesTLS" class="layout-grid space-md mq-md-cols-three">
-              <label v-if="!embeddedManagementCAPEMBase64" class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
-                Management CA file
-                <NInput v-model:value="setupManagementCAFile" size="small" placeholder="/etc/p2pstream/management-ca.pem" />
-              </label>
-              <div v-else class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
-                Management CA
-                <div class="round-md framed frame-standard muted-bg pad-x-md pad-y-sm copy-xs normal-text line-normal letter-normal base-text">
-                  Embedded pinned CA from this management server
-                </div>
-              </div>
-              <label v-if="agentClientCertificateRequired" class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
-                Agent Certificate
-                <NInput v-model:value="setupAgentTLSCertFile" size="small" required />
-              </label>
-              <label v-if="agentClientCertificateRequired" class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
-                Agent Key
-                <NInput v-model:value="setupAgentTLSKeyFile" size="small" required />
-              </label>
-            </div>
-          </div>
-        </details>
-
-        <NTabs
-          class="agent-setup-tabs"
-          type="segment"
-          size="small"
-          :value="setupTab"
-          @update:value="(value) => setupTab = value as 'install' | 'docker' | 'cli'"
-        >
-          <NTab
-            v-for="tab in setupTabOptions"
-            :key="tab.value"
-            :name="tab.value"
-            :tab="tab.label"
-          />
-        </NTabs>
-
-        <p v-if="setupTab === 'install'" class="copy-xs line-normal muted-text">
-          Linux setup runs only a locally supplied, independently pinned installer and raw binary. Remote scripts are never piped into root, and the displayed token is entered through a hidden prompt instead of shell arguments.
-        </p>
-
-        <p v-if="setupSnippetError" class="error-panel pad-md copy-xs line-normal">{{ setupSnippetError }}</p>
-        <pre v-else class="max-height-md scroll-any round-md framed frame-standard muted-bg pad-lg copy-xs line-normal base-text"><code>{{ setupSnippet }}</code></pre>
-
-        <p class="visually-hidden" aria-live="polite">
-		  {{ setupHandoffComplete ? 'Setup command and required credentials copied.' : '' }}
-        </p>
-        <div class="layout-row layout-column-reverse space-md mq-sm-row mq-sm-end">
-          <NButton secondary attr-type="button" @click="requestClearIssuedToken">Done</NButton>
-          <NButton type="primary" attr-type="button" :disabled="Boolean(setupSnippetError)" @click="copySetupSnippet">{{ setupCopyLabel }}</NButton>
-        </div>
-      </div>
-    </NModal>
+    <AgentSetupModal ref="setupModal" />
   </div>
 </template>
 
 <style>
-.agent-credential-heading {
-  justify-content: space-between;
-}
-
 .agent-page__header {
   display: flex;
   flex-direction: column;
@@ -2391,51 +1860,6 @@ async function copyUninstallSnippet() {
   unicode-bidi: isolate;
 }
 
-.agent-advanced-options {
-  overflow: hidden;
-  border: 1px solid var(--app-border);
-  border-radius: 6px;
-  background: var(--app-panel-muted);
-}
-
-.agent-advanced-options summary {
-  display: list-item;
-  cursor: pointer;
-  padding: 0.85rem 1rem;
-  color: var(--app-text);
-  font-size: 0.8125rem;
-  font-weight: 600;
-}
-
-.agent-advanced-options summary::marker {
-  color: var(--app-text-muted);
-}
-
-.agent-advanced-options summary small {
-  display: block;
-  margin-top: 0.15rem;
-  margin-left: 1rem;
-  color: var(--app-text-muted);
-  font-size: 0.75rem;
-  font-weight: 400;
-}
-
-.agent-advanced-options__body {
-  display: grid;
-  gap: 1rem;
-  border-top: 1px solid var(--app-border-subtle);
-  padding: 1rem;
-  background: var(--app-panel);
-}
-
-.agent-setup-tabs {
-  max-width: 100%;
-}
-
-.agent-setup-tabs .n-tabs-nav {
-  width: min(100%, 32rem);
-}
-
 @media (max-width: 639px) {
   .agent-cell__mobile-build {
     display: block;
@@ -2512,8 +1936,7 @@ async function copyUninstallSnippet() {
 
 @media (pointer: coarse) {
   .agent-row-actions .n-button,
-  .agent-exact-details summary,
-  .agent-advanced-options summary {
+  .agent-exact-details summary {
     min-height: 2.75rem;
   }
 }

--- a/web/management/src/views/AgentUpdates.vue
+++ b/web/management/src/views/AgentUpdates.vue
@@ -7,7 +7,6 @@ import {
   CheckCircle2 as CheckIcon,
   CirclePause as PauseIcon,
   CirclePlay as PlayIcon,
-  Copy as CopyIcon,
   Fingerprint as FingerprintIcon,
   PackageCheck as PackageIcon,
   RefreshCw as RefreshIcon,
@@ -15,10 +14,10 @@ import {
   ShieldCheck as ShieldIcon,
   TriangleAlert as WarningIcon,
 } from "@lucide/vue";
-import { dashboardKey, environmentsKey, isBusyKey, runManagementActionKey, selectedEnvironmentIdKey } from "@/composables/managementContextKeys";
+import { dashboardKey, isBusyKey, runManagementActionKey } from "@/composables/managementContextKeys";
 import { useManagementClient } from "@/composables/useManagementClient";
 import { messageFromError } from "@/lib/errors";
-import { agentSetupManagementUrl, DEFAULT_LOCAL_AGENT_BINARY_PATH, DEFAULT_LOCAL_INSTALLER_PATH, linuxManagedUpdaterBootstrapSnippet } from "@/lib/agentSetupSnippets";
+import AgentSetupModal from "@/components/AgentSetupModal.vue";
 import {
   AgentUpdateAssignmentState,
   AgentUpdateCampaignState,
@@ -33,8 +32,6 @@ import {
 const managementClient = useManagementClient();
 const router = useRouter();
 const dashboard = inject(dashboardKey, computed(() => null));
-const environments = inject(environmentsKey, computed(() => []));
-const selectedEnvironmentId = inject(selectedEnvironmentIdKey, computed(() => "0"));
 const isBusy = inject(isBusyKey, computed(() => false));
 const runManagementAction = inject(runManagementActionKey);
 
@@ -59,23 +56,7 @@ const healthyDwellSeconds = ref(120);
 const preview = ref<AgentUpdatePreviewAgent[]>([]);
 const previewFingerprint = ref("");
 const previewLoading = ref(false);
-const bootstrapAgent = ref<AgentUpdateOverviewAgent | null>(null);
-const bootstrapToken = ref("");
-const bootstrapRepository = ref("");
-const bootstrapAuthorityPublicKeyBase64 = ref("");
-const bootstrapAuthorityKeyId = ref("");
-const bootstrapAuthorityEpoch = ref(0n);
-const bootstrapExpiresAt = ref(0n);
-const bootstrapCopied = ref(false);
-const bootstrapTokenCopied = ref(false);
-const bootstrapInstallerPath = ref(DEFAULT_LOCAL_INSTALLER_PATH);
-const bootstrapAgentBinaryPath = ref(DEFAULT_LOCAL_AGENT_BINARY_PATH);
-
-function bytesToBase64(value: Uint8Array): string {
-  let binary = "";
-  for (const byte of value) binary += String.fromCharCode(byte);
-  return btoa(binary);
-}
+const setupModal = ref<InstanceType<typeof AgentSetupModal> | null>(null);
 
 const agents = computed(() => overview.value?.agents ?? []);
 const updaterFreshnessWindowMs = 2 * 60 * 1000;
@@ -209,97 +190,8 @@ async function retryFailed(campaign: AgentUpdateCampaign) {
   else await execute();
 }
 
-function managementOrigin(): string {
-  const environment = environments.value.find((item) => item.id.toString() === selectedEnvironmentId.value);
-  return agentSetupManagementUrl(
-    dashboard.value?.managementSecurity?.defaultManagementUrl,
-    environment?.managementUrl,
-    window.location.origin,
-  );
-}
-
-const bootstrapCommand = computed(() => {
-  if (!bootstrapAgent.value || !bootstrapAgent.value.tunnelVersion || !bootstrapAgent.value.tunnelCommit || !bootstrapToken.value || !bootstrapAuthorityPublicKeyBase64.value || !bootstrapAuthorityKeyId.value || bootstrapAuthorityEpoch.value <= 0n) return "";
-  try {
-    return linuxManagedUpdaterBootstrapSnippet({
-      managementUrl: managementOrigin(),
-      agentId: bootstrapAgent.value.agentPublicId,
-      updaterEnrollmentToken: bootstrapToken.value,
-      agentUpdateAuthorityPublicKeyBase64: bootstrapAuthorityPublicKeyBase64.value,
-      agentUpdateAuthorityKeyId: bootstrapAuthorityKeyId.value,
-      agentUpdateAuthorityEpoch: bootstrapAuthorityEpoch.value,
-      currentTunnelVersion: bootstrapAgent.value.tunnelVersion,
-      currentTunnelCommit: bootstrapAgent.value.tunnelCommit,
-      repository: bootstrapRepository.value,
-      version: trustedTarget.value?.version,
-      installerPath: bootstrapInstallerPath.value,
-      agentBinaryPath: bootstrapAgentBinaryPath.value,
-    });
-  } catch (error) {
-    operationError.value = messageFromError(error);
-    return "";
-  }
-});
-const bootstrapReadyToClose = computed(() => bootstrapCopied.value && bootstrapTokenCopied.value);
-
-async function openBootstrap(agent: AgentUpdateOverviewAgent) {
-  operationError.value = "";
-  try {
-    const response = await managementClient.generateAgentUpdaterEnrollmentToken({
-      agentId: agent.agentId,
-      ttlMillis: 10n * 60n * 1000n,
-    });
-    bootstrapAgent.value = agent;
-    bootstrapToken.value = response.token;
-    bootstrapRepository.value = response.pinnedRepository;
-    bootstrapAuthorityPublicKeyBase64.value = bytesToBase64(response.managementAuthority?.publicKey ?? new Uint8Array());
-    bootstrapAuthorityKeyId.value = response.managementAuthority?.keyId ?? "";
-    bootstrapAuthorityEpoch.value = response.managementAuthority?.epoch ?? 0n;
-    bootstrapExpiresAt.value = response.expiresAtUnixMillis;
-    bootstrapCopied.value = false;
-    bootstrapTokenCopied.value = false;
-    bootstrapInstallerPath.value = DEFAULT_LOCAL_INSTALLER_PATH;
-    bootstrapAgentBinaryPath.value = DEFAULT_LOCAL_AGENT_BINARY_PATH;
-  } catch (error) {
-    operationError.value = messageFromError(error);
-  }
-}
-
-function closeBootstrap() {
-  bootstrapAgent.value = null;
-  bootstrapToken.value = "";
-  bootstrapRepository.value = "";
-  bootstrapAuthorityPublicKeyBase64.value = "";
-  bootstrapAuthorityKeyId.value = "";
-  bootstrapAuthorityEpoch.value = 0n;
-  bootstrapExpiresAt.value = 0n;
-  bootstrapCopied.value = false;
-  bootstrapTokenCopied.value = false;
-}
-
-async function copyBootstrap() {
-  if (!bootstrapCommand.value) return;
-  try {
-    await navigator.clipboard.writeText(bootstrapCommand.value);
-    bootstrapCopied.value = true;
-  } catch (error) {
-    operationError.value = messageFromError(error);
-  }
-}
-
-async function copyBootstrapToken() {
-  if (!bootstrapToken.value) return;
-  try {
-    await navigator.clipboard.writeText(bootstrapToken.value);
-    bootstrapTokenCopied.value = true;
-  } catch (error) {
-    operationError.value = messageFromError(error);
-  }
-}
-
-function formatExpiry(value: bigint): string {
-  if (!value) return "unknown";
-  return new Date(Number(value)).toLocaleString();
+function enableManagedUpdates(agent: AgentUpdateOverviewAgent) {
+  void setupModal.value?.openExisting({ id: agent.agentId, publicId: agent.agentPublicId, name: agent.name, version: agent.tunnelVersion, commit: agent.tunnelCommit }, "enable-updates");
 }
 
 function toggleAgent(agent: AgentUpdateOverviewAgent, checked: boolean) {
@@ -467,7 +359,7 @@ onMounted(refresh);
         <small>connected hosts with a recent updater check-in</small>
       </article>
       <article>
-        <span>Bootstrap required</span>
+        <span>Setup required</span>
         <strong>{{ unsupportedAgents }}</strong>
         <small>need one-time host enrollment; no token rotation</small>
       </article>
@@ -549,7 +441,7 @@ onMounted(refresh);
           <div><span>Live tunnel</span><strong>{{ agent.tunnelVersion || "unreported" }}</strong><small v-if="agent.tunnelCommit" class="mono-text">{{ shortDigest(agent.tunnelCommit) }}</small></div>
           <div><span>Traffic</span><strong>{{ agent.cordoned ? "cordoned" : "eligible" }}</strong></div>
           <NTag v-if="agent.updaterEnrolled" size="small" :bordered="false" :type="updaterIsFresh(agent) ? 'success' : 'warning'">{{ updaterIsFresh(agent) ? "Managed" : "Worker stale" }}</NTag>
-          <NButton v-else secondary size="tiny" :disabled="isBusy || !agent.tunnelVersion || !agent.tunnelCommit" @click="openBootstrap(agent)">Bootstrap</NButton>
+          <NButton v-else secondary size="tiny" :disabled="isBusy || !agent.tunnelVersion || !agent.tunnelCommit" @click="enableManagedUpdates(agent)">Enable managed updates</NButton>
         </div>
       </div>
       <div v-else class="agent-update-empty">No agents are registered.</div>
@@ -645,51 +537,7 @@ onMounted(refresh);
       </div>
     </NModal>
 
-    <NModal
-      :show="Boolean(bootstrapAgent)"
-      preset="card"
-      title="Bootstrap Managed Updates"
-      :style="{ width: 'min(760px, calc(100vw - 2rem))' }"
-      :mask-closable="bootstrapReadyToClose"
-      :close-on-esc="bootstrapReadyToClose"
-      @update:show="(show) => { if (!show && bootstrapReadyToClose) closeBootstrap(); }"
-    >
-      <div v-if="bootstrapAgent" class="stack-lg">
-        <NAlert :type="bootstrapReadyToClose ? 'success' : 'warning'" :bordered="false">
-          {{ bootstrapReadyToClose ? "Command and one-time token copied. Paste the token only into the command's hidden prompt." : "Copy the command and enrollment token separately before closing. The command contains no secret and never rotates the tunnel token." }}
-        </NAlert>
-		<NAlert type="info" :bordered="false">
-		  The pinned file installs the rescue updater only. The live tunnel remains on {{ bootstrapAgent.tunnelVersion }} ({{ shortDigest(bootstrapAgent.tunnelCommit) }}) until a drained campaign activates a verified GitHub release.
-		</NAlert>
-        <div class="agent-bootstrap-identity">
-          <div><span>Agent</span><strong>{{ bootstrapAgent.name }}</strong><small class="mono-text">{{ bootstrapAgent.agentPublicId }}</small></div>
-          <div><span>Release source</span><strong>GitHub</strong><small class="mono-text">{{ bootstrapRepository }}</small></div>
-          <div><span>Management authority</span><strong>epoch {{ bootstrapAuthorityEpoch }}</strong><small class="mono-text">{{ shortDigest(bootstrapAuthorityKeyId) }}</small></div>
-          <div><span>Expires</span><strong>{{ formatExpiry(bootstrapExpiresAt) }}</strong><small>one-time enrollment</small></div>
-        </div>
-        <label class="agent-update-field">
-          <span>One-time updater enrollment token</span>
-          <code class="agent-bootstrap-token">{{ bootstrapToken }}</code>
-        </label>
-        <div class="layout-grid space-md mq-md-cols-two">
-          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
-            Pinned installer file
-            <NInput v-model:value="bootstrapInstallerPath" size="small" required />
-          </label>
-          <label class="layout-grid space-xs copy-xs weight-medium label-case letter-wide muted-text">
-			Pinned rescue updater binary ({{ trustedTarget?.version }})
-            <NInput v-model:value="bootstrapAgentBinaryPath" size="small" required />
-          </label>
-        </div>
-        <p class="copy-xs muted-text">Download and verify both versioned files through a trusted channel before running this local-only command. Remote scripts are never piped into root.</p>
-        <pre class="agent-bootstrap-command"><code>{{ bootstrapCommand }}</code></pre>
-        <div class="agent-update-modal__actions">
-          <NButton :disabled="!bootstrapReadyToClose" @click="closeBootstrap">Done</NButton>
-          <NButton secondary :disabled="!bootstrapToken" @click="copyBootstrapToken"><template #icon><CopyIcon /></template>{{ bootstrapTokenCopied ? "Token copied" : "Copy token" }}</NButton>
-          <NButton type="primary" :disabled="!bootstrapCommand" @click="copyBootstrap"><template #icon><CopyIcon /></template>{{ bootstrapCopied ? "Copied" : "Copy bootstrap command" }}</NButton>
-        </div>
-      </div>
-    </NModal>
+    <AgentSetupModal ref="setupModal" />
   </div>
 </template>
 
@@ -964,17 +812,7 @@ onMounted(refresh);
 .agent-update-preview > .agent-update-preview--blocked { border-color: color-mix(in srgb, var(--app-warning) 34%, var(--app-border)); }
 .agent-update-preview > .agent-update-preview--blocked > svg { color: var(--app-warning); }
 .agent-update-modal__actions { display: flex; justify-content: flex-end; gap: 0.6rem; }
-.agent-bootstrap-identity { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); border: 1px solid var(--app-border); border-radius: 7px; }
-.agent-bootstrap-identity > div { min-width: 0; padding: 0.8rem; }
-.agent-bootstrap-identity > div + div { border-left: 1px solid var(--app-border-subtle); }
-.agent-bootstrap-identity span,
-.agent-bootstrap-identity strong,
-.agent-bootstrap-identity small { display: block; }
-.agent-bootstrap-identity span { color: var(--app-text-muted); font-size: 0.63rem; text-transform: uppercase; letter-spacing: 0.05em; }
-.agent-bootstrap-identity strong { overflow: hidden; margin-top: 0.15rem; font-size: 0.73rem; text-overflow: ellipsis; white-space: nowrap; }
-.agent-bootstrap-identity small { overflow: hidden; margin-top: 0.12rem; color: var(--app-text-muted); font-size: 0.61rem; text-overflow: ellipsis; white-space: nowrap; }
-.agent-bootstrap-command { overflow: auto; max-height: 17rem; margin: 0; border: 1px solid var(--app-border); border-radius: 7px; background: var(--app-panel-muted); padding: 1rem; color: var(--app-text); font-size: 0.68rem; line-height: 1.55; white-space: pre-wrap; overflow-wrap: anywhere; }
-.agent-bootstrap-token { display: block; border: 1px solid var(--app-border); border-radius: 7px; background: var(--app-panel-muted); padding: 0.75rem; color: var(--app-text); font-size: 0.68rem; overflow-wrap: anywhere; }
+
 
 @media (max-width: 900px) {
   .agent-release-deck,
@@ -1004,8 +842,6 @@ onMounted(refresh);
   .agent-rollout-rail__steps { grid-template-columns: 1fr; }
   .agent-update-form-grid,
   .agent-update-preview { grid-template-columns: 1fr; }
-  .agent-bootstrap-identity { grid-template-columns: 1fr; }
-  .agent-bootstrap-identity > div + div { border-top: 1px solid var(--app-border-subtle); border-left: 0; }
   .agent-update-campaign__summary { align-items: flex-start; grid-template-columns: 1fr; }
   .agent-update-campaign__actions { justify-content: flex-start; }
   .agent-update-assignment { grid-template-columns: 1fr; }

--- a/web/management/tests/agentSetupDownload.test.ts
+++ b/web/management/tests/agentSetupDownload.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync, statSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { linuxInstallSnippet, linuxManagedUpdaterBootstrapSnippet, linuxRotateAgentTokenSnippet, linuxUninstallSnippet } from "../src/lib/agentSetupSnippets";
+
+const roots: string[] = [];
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+
+const input = {
+  managementUrl: "https://remote.example.test:8081",
+  agentId: "agent-existing",
+  agentToken: "token' with $(touch SHOULD_NOT_EXIST) and `id`",
+  repository: "Example/p2pstream",
+  version: "v1.2.3-staging.84",
+};
+const authority = {
+  updaterEnrollmentToken: "p2puet_'quoted-token",
+  agentUpdateAuthorityPublicKeyBase64: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+  agentUpdateAuthorityKeyId: "a".repeat(64),
+  agentUpdateAuthorityEpoch: 1n,
+};
+
+// All commands run against local fixtures. sudo and curl are replaced; neither
+// the real installer nor a remote service is invoked by these tests.
+function fixture(options: { arch?: string; legacy?: boolean; version?: string } = {}) {
+  const version = options.version ?? input.version;
+  const arch = options.arch ?? "amd64";
+  const root = mkdtempSync(join(tmpdir(), "agent-setup-test-"));
+  roots.push(root);
+  const bin = join(root, "bin");
+  const assets = join(root, "assets");
+  const scratch = join(root, "scratch");
+  for (const dir of [bin, assets, scratch]) mkdirSync(dir);
+  const sourceRoot = join(root, `p2pstream-${version}`);
+  mkdirSync(join(sourceRoot, "scripts"), { recursive: true });
+  const installer = join(sourceRoot, "scripts/install-agent.sh");
+  writeFileSync(installer, 'set -eu\nenv -0 > "$FIXTURE/result"\ncp "$P2PSTREAM_AGENT_BINARY_FILE" "$FIXTURE/installed-binary"\n');
+  writeFileSync(join(sourceRoot, "scripts/uninstall-agent.sh"), 'set -eu\nenv -0 > "$FIXTURE/result"\n');
+  const sourceAsset = `p2pstream_${version}_source.tar.gz`;
+  expect(Bun.spawnSync(["tar", "-czf", join(assets, sourceAsset), "-C", root, `p2pstream-${version}`]).exitCode).toBe(0);
+  const binary = join(root, "p2pstream");
+  writeFileSync(binary, `fixture binary for ${version} ${arch}`);
+  let binaryAsset = `p2pstream_${version}_linux_${arch}`;
+  if (options.legacy) {
+    binaryAsset += ".tar.gz";
+    expect(Bun.spawnSync(["tar", "-czf", join(assets, binaryAsset), "-C", root, "./p2pstream"]).exitCode).toBe(0);
+  } else {
+    writeFileSync(join(assets, binaryAsset), readFileSync(binary));
+  }
+  const checksum = (name: string) => `${createHash("sha256").update(readFileSync(join(assets, name))).digest("hex")}  ${name}\n`;
+  const manifest = checksum(sourceAsset) + checksum(binaryAsset);
+  writeFileSync(join(assets, "checksums.txt"), manifest);
+  writeFileSync(join(bin, "sudo"), '#!/bin/bash\nexec "$@"\n', { mode: 0o755 });
+  writeFileSync(join(bin, "uname"), `#!/bin/bash\nif [ "$1" = -s ]; then echo Linux; else echo ${arch === "arm64" ? "aarch64" : "x86_64"}; fi\n`, { mode: 0o755 });
+  writeFileSync(join(bin, "curl"), `#!/bin/bash
+set -eu
+output=; url=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) output=$2; shift 2 ;;
+    --proto|--proto-redir|--retry|--connect-timeout|--max-time|--max-filesize|--write-out) shift 2 ;;
+    --*) shift ;;
+    *) url=$1; shift ;;
+  esac
+done
+printf '%s\\n' "$url" >> "$FIXTURE/downloads"
+if [ "$url" = "https://github.com/Example/p2pstream/releases/latest" ]; then
+  printf '%s' "https://github.com/Example/p2pstream/releases/tag/\${RESOLVED_VERSION:-${version}}"
+else
+  [[ "$url" = "https://github.com/Example/p2pstream/releases/download/${version}/"* ]] || exit 22
+  [ "\${url##*/}" != "\${FAIL_ASSET:-}" ] || exit 22
+  cp "$FIXTURE/assets/\${url##*/}" "$output"
+fi
+`, { mode: 0o755 });
+  const environmentPath = join(root, "agent.env");
+  const existingToken = "existing' token with $LITERAL and `id`";
+  writeFileSync(environmentPath, `AGENT_ID="${input.agentId}"\nAGENT_TOKEN="${existingToken}"\nMANAGEMENT_URL="https://localhost:8081"\n`, { mode: 0o640 });
+  if (process.env.P2PSTREAM_TEST_USER_SYSTEMD === "true") {
+    writeFileSync(join(bin, "systemd-run"), '#!/bin/bash\nexec /usr/bin/systemd-run --user --setenv="FIXTURE=$FIXTURE" --setenv="PATH=$PATH" "$@"\n', { mode: 0o755 });
+  } else {
+    writeFileSync(join(bin, "systemd-run"), `#!/bin/bash
+set -eu
+while [[ "$1" = --* ]]; do shift; done
+args=()
+for arg in "$@"; do
+  args+=( "\${arg//\\$\\$/\\$}" )
+done
+exec env -i PATH="$PATH" FIXTURE="$FIXTURE" AGENT_ID="\${FIXTURE_EXISTING_ID:-${input.agentId}}" AGENT_TOKEN="$FIXTURE_EXISTING_TOKEN" MANAGEMENT_URL=https://localhost:8081 "\${args[@]}"
+`, { mode: 0o755 });
+  }
+  writeFileSync(join(bin, "systemctl"), '#!/bin/bash\nprintf "%s\\n" "$*" >> "$FIXTURE/systemctl.log"\n', { mode: 0o755 });
+  const run = (command: string, extraEnv: Record<string, string> = {}) => {
+    const result = Bun.spawnSync(["bash", "-c", command], {
+      cwd: root,
+      stdin: "ignore",
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, FIXTURE: root, TMPDIR: scratch, FIXTURE_EXISTING_TOKEN: existingToken, ...extraEnv },
+    });
+    expect(readdirSync(scratch)).toEqual([]);
+    const values = readdirSync(root).includes("result")
+      ? Object.fromEntries(readFileSync(join(root, "result"), "utf8").split("\0").filter(Boolean).map((entry) => [entry.slice(0, entry.indexOf("=")), entry.slice(entry.indexOf("=") + 1)]))
+      : null;
+    return { exitCode: result.exitCode, stderr: result.stderr.toString(), values };
+  };
+  const downloads = () => readdirSync(root).includes("downloads") ? readFileSync(join(root, "downloads"), "utf8").trim().split("\n") : [];
+  return { root, assets, installer, binary, sourceAsset, binaryAsset, manifest, run, downloads, environmentPath, existingToken };
+}
+
+describe("copy-and-paste Linux setup commands", () => {
+  for (const arch of ["amd64", "arm64"]) {
+    test(`downloads and verifies ${arch} installer and binary without prompting`, () => {
+      const f = fixture({ arch });
+      const result = f.run(linuxInstallSnippet({ ...input, ...authority, enableManagedUpdates: true }));
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+      expect(result.values?.AGENT_TOKEN).toBe(input.agentToken);
+      expect(result.values?.P2PSTREAM_UPDATER_ENROLLMENT_TOKEN).toBe(authority.updaterEnrollmentToken);
+      expect(result.values?.MANAGEMENT_URL).toBe(input.managementUrl);
+      expect(result.values?.P2PSTREAM_AGENT_UPDATE_CHANNEL).toBe("staging");
+      expect(result.values?.P2PSTREAM_VERSION).toBe(input.version);
+      expect(readFileSync(join(f.root, "installed-binary"), "utf8")).toBe(`fixture binary for ${input.version} ${arch}`);
+      expect(f.downloads().map((url) => url.split("/").pop())).toEqual(["checksums.txt", f.sourceAsset, f.binaryAsset]);
+      expect(readdirSync(f.root)).not.toContain("SHOULD_NOT_EXIST");
+    });
+  }
+
+  test("supports older releases with archived binaries and resolves latest once", () => {
+    const f = fixture({ version: "v0.1.52", legacy: true });
+    const result = f.run(linuxInstallSnippet({ ...input, version: "latest" }));
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(result.values?.P2PSTREAM_VERSION).toBe("v0.1.52");
+    expect(f.downloads()).toHaveLength(4);
+    expect(f.downloads()[0]).toEndWith("/releases/latest");
+    expect(f.downloads().slice(1).every((url) => url.includes("/download/v0.1.52/"))).toBe(true);
+    expect(readFileSync(join(f.root, "installed-binary"), "utf8")).toContain("v0.1.52");
+  });
+
+  test("bootstraps with the enrollment credential and preserves the existing tunnel identity", () => {
+    const f = fixture();
+    const result = f.run(linuxManagedUpdaterBootstrapSnippet({ ...input, ...authority, currentTunnelVersion: "v0.1.52", currentTunnelCommit: "b".repeat(40) }));
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(result.values?.AGENT_TOKEN).toBeUndefined();
+    expect(result.values?.P2PSTREAM_UPDATER_ENROLLMENT_TOKEN).toBe(authority.updaterEnrollmentToken);
+    expect(result.values?.P2PSTREAM_EXISTING_TUNNEL_VERSION).toBe("v0.1.52");
+    expect(result.values?.P2PSTREAM_EXISTING_TUNNEL_COMMIT).toBe("b".repeat(40));
+  });
+
+  test("keeps explicit local files available without network access", () => {
+    const f = fixture();
+    const result = f.run(linuxInstallSnippet({ ...input, installerPath: f.installer, agentBinaryPath: f.binary }));
+    expect(result.exitCode).toBe(0);
+    expect(result.values?.AGENT_TOKEN).toBe(input.agentToken);
+    expect(f.downloads()).toEqual([]);
+  });
+
+  test("downloads only the verified source for uninstall", () => {
+    const f = fixture();
+    const result = f.run(linuxUninstallSnippet(input));
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(result.values?.P2PSTREAM_UNINSTALL_CONFIRM).toBe("full-purge");
+    expect(result.values?.AGENT_TOKEN).toBeUndefined();
+    expect(f.downloads().map((url) => url.split("/").pop())).toEqual(["checksums.txt", f.sourceAsset]);
+  });
+
+  test("reinstall reuses the existing host token and applies the edited management URL", () => {
+    const f = fixture();
+    const command = linuxInstallSnippet({ ...input, agentToken: "", reuseExistingToken: true, agentEnvironmentPath: f.environmentPath, ...authority, enableManagedUpdates: true });
+    expect(command).not.toContain(f.existingToken);
+    const result = f.run(command);
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(result.values?.AGENT_TOKEN).toBe(f.existingToken);
+    expect(result.values?.MANAGEMENT_URL).toBe(input.managementUrl);
+    expect(result.values?.P2PSTREAM_UPDATER_ENROLLMENT_TOKEN).toBe(authority.updaterEnrollmentToken);
+    expect(result.values?.P2PSTREAM_AGENT_UPDATE_CHANNEL).toBe("staging");
+  });
+
+  test("reinstall refuses the wrong agent host before running its installer", () => {
+    const f = fixture();
+    const result = f.run(linuxInstallSnippet({ ...input, agentId: "wrong-agent", agentToken: "", reuseExistingToken: true, agentEnvironmentPath: f.environmentPath }));
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("selected agent identity");
+    expect(result.values).toBeNull();
+  });
+
+  test("reinstall rejects missing and symlinked environment files", () => {
+    const f = fixture();
+    for (const path of [join(f.root, "missing.env"), join(f.root, "symlink.env")]) {
+      if (path.endsWith("symlink.env")) symlinkSync(f.environmentPath, path);
+      const result = f.run(linuxInstallSnippet({ ...input, agentToken: "", reuseExistingToken: true, agentEnvironmentPath: path }));
+      expect(result.exitCode).not.toBe(0);
+      expect(result.values).toBeNull();
+    }
+    expect(f.downloads()).toEqual([]);
+  });
+
+  test("token rotation only updates credentials and restarts, preserving existing settings and permissions", () => {
+    const f = fixture();
+    const before = readFileSync(f.environmentPath, "utf8");
+    const token = "new' token with \"quotes\", $LITERAL, `id`, and \\slashes";
+    const result = f.run(linuxRotateAgentTokenSnippet({ agentId: input.agentId, agentToken: token, agentEnvironmentPath: f.environmentPath }));
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(readFileSync(f.environmentPath, "utf8")).toBe(before + '\n\nAGENT_TOKEN="' + token.replaceAll("\\", "\\\\").replaceAll('"', '\\"') + '"\n');
+    expect(statSync(f.environmentPath).mode & 0o777).toBe(0o640);
+    expect(readFileSync(join(f.root, "systemctl.log"), "utf8")).toBe("restart p2pstream-agent\n");
+    expect(f.downloads()).toEqual([]);
+    expect(readdirSync(f.root)).not.toContain("installed-binary");
+  });
+
+  test("token rotation refuses the wrong host without modifying credentials", () => {
+    const f = fixture();
+    const before = readFileSync(f.environmentPath, "utf8");
+    const result = f.run(linuxRotateAgentTokenSnippet({ agentId: "wrong-agent", agentToken: "new-token", agentEnvironmentPath: f.environmentPath }));
+    expect(result.exitCode).not.toBe(0);
+    expect(readFileSync(f.environmentPath, "utf8")).toBe(before);
+    expect(readdirSync(f.root)).not.toContain("systemctl.log");
+  });
+
+  for (const failure of ["source mismatch", "binary mismatch", "missing checksum", "duplicate checksum", "download failure", "invalid latest"]) {
+    test(`does not execute the installer on ${failure}`, () => {
+      const f = fixture();
+      if (failure === "source mismatch") writeFileSync(join(f.assets, f.sourceAsset), "tampered");
+      if (failure === "binary mismatch") writeFileSync(join(f.assets, f.binaryAsset), "tampered");
+      if (failure === "missing checksum") writeFileSync(join(f.assets, "checksums.txt"), "");
+      if (failure === "duplicate checksum") writeFileSync(join(f.assets, "checksums.txt"), f.manifest.repeat(2));
+      const result = f.run(linuxInstallSnippet({ ...input, version: failure === "invalid latest" ? "latest" : input.version }), {
+        ...(failure === "download failure" ? { FAIL_ASSET: f.binaryAsset } : {}),
+        ...(failure === "invalid latest" ? { RESOLVED_VERSION: "../../malicious" } : {}),
+      });
+      expect(result.exitCode).not.toBe(0);
+      expect(result.values).toBeNull();
+    });
+  }
+});


### PR DESCRIPTION
Agent setup required manual token and file-path edits, used inconsistent dialogs, and could generate a localhost Management URL for a remote environment. Deleting a disconnected agent also failed when historical records still referenced it.

Share one setup dialog across installation, repair, and managed-update enrollment, with an editable Management URL and complete commands that download and verify release assets. Repair reuses the host token; token rotation applies only the replacement credential. Managed-update enrollment preserves the existing tunnel configuration and destination policy.

Delete agents transactionally after detaching their connection, stats, and request-history references. Retain historical records, preserve other agents' references, and roll back changes if deletion fails.

Local `make verify` passes: generated files are current, installer lifecycle checks pass, Go tests/vet pass, and all 245 frontend tests plus typecheck and production build pass. Additional verification covers real systemd EnvironmentFile parsing and the shared setup dialog at desktop and mobile widths. Deletion regression tests cover history preservation, rollback, and authorization. Required CI also builds the runtime image.
