### PR TITLE
Fix agent updater slot permissions under hardened systemd units

### DIFF
--- a/docs/operations/managed-agent-updates.md
+++ b/docs/operations/managed-agent-updates.md
@@ -150,6 +150,8 @@ If a host enrolled successfully but shows **Worker stale**, check `systemctl sta
 
 Re-enrolling or repairing an already managed host updates its rescue runner and keeps its existing agent binary and rollback state. Upgrading that binary requires a rollout campaign. A successful repair message alone does not confirm that the agent upgraded; check **Live tunnel** and the campaign result.
 
+If activation reports that the agent service did not become active and rolled back, inspect the agent service journal and the candidate slot permissions. Updater builds through `v0.1.53-staging.86` created the new slot directory with mode `0700`; the activator's `UMask=0077` also restricted the executable to `0700`. The `p2pstream` service user cannot execute that root-owned slot. The corrected updater explicitly applies `0755` to the verified executable and its version directory before promotion, and repairs those permissions on verified existing slots during retry. Its private state still uses the restrictive umask. Install a release containing this correction into each host's pinned rescue updater before attempting further rollouts; changing only the management server or the agent's live binary does not replace that separate runner.
+
 - A failed download, manifest, size, or digest check never reaches the
   privileged helper.
 - A crash during activation is recovered from its fsynced journal and either

--- a/internal/updater/activate.go
+++ b/internal/updater/activate.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"golang.org/x/sys/unix"
 	"p2pstream/internal/agentupdateauth"
 )
 
@@ -216,12 +217,9 @@ func installSlot(paths Paths, release VerifiedRelease, artifact *os.File) (strin
 	}
 	slotDir := filepath.Join(paths.slotsDir(), release.Version)
 	slotPath := filepath.Join(slotDir, "p2pstream")
-	if info, err := os.Lstat(slotPath); err == nil {
-		if !info.Mode().IsRegular() || info.Mode().Perm()&0022 != 0 {
-			return "", errors.New("existing version slot is not a protected regular file")
-		}
-		if err := verifyFile(slotPath, release.Artifact); err != nil {
-			return "", fmt.Errorf("existing version slot does not match release artifact: %w", err)
+	if _, err := os.Lstat(slotDir); err == nil {
+		if err := prepareExistingSlot(slotDir, release.Artifact); err != nil {
+			return "", err
 		}
 		return slotPath, nil
 	} else if !errors.Is(err, os.ErrNotExist) {
@@ -250,11 +248,20 @@ func installSlot(paths Paths, release VerifiedRelease, artifact *os.File) (strin
 		_ = out.Close()
 		return "", err
 	}
+	// The activator runs with UMask=0077, but the agent runs as a separate
+	// unprivileged user. Publish verified executable bytes with explicit modes.
+	if err := out.Chmod(0755); err != nil {
+		_ = out.Close()
+		return "", err
+	}
 	if err := out.Sync(); err != nil {
 		_ = out.Close()
 		return "", err
 	}
 	if err := out.Close(); err != nil {
+		return "", err
+	}
+	if err := os.Chmod(tmpDir, 0755); err != nil {
 		return "", err
 	}
 	if err := syncDir(tmpDir); err != nil {
@@ -264,7 +271,7 @@ func installSlot(paths Paths, release VerifiedRelease, artifact *os.File) (strin
 		if !errors.Is(err, os.ErrExist) {
 			return "", err
 		}
-		if err := verifyFile(slotPath, release.Artifact); err != nil {
+		if err := prepareExistingSlot(slotDir, release.Artifact); err != nil {
 			return "", err
 		}
 	} else {
@@ -276,12 +283,59 @@ func installSlot(paths Paths, release VerifiedRelease, artifact *os.File) (strin
 	return slotPath, nil
 }
 
+// A failed activation may have left a verified slot with the old root-only
+// modes. Repair only that protected slot, after rechecking its artifact.
+func prepareExistingSlot(slotDir string, artifact Artifact) error {
+	fd, err := unix.Open(slotDir, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return fmt.Errorf("open existing version slot directory: %w", err)
+	}
+	dir := os.NewFile(uintptr(fd), slotDir)
+	defer dir.Close()
+	info, err := dir.Stat()
+	if err != nil {
+		return err
+	}
+	if info.Mode().Perm()&0022 != 0 {
+		return errors.New("existing version slot directory is not protected")
+	}
+	f, err := openRegularNoFollow(filepath.Join(slotDir, "p2pstream"), artifact.Size)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	info, err = f.Stat()
+	if err != nil {
+		return err
+	}
+	if info.Mode().Perm()&0022 != 0 {
+		return errors.New("existing version slot is not a protected regular file")
+	}
+	if err := verifyFileContents(f, artifact); err != nil {
+		return fmt.Errorf("existing version slot does not match release artifact: %w", err)
+	}
+	if err := f.Chmod(0755); err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		return err
+	}
+	if err := dir.Chmod(0755); err != nil {
+		return err
+	}
+	return dir.Sync()
+}
+
 func verifyFile(path string, artifact Artifact) error {
 	f, err := openRegularNoFollow(path, artifact.Size)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
+	return verifyFileContents(f, artifact)
+}
+
+func verifyFileContents(f *os.File, artifact Artifact) error {
 	h := sha256.New()
 	n, err := io.Copy(h, io.LimitReader(f, artifact.Size+1))
 	if err != nil {

--- a/internal/updater/slot_permissions_test.go
+++ b/internal/updater/slot_permissions_test.go
@@ -1,0 +1,144 @@
+package updater
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestInstallSlotWithActivatorUmask(t *testing.T) {
+	// Umask is process-wide. Match the root activator's UMask=0077 in a
+	// subprocess so this test cannot affect other filesystem tests.
+	if os.Getenv("P2PSTREAM_TEST_SLOT_UMASK") != "1" {
+		cmd := exec.Command(os.Args[0], "-test.run=^TestInstallSlotWithActivatorUmask$")
+		cmd.Env = append(os.Environ(), "P2PSTREAM_TEST_SLOT_UMASK=1")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("activator umask regression: %v\n%s", err, output)
+		}
+		return
+	}
+	previousMask := unix.Umask(0077)
+	defer unix.Umask(previousMask)
+	for _, reuse := range []bool{false, true} {
+		name := "new_slot"
+		if reuse {
+			name = "retry_legacy_slot"
+		}
+		t.Run(name, func(t *testing.T) {
+			f := newFixture(t)
+			stageFixture(t, f)
+			slotDir := filepath.Join(f.paths.slotsDir(), f.release.Version)
+			slotPath := filepath.Join(slotDir, "p2pstream")
+			if reuse {
+				if err := os.Mkdir(slotDir, 0700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(slotPath, f.body, 0700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			artifact, err := os.Open(filepath.Join(f.paths.candidateDir(), "artifact.bin"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer artifact.Close()
+			if _, err := installSlot(f.paths, f.release, artifact); err != nil {
+				t.Fatal(err)
+			}
+			// The service runs as p2pstream, not the root activator. Both the
+			// directory and executable must allow that separate user access.
+			for _, path := range []string{slotDir, slotPath} {
+				info, err := os.Stat(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if info.Mode().Perm() != 0755 {
+					t.Errorf("%s permissions = %04o, want 0755 for the unprivileged agent service", filepath.Base(path), info.Mode().Perm())
+				}
+			}
+			if err := verifyFile(slotPath, f.release.Artifact); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestInstallSlotRejectsUnsafeExistingSlotBeforeChangingPermissions(t *testing.T) {
+	for _, kind := range []string{"corrupt", "writable_file", "writable_directory", "symlink_directory", "symlink_file", "hardlink_file"} {
+		t.Run(kind, func(t *testing.T) {
+			f := newFixture(t)
+			stageFixture(t, f)
+			slotDir := filepath.Join(f.paths.slotsDir(), f.release.Version)
+			realDir := slotDir
+			if kind == "symlink_directory" {
+				realDir = filepath.Join(f.paths.slotsDir(), "redirected")
+			}
+			if err := os.Mkdir(realDir, 0700); err != nil {
+				t.Fatal(err)
+			}
+			if realDir != slotDir {
+				if err := os.Symlink(realDir, slotDir); err != nil {
+					t.Fatal(err)
+				}
+			}
+			binaryPath := filepath.Join(realDir, "p2pstream")
+			data := f.body
+			if kind == "corrupt" {
+				data = bytes.Repeat([]byte("!"), len(f.body))
+			}
+			if err := os.WriteFile(binaryPath, data, 0700); err != nil {
+				t.Fatal(err)
+			}
+			dirMode, fileMode := os.FileMode(0700), os.FileMode(0700)
+			switch kind {
+			case "writable_file":
+				fileMode = 0777
+				if err := os.Chmod(binaryPath, fileMode); err != nil {
+					t.Fatal(err)
+				}
+			case "writable_directory":
+				dirMode = 0777
+				if err := os.Chmod(realDir, dirMode); err != nil {
+					t.Fatal(err)
+				}
+			case "symlink_file", "hardlink_file":
+				otherPath := filepath.Join(realDir, "other")
+				if err := os.Rename(binaryPath, otherPath); err != nil {
+					t.Fatal(err)
+				}
+				link := os.Link
+				if kind == "symlink_file" {
+					link = os.Symlink
+				}
+				if err := link(otherPath, binaryPath); err != nil {
+					t.Fatal(err)
+				}
+			}
+			artifact, err := os.Open(filepath.Join(f.paths.candidateDir(), "artifact.bin"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer artifact.Close()
+			if _, err := installSlot(f.paths, f.release, artifact); err == nil {
+				t.Fatal("unsafe existing slot was accepted")
+			}
+			for path, mode := range map[string]os.FileMode{realDir: dirMode, binaryPath: fileMode} {
+				info, err := os.Stat(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if info.Mode().Perm() != mode {
+					t.Errorf("%s permissions changed to %04o", path, info.Mode().Perm())
+				}
+			}
+			current, err := currentTarget(f.paths)
+			if err != nil || current != f.bootstrap.Target {
+				t.Fatalf("live slot changed: %q, %v", current, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Managed agent activation created root-only version directories and executables under the activator's `UMask=0077`. The agent service runs as `p2pstream`, so it could not start the candidate and the updater rolled back after the health timeout.

Set explicit `0755` permissions on verified binaries and version directories before promotion. On retry, reverify an existing protected slot before repairing permissions left by affected updater versions. Keep the restrictive umask for private updater state, and reject corrupt artifacts, writable slots, symlinks, and hard-linked executables before changing permissions.

Document that this correction must reach the separately pinned host updater; replacing only the management server or live agent binary does not install it.

Validation:
- `make verify`: generated code, installer lifecycle tests, all Go tests/vet, frontend tests/typecheck/build.
- Regression tests reproduce the production umask in a subprocess and cover new slots, existing failed slots, and rejection of unsafe or corrupt slots without changing their permissions or the current agent.
- The permissions regression failed before the patch and passed afterward. Live host journal confirmation remains separate from the reproduced code defect.
