### PR TITLE
Fix managed update recovery and repeated rollouts

### DIFF
--- a/cmd/agentupdate-manifest/compatibility_floor_test.go
+++ b/cmd/agentupdate-manifest/compatibility_floor_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"p2pstream/internal/agentupdate"
+)
+
+func TestCreateAppliesFixedUpdaterCompatibilityFloor(t *testing.T) {
+	for _, test := range []struct {
+		name, version, configured, want string
+	}{
+		{"first corrected release", "v0.1.53-staging.88", "v0.1.52", "v0.1.53-staging.88"},
+		{"later release keeps compatible runner", "v0.1.53-staging.89", "v0.1.52", "v0.1.53-staging.88"},
+		{"numeric prerelease ordering", "v0.1.53-staging.100", "v0.1.53-staging.99", "v0.1.53-staging.99"},
+		{"stricter configured floor retained", "v0.1.54-staging.1", "v0.1.53", "v0.1.53"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			directory := t.TempDir()
+			artifactPath := filepath.Join(directory, "p2pstream_"+test.version+"_linux_amd64")
+			output := filepath.Join(directory, "manifest.json")
+			if err := os.WriteFile(artifactPath, []byte("test executable"), 0755); err != nil {
+				t.Fatal(err)
+			}
+			err := run([]string{
+				"create", "--channel", "staging", "--version", test.version, "--commit", strings.Repeat("a", 40), "--sequence", "88",
+				"--published-at", "2026-09-11T00:00:00Z", "--expires-at", "2026-10-11T00:00:00Z",
+				"--minimum-safe-version", "v0.1.52", "--security-epoch", "1",
+				"--server-min", "v0.1.52", "--server-max", "v0.1.999", "--protocol-min", "1", "--protocol-max", "1",
+				"--updater-min", test.configured, "--updater-max", "v0.1.999", "--artifact", "linux/amd64=" + artifactPath,
+				"--output", output,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			data, err := os.ReadFile(output)
+			if err != nil {
+				t.Fatal(err)
+			}
+			manifest, err := agentupdate.ParseManifest(data)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if manifest.Compatibility.Updater.Min != test.want {
+				t.Fatalf("manifest minimum updater = %s, want %s", manifest.Compatibility.Updater.Min, test.want)
+			}
+		})
+	}
+}
+
+func TestCreateRejectsImpossibleOrMalformedUpdaterCompatibility(t *testing.T) {
+	for _, test := range []struct{ minimum, maximum string }{
+		{"v0.1.52", "v0.1.53-staging.87"},
+		{"v0.1.54", "v0.1.53"},
+		{"", "v0.1.999"},
+		{"v0.1", "v0.1.999"},
+		{"v0.1.52", "v0.1.53-staging.088"},
+	} {
+		t.Run(test.minimum+"/"+test.maximum, func(t *testing.T) {
+			output := filepath.Join(t.TempDir(), "manifest.json")
+			err := run([]string{"create", "--updater-min", test.minimum, "--updater-max", test.maximum, "--output", output})
+			if err == nil || !strings.Contains(err.Error(), "updater compatibility") {
+				t.Fatalf("error = %v, want updater compatibility rejection", err)
+			}
+			if _, err := os.Stat(output); !os.IsNotExist(err) {
+				t.Fatal("invalid compatibility wrote a release manifest")
+			}
+		})
+	}
+}

--- a/cmd/agentupdate-manifest/main.go
+++ b/cmd/agentupdate-manifest/main.go
@@ -16,7 +16,13 @@ import (
 	"time"
 
 	"p2pstream/internal/agentupdate"
+	"p2pstream/internal/releaseversion"
 )
+
+// The first rescue runner containing the durable receipt, readable-floor and
+// privileged-slot fixes. Keep this fixed across later releases: a compatible
+// pinned updater must not require re-enrollment for every new tunnel version.
+const minimumSupportedUpdaterVersion = "v0.1.53-staging.88"
 
 type artifactFlags []string
 
@@ -221,6 +227,10 @@ func runCreate(arguments []string) error {
 	if *protocolMin > uint(^uint32(0)) || *protocolMax > uint(^uint32(0)) {
 		return errors.New("protocol version exceeds uint32")
 	}
+	updaterRange, err := supportedUpdaterRange(*updaterMin, *updaterMax)
+	if err != nil {
+		return err
+	}
 	manifestArtifacts := make([]agentupdate.Artifact, 0, len(artifacts))
 	for _, specification := range artifacts {
 		artifact, err := inspectArtifact(specification)
@@ -267,7 +277,7 @@ func runCreate(arguments []string) error {
 		Compatibility: agentupdate.Compatibility{
 			Server:   agentupdate.VersionRange{Min: *serverMin, Max: *serverMax},
 			Protocol: agentupdate.ProtocolRange{Min: uint32(*protocolMin), Max: uint32(*protocolMax)},
-			Updater:  agentupdate.VersionRange{Min: *updaterMin, Max: *updaterMax},
+			Updater:  updaterRange,
 		},
 		Artifacts:     manifestArtifacts,
 		OCIImages:     manifestOCIImages,
@@ -278,6 +288,19 @@ func runCreate(arguments []string) error {
 		return fmt.Errorf("create manifest: %w", err)
 	}
 	return writeExclusive(*output, data, 0o644)
+}
+
+func supportedUpdaterRange(minimum, maximum string) (agentupdate.VersionRange, error) {
+	if !releaseversion.Valid(minimum) || !releaseversion.Valid(maximum) {
+		return agentupdate.VersionRange{}, errors.New("updater compatibility requires canonical SemVer bounds")
+	}
+	if releaseversion.Compare(minimum, minimumSupportedUpdaterVersion) < 0 {
+		minimum = minimumSupportedUpdaterVersion
+	}
+	if releaseversion.Compare(minimum, maximum) > 0 {
+		return agentupdate.VersionRange{}, fmt.Errorf("updater compatibility maximum %s is below required minimum %s", maximum, minimum)
+	}
+	return agentupdate.VersionRange{Min: minimum, Max: maximum}, nil
 }
 
 func inspectReleaseAsset(path string) (agentupdate.ReleaseAsset, error) {

--- a/docs/operations/managed-agent-updates.md
+++ b/docs/operations/managed-agent-updates.md
@@ -146,6 +146,12 @@ decisions.
 
 ## Failure and recovery
 
+Cancelling a campaign does not immediately release hosts with an outstanding activation authorization. They remain cordoned and reserved until the privileged updater attests rollback and the agent establishes a fresh tunnel. A blocked host in a cancelled campaign can use **Recover agents** (called **Retry** in older interfaces) to request recovery. When rollback is already pending, wait for the updater instead of retrying the same assignment again. A paused campaign must be resumed or cancelled before its queued rollback can execute.
+
+After verified recovery, the historical assignment remains **failed**, with desired action **none** and traffic eligible. That host can be selected in **Plan rollout** again. If the updater is stale or rollback times out, inspect the updater and activator service journals on the host; cancelling or refreshing the browser cannot replace that missing host evidence. Management builds through `v0.1.53-staging.87` also rejected rollback results for assignments left in the blocked phase by cancellation. The corrected report handler accepts those administrator-authorized recovery results while retaining root signature validation and the fresh-tunnel requirement.
+
+If the worker journal repeats `root action report does not match its signed result receipt`, updater builds through `v0.1.53-staging.87` omitted the restored version, commit, and digests from the rollback report envelope, even though the signed root receipt contained them. The worker retries this durable result before polling, so restarting it cannot clear the loop. Upgrade management to a build containing the rollback-report compatibility fix: it accepts the all-empty legacy envelope only for rollback, verifies the signed receipt normally, and records the receipt's result. New updater builds also fill the envelope correctly. If the assignment already reached `root_action_timeout`, use **Recover agents** after upgrading management; the obsolete result can then be acknowledged without releasing the traffic fence, and the worker can obtain a new signed rollback. Do not delete or edit host receipts, rotate the agent token, or reinstall the live agent to clear this reporting error. The separate pinned-updater permission fix described below is still required before retrying activation on an old rescue runner.
+
 If a host enrolled successfully but shows **Worker stale**, check `systemctl status p2pstream-updater.service` and its journal. Releases through `v0.1.53-staging.85` installed units with an obsolete `ConditionPathExists=/etc/p2pstream-updater/root.json` requirement. The current updater provisions `updater.json`, `enrolled.json`, and `management-authority.json`; it does not create `root.json`. Replace that exact obsolete condition with `ConditionPathExists=/etc/p2pstream-updater/updater.json` in both updater service files, reload systemd, restart the updater timer and activation path, and start `p2pstream-updater.service`. Keep the enrollment and management-authority conditions. No token rotation or changes to agent destination permissions are needed.
 
 Re-enrolling or repairing an already managed host updates its rescue runner and keeps its existing agent binary and rollback state. Upgrading that binary requires a rollout campaign. A successful repair message alone does not confirm that the agent upgraded; check **Live tunnel** and the campaign result.
@@ -186,3 +192,51 @@ validity, security/minimum-safe, server/updater/protocol compatibility, and
 current-protocol repository variables listed in
 `internal/agentupdate/README.md`. Docker deployments that require immutable
 rollbacks should pin the version tag or OCI digest rather than a channel alias.
+
+## Verification
+
+The manifest generator enforces the repository's minimum supported pinned
+updater, `v0.1.53-staging.88`. It takes the higher of this floor and the configured
+`AGENT_UPDATE_UPDATER_MIN_VERSION`, and rejects an incompatible maximum. The
+floor stays fixed for later tunnel releases, so a corrected `.88` updater can
+install subsequent compatible releases without another repair. Updater range
+bounds accept canonical SemVer prereleases; server compatibility and minimum
+safe-version bounds keep their existing stable-version rules. Upgrade
+management first, complete any pending recovery, then repair older pinned
+updaters before starting the next rollout. Older management builds reject a
+manifest containing the new prerelease updater bound until management itself
+is upgraded.
+
+Run the real service lifecycle test on a Linux amd64 workstation with Go and
+Multipass installed:
+
+```sh
+scripts/test-managed-updates-systemd.sh
+```
+
+The script builds the current source and an actual `.84` worker, creates a
+disposable Ubuntu 24.04 VM, and uses the production installer, service users,
+systemd hardening, updater/activator executables, authenticated management
+handlers, and agent tunnels. It verifies upgrades, signed cancellation
+rollback, legacy worker reporting, lost-response retry, pinned updater repair
+after verified recovery, recovery from an exhausted systemd crash limit, and a
+subsequent rollout to the same cancelled target.
+Success checks include the real agent
+process executable, reported build, released traffic fence, and unchanged
+agent token/network configuration. It independently checks the repaired pinned
+binary and its enrolled updater version. A VM-local TLS mirror supplies fixture
+artifacts through the normal download and digest-verification path.
+
+Logs are retained under `tmp/managed-updates-systemd` and a VM created by the
+script is removed afterward. Set `P2PSTREAM_SYSTEMD_OUTPUT_DIR` for another log
+directory. `P2PSTREAM_SYSTEMD_VM_NAME` may select an existing disposable VM named
+`p2pstream-update-review...`; it must have no agent installation and is retained
+for inspection. The harness refuses to provision the workstation.
+
+This test covers one Linux amd64 agent. It does not simulate a multi-agent
+route quorum, active routed request draining, ARM64, production GitHub/OCI
+publication, or a pre-existing host's arbitrary configuration. Candidate
+binaries use the same current source with distinct build identities; the old
+worker uses its historical source while the privileged activator stays fixed.
+Unit and lifecycle tests cover additional state transitions and failure
+injection, and a production rollout still begins with a canary.

--- a/docs/operations/managed-updates-review-2026-09-11.md
+++ b/docs/operations/managed-updates-review-2026-09-11.md
@@ -1,0 +1,88 @@
+# Managed updates pre-staging review — 2026-09-11
+
+Scope: the pending changes on top of staging commit
+`6e529c0fc2c3615134e5fc47a2ba74c30826ca97`, following failures on
+`v0.1.53-staging.84`–`.87`. This review does not publish a release or modify the
+remote fleet.
+
+## Review method
+
+Three independent agents reviewed management recovery, host execution, and
+UI/release compatibility. Follow-up passes cross-reviewed the fixes. The parent
+added a disposable Ubuntu 24.04 Multipass test using the actual installer,
+systemd services, separate Unix identities, signed management API, release
+verification, and real agent tunnels. Docker additionally exercised host tests
+as root with an unprivileged floor reader.
+
+The VM test exposed an activation handoff race that the original unit tests did
+not catch: a worker poll while the privileged helper finished could enqueue the
+same activation again. The helper rejected that duplicate, and its failure
+report replaced an already accepted successful activation. This became an
+additional regression gate.
+
+## Findings addressed
+
+| Area | Failure | Correction and evidence |
+| --- | --- | --- |
+| Legacy recovery | The `.84` worker omitted four duplicated rollback fields, although its signed root receipt included the result. | Accept only the completely empty legacy rollback envelope with a verified, matching root receipt. Reject conflicting/partial fields. Tests exercise lost responses and replay counters. |
+| Cancellation | Cancelling a blocked or incompletely proven rollback released the traffic fence. | Preserve the fence until a verified result and fresh matching tunnel prove recovery; pre-authorization cancellation still releases safely. |
+| Retry deadlines | New rollback generations retained old completed root evidence and escaped the new action deadline. | Clear generation-local evidence while preserving identity replay floors; recognize legacy persisted pending recovery. |
+| Management restart | Cached authorization and the reported management build could disagree after a generation or server upgrade. | Validate cached command context; use the signed server version for outstanding privileged commands and reverify staged metadata when the first command uses a newer server. |
+| Unix permissions | Atomic root writes changed the floor to `root:root`, preventing the worker from staging another update. | Preserve updater-group read access while keeping the floor root-owned. Test with an actual unprivileged UID. |
+| Repeated target | A healthy activation followed by rollback made the same target fail strict version/sequence floors. | Permit only an exact previously activated manifest hash at the equal floor. Keep signature, compatibility, expiry, epoch and minimum-safe checks. Migrate older floors only from authenticated matching evidence. |
+| Duplicate commands | Repeated rollback commands restarted services and minted different receipts; repeated activation could turn success into failure. | Authenticate completed-command replay and republish its original result without re-execution. Reject substituted or superseded commands. Management preserves accepted proof against obsolete execution-failure reports while retaining real health-failure quarantine. |
+| Shared staging files | Cleanup for an old completed command could remove the next campaign's staged files before its ready marker existed. | Coordinate with the existing worker lock and require a matching live command before deleting shared files. Retain unarmed candidates, including identical-target candidates for a new generation. |
+| Recovery slot | Reactivating the running target could overwrite its distinct fallback with itself. | Preserve the authenticated previous slot. Exclude an already-running exact version and commit from new campaign previews. |
+| First enrollment | A newer rescue updater raised the initial tunnel floor above the preserved old live agent. | Seed the tunnel floor from the actual preserved live build; track rescue compatibility separately. |
+| Repair concurrency | Bootstrap changed shared state before stopping updater writers. | Stop triggers, then activator, then worker; refuse still-active writers. Serialize root bootstrap and worker enrollment with their respective locks. |
+| Service recovery | Successful helper invocations exhausted systemd's five-start limit, leaving the following rollout stuck even after repair. | Keep successful commands from exhausting the crash budget and restore failed updater units during a completed repair. Exercise repeated real systemd actions in the VM. |
+| UI state | Recovery history could disappear behind terminal history; polling and mixed retry/recovery controls obscured state. | Prioritize unresolved campaigns, poll with environment isolation, preserve draft inputs, separate recovery from stage retry, keep errors beside the action, and wrap narrow layouts. |
+| Release compatibility | The configured minimum still admitted known-broken old rescue runners. | Manifest generation enforces a fixed minimum `v0.1.53-staging.88`, or a stricter configured minimum. Later tunnel releases retain this fixed baseline. |
+
+## Verification record
+
+| Check | Result | Local evidence |
+| --- | --- | --- |
+| `go test ./...` | Passed, including server and integration suites | `tmp/deep-review-go-test.log` |
+| Focused race tests across updater, release verification, signed protocol and management | Passed; server portion 106.823 seconds | `tmp/deep-review-race.log` |
+| `go vet ./...` and final harness vet | Passed | `tmp/deep-review-vet.log`, `tmp/deep-review-harness-vet.log` |
+| Frontend tests | 257 tests / 904 assertions passed | `/tmp/p2pstream-ui-deep-review-tests.log` |
+| Frontend typecheck and production build | Passed | `/tmp/p2pstream-review-final-build.log` |
+| Installer lifecycle suite and shell syntax | Passed | `tmp/deep-review-lifecycle.log` |
+| Real Multipass/systemd lifecycle | Passed in 91.45 seconds on Ubuntu 24.04 amd64 | `tmp/managed-updates-systemd/test.log`, `tmp/managed-updates-systemd/systemd-journal.log` |
+| Code generation | Passed; generated files unchanged | `tmp/deep-review-generate.log` |
+| Browser check of the existing remote-environment view | No horizontal overflow at 375, 900 and 1174 pixels; polling refreshed status and preserved a custom open planner draft | Read-only browser interaction; no campaign submitted |
+
+The repeatable VM entry point is `scripts/test-managed-updates-systemd.sh`.
+Its final run completed installation and enrollment, upgrade to `v1.1.0`,
+activation of `v1.2.0`, signed cancellation rollback with the historical `.84`
+worker, loss and retry of an already accepted rollback response, and recovery
+of the previous live tunnel. It then proved six failed start attempts executed
+only five helper processes, repaired the pinned updater without resetting the
+failed unit manually, and successfully rolled out the same `v1.2.0` target.
+Assertions verified process paths, signed evidence, fresh tunnels, floor read
+permissions, pinned binary digest, enrolled updater version, and unchanged agent
+credentials/network configuration. No production fleet action was submitted.
+The disposable VM was removed after collecting the logs.
+
+## Limits and deployment order
+
+The VM covers Linux amd64 and one agent, with current-source binaries stamped
+with distinct test build identities. The historical `.84` source supplies the
+legacy worker while the privileged helper uses the fix. A VM-local TLS mirror
+stands in for GitHub artifact hosting. This does not prove ARM64, real GitHub/OCI
+publication, multi-host route quorum, active proxied traffic draining, arbitrary
+existing machine configuration, or VM reboot/power-loss behavior. Unit tests
+cover additional quorum, drain, timeout and interrupted-journal paths.
+
+Upgrade management first so it can accept legacy recovery receipts and parse
+the new updater compatibility bound. Complete pending recovery, then repair
+older pinned updaters, preserving the agent token, live binary and network
+policy. Start with a canary before wider rollout. A machine whose worker remains
+stale must be diagnosed before it can provide recovery proof; a management-only
+release cannot repair an unreachable host process.
+
+The intended first corrected updater is `.88`; confirm that tag contains these
+fixes when publishing. If another release consumes that tag first, move the fixed
+minimum to the first release that actually contains the corrections. Re-run the
+VM gate before staging changes to execution, recovery, enrollment or units.

--- a/internal/agentupdate/manifest.go
+++ b/internal/agentupdate/manifest.go
@@ -219,7 +219,7 @@ func validateManifest(manifest Manifest) error {
 	if err := validateVersionRange(manifest.Compatibility.Server); err != nil {
 		return fmt.Errorf("invalid server compatibility: %w", err)
 	}
-	if err := validateVersionRange(manifest.Compatibility.Updater); err != nil {
+	if err := validateUpdaterVersionRange(manifest.Compatibility.Updater); err != nil {
 		return fmt.Errorf("invalid updater compatibility: %w", err)
 	}
 	if manifest.Compatibility.Protocol.Min == 0 || manifest.Compatibility.Protocol.Max < manifest.Compatibility.Protocol.Min {
@@ -320,6 +320,19 @@ func validateVersionRange(versionRange VersionRange) error {
 	}
 	if err := validateStableVersion(versionRange.Max); err != nil {
 		return err
+	}
+	if releaseversion.Compare(versionRange.Min, versionRange.Max) > 0 {
+		return errors.New("minimum version exceeds maximum version")
+	}
+	return nil
+}
+
+// Updater fixes may first ship in an immutable staging release. A prerelease
+// bound lets a manifest exclude broken earlier runners without excluding the
+// corrected staging runner until the next stable release.
+func validateUpdaterVersionRange(versionRange VersionRange) error {
+	if !releaseversion.Valid(versionRange.Min) || !releaseversion.Valid(versionRange.Max) {
+		return errors.New("version must be canonical SemVer")
 	}
 	if releaseversion.Compare(versionRange.Min, versionRange.Max) > 0 {
 		return errors.New("minimum version exceeds maximum version")

--- a/internal/agentupdate/retry_test.go
+++ b/internal/agentupdate/retry_test.go
@@ -1,0 +1,96 @@
+package agentupdate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestVerifyExactActivatedManifestRetry(t *testing.T) {
+	for _, channel := range []string{"stable", "staging"} {
+		t.Run(channel, func(t *testing.T) {
+			manifestJSON, _ := testBundle(t, channel)
+			manifest, err := ParseManifest(manifestJSON)
+			if err != nil {
+				t.Fatal(err)
+			}
+			policy := testPolicy()
+			policy.RequiredChannel = channel
+			policy.CurrentSequence = manifest.Sequence
+			policy.CurrentVersion = manifest.Version
+			digest := sha256.Sum256(manifestJSON)
+			policy.CurrentManifestSHA256 = hex.EncodeToString(digest[:])
+			if _, err := Verify(manifestJSON, policy); err != nil {
+				t.Fatalf("exact activated manifest cannot be retried: %v", err)
+			}
+		})
+	}
+}
+
+func TestExactManifestRetryRetainsFloorsAndCompatibility(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*VerifyPolicy)
+	}{
+		{"empty pin", func(p *VerifyPolicy) { p.CurrentManifestSHA256 = "" }},
+		{"different pin", func(p *VerifyPolicy) { p.CurrentManifestSHA256 = strings.Repeat("f", 64) }},
+		{"lower sequence", func(p *VerifyPolicy) { p.CurrentSequence++ }},
+		{"lower version", func(p *VerifyPolicy) { p.CurrentVersion = "v1.2.4" }},
+		{"higher sequence same version", func(p *VerifyPolicy) { p.CurrentSequence-- }},
+		{"same sequence higher version", func(p *VerifyPolicy) { p.CurrentVersion = "v1.2.2" }},
+		{"epoch floor", func(p *VerifyPolicy) { p.CurrentSecurityEpoch = 3 }},
+		{"minimum safe floor", func(p *VerifyPolicy) { p.CurrentMinimumSafeVersion = "v1.1.0" }},
+		{"expiry", func(p *VerifyPolicy) { p.Now = time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC) }},
+		{"server compatibility", func(p *VerifyPolicy) { p.ServerVersion = "v2.1.0" }},
+		{"updater compatibility", func(p *VerifyPolicy) { p.UpdaterVersion = "v0.9.0" }},
+		{"protocol compatibility", func(p *VerifyPolicy) { p.ProtocolVersion = 3 }},
+		{"channel", func(p *VerifyPolicy) { p.RequiredChannel = "staging" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			data, _ := testBundle(t, "stable")
+			policy := testPolicy()
+			policy.CurrentSequence = 10203
+			policy.CurrentVersion = "v1.2.3"
+			digest := sha256.Sum256(data)
+			policy.CurrentManifestSHA256 = hex.EncodeToString(digest[:])
+			test.mutate(&policy)
+			if _, err := Verify(data, policy); err == nil {
+				t.Fatal("exact-target retry bypassed a required trust/compatibility check")
+			}
+		})
+	}
+}
+
+func TestExactManifestRetryRejectsChangedReleaseIdentity(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*Manifest)
+	}{
+		{"commit", func(m *Manifest) { m.Commit = strings.Repeat("b", 40) }},
+		{"artifact", func(m *Manifest) { m.Artifacts[0].SHA256 = strings.Repeat("e", 64) }},
+		{"epoch", func(m *Manifest) { m.SecurityEpoch++ }},
+		{"metadata expiry", func(m *Manifest) { m.ExpiresAt = "2026-02-02T00:00:00Z" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			data, _ := testBundle(t, "stable")
+			manifest, err := ParseManifest(data)
+			if err != nil {
+				t.Fatal(err)
+			}
+			policy := testPolicy()
+			policy.CurrentSequence, policy.CurrentVersion = manifest.Sequence, manifest.Version
+			digest := sha256.Sum256(data)
+			policy.CurrentManifestSHA256 = hex.EncodeToString(digest[:])
+			test.mutate(&manifest)
+			changed, err := CanonicalManifest(manifest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Verify(changed, policy); err == nil {
+				t.Fatal("same-target retry accepted altered manifest bytes")
+			}
+		})
+	}
+}

--- a/internal/agentupdate/updater_compatibility_test.go
+++ b/internal/agentupdate/updater_compatibility_test.go
@@ -1,0 +1,68 @@
+package agentupdate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPrereleaseUpdaterFloorRejectsOldRunnerAndAllowsLaterRollouts(t *testing.T) {
+	data, _ := testBundle(t, "staging")
+	manifest, err := ParseManifest(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest.Compatibility.Updater = VersionRange{Min: "v0.1.53-staging.88", Max: "v0.1.999"}
+	data, err = CanonicalManifest(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		updater string
+		wantOK  bool
+	}{
+		{"v0.1.52", false},
+		{"v0.1.53-staging.84", false},
+		{"v0.1.53-staging.87", false},
+		{"v0.1.53-staging.88", true},
+		{"v0.1.53-staging.89", true},
+		{"v0.1.53-staging.100", true},
+		{"v0.1.53", true},
+	} {
+		t.Run(test.updater, func(t *testing.T) {
+			policy := testPolicy()
+			policy.RequiredChannel = "staging"
+			policy.UpdaterVersion = test.updater
+			_, err := Verify(data, policy)
+			if test.wantOK && err != nil {
+				t.Fatalf("compatible updater rejected: %v", err)
+			}
+			if !test.wantOK && (err == nil || !strings.Contains(err.Error(), "updater version is outside")) {
+				t.Fatalf("old updater rejection = %v", err)
+			}
+		})
+	}
+}
+
+func TestUpdaterCompatibilityPrereleaseBoundsRemainStrict(t *testing.T) {
+	data, _ := testBundle(t, "stable")
+	base, err := ParseManifest(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, bounds := range []VersionRange{
+		{Min: "v0.1.53-staging.089", Max: "v0.1.999"},
+		{Min: "v0.1.53-staging.89", Max: "v0.1.53-staging.88"},
+		{Min: "v0.1.53+mutable", Max: "v0.1.999"},
+		{Min: "v0.1", Max: "v0.1.999"},
+	} {
+		manifest := base
+		manifest.Compatibility.Updater = bounds
+		if _, err := CanonicalManifest(manifest); err == nil || !strings.Contains(err.Error(), "updater compatibility") {
+			t.Fatalf("bounds %+v accepted: %v", bounds, err)
+		}
+	}
+	base.Compatibility.Server.Min = "v0.1.53-staging.88"
+	if _, err := CanonicalManifest(base); err == nil || !strings.Contains(err.Error(), "server compatibility") {
+		t.Fatalf("updater range change unexpectedly widened server range validation: %v", err)
+	}
+}

--- a/internal/agentupdate/verify.go
+++ b/internal/agentupdate/verify.go
@@ -26,11 +26,14 @@ type VerifyPolicy struct {
 	CurrentSecurityEpoch      uint64
 	CurrentMinimumSafeVersion string
 	CurrentVersion            string
-	ServerVersion             string
-	UpdaterVersion            string
-	ProtocolVersion           uint32
-	GOOS                      string
-	GOARCH                    string
+	// CurrentManifestSHA256 pins an already activated release. Only those exact
+	// bytes may be retried at the equal version/sequence floor after rollback.
+	CurrentManifestSHA256 string
+	ServerVersion         string
+	UpdaterVersion        string
+	ProtocolVersion       uint32
+	GOOS                  string
+	GOARCH                string
 }
 
 type VerifiedManifest struct {
@@ -114,7 +117,9 @@ func Verify(manifestJSON []byte, policy VerifyPolicy) (*VerifiedManifest, error)
 		return nil, err
 	}
 	manifest := verified.Manifest
-	if manifest.Sequence <= policy.CurrentSequence {
+	exactRetry := policy.CurrentSequence > 0 && manifest.Sequence == policy.CurrentSequence &&
+		manifest.Version == policy.CurrentVersion && policy.CurrentManifestSHA256 == verified.ManifestSHA256
+	if manifest.Sequence <= policy.CurrentSequence && !exactRetry {
 		return nil, errors.New("manifest sequence does not advance the persisted sequence")
 	}
 	if manifest.SecurityEpoch < policy.CurrentSecurityEpoch {
@@ -131,7 +136,7 @@ func Verify(manifestJSON []byte, policy VerifyPolicy) (*VerifiedManifest, error)
 	if !releaseversion.Valid(policy.CurrentVersion) {
 		return nil, errors.New("invalid current version: version must be canonical SemVer")
 	}
-	if releaseversion.Compare(manifest.Version, policy.CurrentVersion) <= 0 {
+	if releaseversion.Compare(manifest.Version, policy.CurrentVersion) <= 0 && !exactRetry {
 		return nil, errors.New("manifest version does not advance the installed version")
 	}
 	if err := requireVersionInRange("server", policy.ServerVersion, manifest.Compatibility.Server); err != nil {

--- a/internal/server/agent_update_cancel_recovery_test.go
+++ b/internal/server/agent_update_cancel_recovery_test.go
@@ -1,0 +1,198 @@
+package server
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"slices"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/proto"
+
+	p2pstreamv1 "p2pstream/gen/proto/p2pstream/v1"
+	"p2pstream/internal/agentupdateauth"
+)
+
+func TestCancelledBlockedAgentUpdateAcceptsRollbackRecovery(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		rollbackFails bool
+		legacyReport  bool
+		timedOut      bool
+	}{
+		{name: "verified rollback releases assignment after fresh tunnel"},
+		{name: "legacy rollback report uses signed receipt results", legacyReport: true},
+		{name: "legacy rollback recovers after watchdog timeout", legacyReport: true, timedOut: true},
+		{name: "rollback failure remains fenced and can be retried", rollbackFails: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			database := newServerTestDB(t)
+			app := newAgentUpdateTestApp(t, database)
+			agent := createAgentUpdateTestAgent(t, database, "cancel-blocked-recovery")
+			updaterPublic, updaterPrivate, _ := ed25519.GenerateKey(rand.Reader)
+			activatorPublic, activatorPrivate, _ := ed25519.GenerateKey(rand.Reader)
+			insertAgentUpdateIdentity(t, app, database, agent.ID, updaterPublic, activatorPublic)
+			campaignID, assignmentID := insertAgentUpdateTestCampaign(t, database, agent.ID, "staged", "none", false)
+			authorizeAgentUpdateTestActivation(t, app, agent.ID)
+
+			failure := &p2pstreamv1.ReportAgentUpdateRequest{
+				AgentPublicId: agent.PublicID, Counter: 1, AssignmentId: assignmentID, Generation: 1,
+				State:       p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_FAILED,
+				FailureCode: "activation_failed", FailureDetail: "candidate failed health check and was rolled back",
+			}
+			signAgentUpdateTestReport(failure, updaterPrivate)
+			if _, err := app.ReportAgentUpdate(ctx, connect.NewRequest(failure)); err != nil {
+				t.Fatal(err)
+			}
+			assertAgentUpdateAssignmentState(t, database, assignmentID, "blocked")
+
+			header := createTestAdminSession(t, app)
+			cancel := connect.NewRequest(&p2pstreamv1.ChangeAgentUpdateCampaignStateRequest{CampaignId: campaignID, ExpectedGeneration: 2})
+			cancel.Header().Set("Cookie", header.Get("Cookie"))
+			if _, err := app.CancelAgentUpdateCampaign(ctx, cancel); err != nil {
+				t.Fatal(err)
+			}
+			check := &p2pstreamv1.CheckAgentUpdateRequest{AgentPublicId: agent.PublicID, Counter: 2}
+			check.Signature = ed25519.Sign(updaterPrivate, agentupdateauth.CheckPayload(check.AgentPublicId, check.Counter))
+			response, err := app.CheckAgentUpdate(ctx, connect.NewRequest(check))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if response.Msg.DesiredAction != p2pstreamv1.AgentUpdateDesiredAction_AGENT_UPDATE_DESIRED_ACTION_ROLLBACK || response.Msg.Authorization == nil {
+				t.Fatalf("cancel did not authorize recovery: %+v", response.Msg)
+			}
+			preview, err := app.previewAgentUpdateAgents(ctx, []int64{agent.ID}, response.Msg.Target, 1)
+			if err != nil || !slices.Contains(preview[0].Blockers, "active_assignment") || !app.isAgentUpdateCordoned(agent.ID) {
+				t.Fatalf("unconfirmed rollback became eligible: preview=%+v err=%v", preview, err)
+			}
+
+			report := &p2pstreamv1.ReportAgentUpdateRequest{
+				AgentPublicId: agent.PublicID, Counter: 3, AssignmentId: assignmentID, Generation: response.Msg.Generation,
+				State: p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_ROLLED_BACK,
+			}
+			if tc.rollbackFails {
+				report.State = p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_FAILED
+				report.FailureCode = "rollback_failed"
+			} else {
+				receipt := newAgentUpdateTestRootActionReceipt(t, app, agent.ID, activatorPrivate, agentupdateauth.AssignmentActionRollback, 1)
+				if !tc.legacyReport {
+					report.ManifestSha256, report.BinarySha256 = receipt.ResultManifestSha256, receipt.ResultArtifactSha256
+					report.RunningVersion, report.RunningCommit = receipt.ResultVersion, receipt.ResultCommit
+				}
+				report.RootActionReceipt = receipt
+				if tc.legacyReport {
+					partial := proto.Clone(report).(*p2pstreamv1.ReportAgentUpdateRequest)
+					partial.BinarySha256 = receipt.ResultArtifactSha256
+					signAgentUpdateTestReport(partial, updaterPrivate)
+					if _, err := app.ReportAgentUpdate(ctx, connect.NewRequest(partial)); connect.CodeOf(err) != connect.CodeFailedPrecondition {
+						t.Fatalf("partially omitted result accepted: %v", err)
+					}
+				}
+				// The blocked phase must not make an unsigned worker's claim enough
+				// to clear the fence: the root receipt still has to authenticate.
+				receipt.Signature[0] ^= 1
+				signAgentUpdateTestReport(report, updaterPrivate)
+				if _, err := app.ReportAgentUpdate(ctx, connect.NewRequest(report)); connect.CodeOf(err) != connect.CodeUnauthenticated {
+					t.Fatalf("forged rollback receipt accepted: %v", err)
+				}
+				assertAgentUpdateAssignmentState(t, database, assignmentID, "blocked")
+				receipt.Signature[0] ^= 1
+			}
+			if tc.timedOut {
+				old := time.Now().UTC().Add(-agentUpdatePostActionTimeout - time.Second)
+				if _, err := database.ExecContext(ctx, `UPDATE agent_update_assignments SET updated_at=? WHERE id=?`, old, assignmentID); err != nil {
+					t.Fatal(err)
+				}
+				app.reconcileAgentUpdateMaintenance(ctx, time.Now().UTC())
+				signAgentUpdateTestReport(report, updaterPrivate)
+				if _, err := app.ReportAgentUpdate(ctx, connect.NewRequest(report)); connect.CodeOf(err) != connect.CodeFailedPrecondition {
+					t.Fatalf("timed-out rollback bypassed administrator recovery: %v", err)
+				}
+				retry := connect.NewRequest(&p2pstreamv1.RetryAgentUpdateAssignmentsRequest{CampaignId: campaignID, ExpectedCampaignGeneration: 3, AssignmentIds: []int64{assignmentID}})
+				retry.Header().Set("Cookie", header.Get("Cookie"))
+				if _, err := app.RetryAgentUpdateAssignments(ctx, retry); err != nil {
+					t.Fatalf("timed-out recovery could not be retried: %v", err)
+				}
+				// Drain the obsolete durable result without using it as recovery
+				// evidence. The worker can then poll the new signed rollback.
+				ack, err := app.ReportAgentUpdate(ctx, connect.NewRequest(report))
+				if err != nil || ack.Msg.Generation <= report.Generation {
+					t.Fatalf("obsolete receipt blocked polling: %+v, %v", ack, err)
+				}
+				var rootCounter int64
+				if err := database.QueryRowContext(ctx, `SELECT last_root_action_counter FROM agent_updater_identities WHERE agent_id=?`, agent.ID).Scan(&rootCounter); err != nil {
+					t.Fatal(err)
+				}
+				if rootCounter != 0 || !app.isAgentUpdateCordoned(agent.ID) {
+					t.Fatal("obsolete receipt was treated as recovery evidence")
+				}
+				check.Counter = 4
+				check.Signature = ed25519.Sign(updaterPrivate, agentupdateauth.CheckPayload(check.AgentPublicId, check.Counter))
+				response, err = app.CheckAgentUpdate(ctx, connect.NewRequest(check))
+				if err != nil || response.Msg.Authorization == nil || response.Msg.DesiredAction != p2pstreamv1.AgentUpdateDesiredAction_AGENT_UPDATE_DESIRED_ACTION_ROLLBACK {
+					t.Fatalf("new rollback was not issued: %+v, %v", response, err)
+				}
+				report.Generation, report.Counter = response.Msg.Generation, 5
+				report.RootActionReceipt = newAgentUpdateTestRootActionReceipt(t, app, agent.ID, activatorPrivate, agentupdateauth.AssignmentActionRollback, 2)
+			}
+			signAgentUpdateTestReport(report, updaterPrivate)
+			if _, err := app.ReportAgentUpdate(ctx, connect.NewRequest(report)); err != nil {
+				t.Fatalf("cancelled blocked assignment rejected recovery result: %v", err)
+			}
+			if !app.isAgentUpdateCordoned(agent.ID) {
+				t.Fatal("recovery result cleared the fence before a fresh tunnel")
+			}
+			if tc.rollbackFails {
+				assertAgentUpdateAssignmentState(t, database, assignmentID, "blocked")
+				retry := connect.NewRequest(&p2pstreamv1.RetryAgentUpdateAssignmentsRequest{CampaignId: campaignID, ExpectedCampaignGeneration: 3, AssignmentIds: []int64{assignmentID}})
+				retry.Header().Set("Cookie", header.Get("Cookie"))
+				if _, err := app.RetryAgentUpdateAssignments(ctx, retry); err != nil {
+					t.Fatalf("recovery could not be retried: %v", err)
+				}
+				return
+			}
+
+			assertAgentUpdateAssignmentState(t, database, assignmentID, "awaiting_tunnel")
+			// Lost responses must be retryable with the same signed root receipt,
+			// including the incomplete envelope sent by older pinned workers.
+			for _, counter := range []uint64{report.Counter, report.Counter + 1} {
+				report.Counter = counter
+				signAgentUpdateTestReport(report, updaterPrivate)
+				if _, err := app.ReportAgentUpdate(ctx, connect.NewRequest(report)); err != nil {
+					t.Fatalf("rollback receipt retry at counter %d: %v", counter, err)
+				}
+			}
+			mismatch := proto.Clone(report).(*p2pstreamv1.ReportAgentUpdateRequest)
+			mismatch.RunningVersion = "v9.9.9"
+			signAgentUpdateTestReport(mismatch, updaterPrivate)
+			if _, err := app.ReportAgentUpdate(ctx, connect.NewRequest(mismatch)); connect.CodeOf(err) != connect.CodeUnauthenticated {
+				t.Fatalf("mismatched retry accepted: %v", err)
+			}
+			var workerCounter, rootCounter int64
+			var storedVersion, storedCommit, storedBinary string
+			if err := database.QueryRowContext(ctx, `SELECT i.last_counter,i.last_root_action_counter,x.running_version,x.running_commit,x.attested_binary_sha256 FROM agent_update_assignments x JOIN agent_updater_identities i ON i.agent_id=x.agent_id WHERE x.id=?`, assignmentID).Scan(&workerCounter, &rootCounter, &storedVersion, &storedCommit, &storedBinary); err != nil {
+				t.Fatal(err)
+			}
+			if workerCounter != int64(report.Counter) || rootCounter != int64(report.RootActionReceipt.RootActionCounter) || storedVersion != report.RootActionReceipt.ResultVersion || storedCommit != report.RootActionReceipt.ResultCommit || storedBinary != report.RootActionReceipt.ResultArtifactSha256 {
+				t.Fatalf("receipt results/counters were not preserved: %d/%d %q/%q/%q", workerCounter, rootCounter, storedVersion, storedCommit, storedBinary)
+			}
+			var completedAt time.Time
+			if err := database.QueryRowContext(ctx, `SELECT root_action_completed_at FROM agent_update_assignments WHERE id=?`, assignmentID).Scan(&completedAt); err != nil {
+				t.Fatal(err)
+			}
+			conn := &AgentConn{AgentID: agent.ID, PublicID: agent.PublicID, Done: make(chan struct{}), ConnectedAt: completedAt.Add(time.Millisecond)}
+			if err := app.AgentHub.connect(conn); err != nil {
+				t.Fatal(err)
+			}
+			app.recordAgentUpdateFreshTunnel(conn)
+			assertAgentUpdateAssignmentState(t, database, assignmentID, "failed")
+			preview, err = app.previewAgentUpdateAgents(ctx, []int64{agent.ID}, response.Msg.Target, 1)
+			if err != nil || !preview[0].Eligible || app.isAgentUpdateCordoned(agent.ID) {
+				t.Fatalf("verified recovery still prevents a new rollout: preview=%+v err=%v", preview, err)
+			}
+		})
+	}
+}

--- a/internal/server/agent_update_deep_review_test.go
+++ b/internal/server/agent_update_deep_review_test.go
@@ -1,0 +1,444 @@
+package server
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"database/sql"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	p2pstreamv1 "p2pstream/gen/proto/p2pstream/v1"
+	"p2pstream/internal/agentupdateauth"
+	"p2pstream/internal/buildinfo"
+	"p2pstream/internal/db"
+)
+
+// These regressions exercise transitions through the public updater/admin
+// handlers. SQL is used only to move the server-owned watchdog clock forward.
+type deepRecoveryFixture struct {
+	t                *testing.T
+	app              *App
+	database         *db.DB
+	agent            db.Agent
+	updaterPrivate   ed25519.PrivateKey
+	activatorPrivate ed25519.PrivateKey
+	campaignID       int64
+	assignmentID     int64
+	counter          uint64
+	cookie           string
+}
+
+func newDeepRecoveryFixture(t *testing.T) *deepRecoveryFixture {
+	t.Helper()
+	database := newServerTestDB(t)
+	app := newAgentUpdateTestApp(t, database)
+	agent := createAgentUpdateTestAgent(t, database, "deep-recovery")
+	updaterPublic, updaterPrivate, _ := ed25519.GenerateKey(rand.Reader)
+	activatorPublic, activatorPrivate, _ := ed25519.GenerateKey(rand.Reader)
+	insertAgentUpdateIdentity(t, app, database, agent.ID, updaterPublic, activatorPublic)
+	campaignID, assignmentID := insertAgentUpdateTestCampaign(t, database, agent.ID, "staged", "none", false)
+	authorizeAgentUpdateTestActivation(t, app, agent.ID)
+	return &deepRecoveryFixture{t: t, app: app, database: database, agent: agent, updaterPrivate: updaterPrivate,
+		activatorPrivate: activatorPrivate, campaignID: campaignID, assignmentID: assignmentID,
+		cookie: createTestAdminSession(t, app).Get("Cookie")}
+}
+
+func (f *deepRecoveryFixture) report(state p2pstreamv1.AgentUpdaterReportState, rootCounter uint64) {
+	f.t.Helper()
+	x, _, err := f.app.activeAgentUpdateAssignment(context.Background(), f.agent.ID)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	f.counter++
+	report := &p2pstreamv1.ReportAgentUpdateRequest{AgentPublicId: f.agent.PublicID, Counter: f.counter,
+		AssignmentId: f.assignmentID, Generation: x.Generation, State: state}
+	if state == p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_FAILED {
+		report.FailureCode, report.FailureDetail = "action_failed", "test root action failure"
+	} else {
+		action := agentupdateauth.AssignmentActionActivate
+		if state == p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_ROLLED_BACK {
+			action = agentupdateauth.AssignmentActionRollback
+		}
+		receipt := newAgentUpdateTestRootActionReceipt(f.t, f.app, f.agent.ID, f.activatorPrivate, action, rootCounter)
+		report.RootActionReceipt = receipt
+		report.ManifestSha256, report.BinarySha256 = receipt.ResultManifestSha256, receipt.ResultArtifactSha256
+		report.RunningVersion, report.RunningCommit = receipt.ResultVersion, receipt.ResultCommit
+	}
+	signAgentUpdateTestReport(report, f.updaterPrivate)
+	if _, err := f.app.ReportAgentUpdate(context.Background(), connect.NewRequest(report)); err != nil {
+		f.t.Fatal(err)
+	}
+}
+
+func (f *deepRecoveryFixture) retryResumeAndPoll() {
+	f.t.Helper()
+	campaign, err := f.app.getAgentUpdateCampaignProto(context.Background(), f.campaignID)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	retry := connect.NewRequest(&p2pstreamv1.RetryAgentUpdateAssignmentsRequest{CampaignId: f.campaignID,
+		ExpectedCampaignGeneration: campaign.Generation, AssignmentIds: []int64{f.assignmentID}})
+	retry.Header().Set("Cookie", f.cookie)
+	retried, err := f.app.RetryAgentUpdateAssignments(context.Background(), retry)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	resume := connect.NewRequest(&p2pstreamv1.ChangeAgentUpdateCampaignStateRequest{CampaignId: f.campaignID, ExpectedGeneration: retried.Msg.Campaign.Generation})
+	resume.Header().Set("Cookie", f.cookie)
+	if _, err := f.app.ResumeAgentUpdateCampaign(context.Background(), resume); err != nil {
+		f.t.Fatal(err)
+	}
+	f.counter++
+	check := &p2pstreamv1.CheckAgentUpdateRequest{AgentPublicId: f.agent.PublicID, Counter: f.counter}
+	check.Signature = ed25519.Sign(f.updaterPrivate, agentupdateauth.CheckPayload(check.AgentPublicId, check.Counter))
+	response, err := f.app.CheckAgentUpdate(context.Background(), connect.NewRequest(check))
+	if err != nil || response.Msg.DesiredAction != p2pstreamv1.AgentUpdateDesiredAction_AGENT_UPDATE_DESIRED_ACTION_ROLLBACK || response.Msg.Authorization == nil {
+		f.t.Fatalf("expected authorized rollback: response=%+v err=%v", response, err)
+	}
+}
+
+func TestDeepReviewCancelPreservesUnconfirmedRollbackFence(t *testing.T) {
+	for _, rollbackReceipt := range []bool{false, true} {
+		name := "failed rollback"
+		if rollbackReceipt {
+			name = "rollback awaiting fresh tunnel"
+		}
+		t.Run(name, func(t *testing.T) {
+			f := newDeepRecoveryFixture(t)
+			// Activation escaped but no activation receipt reached management.
+			f.report(p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_FAILED, 0)
+			f.retryResumeAndPoll()
+			if rollbackReceipt {
+				f.report(p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_ROLLED_BACK, 1)
+			} else {
+				f.report(p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_FAILED, 0)
+			}
+			if !f.app.isAgentUpdateCordoned(f.agent.ID) {
+				t.Fatal("fixture should remain fenced before cancel")
+			}
+			campaign, err := f.app.getAgentUpdateCampaignProto(context.Background(), f.campaignID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cancel := connect.NewRequest(&p2pstreamv1.ChangeAgentUpdateCampaignStateRequest{CampaignId: f.campaignID, ExpectedGeneration: campaign.Generation})
+			cancel.Header().Set("Cookie", f.cookie)
+			if _, err := f.app.CancelAgentUpdateCampaign(context.Background(), cancel); err != nil {
+				t.Fatal(err)
+			}
+			var state, action string
+			var cordoned int64
+			if err := f.database.QueryRow(`SELECT state,desired_action,cordoned FROM agent_update_assignments WHERE id=?`, f.assignmentID).Scan(&state, &action, &cordoned); err != nil {
+				t.Fatal(err)
+			}
+			if cordoned != 1 || !f.app.isAgentUpdateCordoned(f.agent.ID) {
+				t.Fatalf("cancel discarded unconfirmed rollback fence: state=%s action=%s cordoned=%d", state, action, cordoned)
+			}
+			if !rollbackReceipt {
+				f.counter++
+				check := &p2pstreamv1.CheckAgentUpdateRequest{AgentPublicId: f.agent.PublicID, Counter: f.counter}
+				check.Signature = ed25519.Sign(f.updaterPrivate, agentupdateauth.CheckPayload(check.AgentPublicId, check.Counter))
+				response, err := f.app.CheckAgentUpdate(context.Background(), connect.NewRequest(check))
+				if err != nil || response.Msg.Authorization == nil || response.Msg.Authorization.Generation != response.Msg.Generation {
+					t.Fatalf("cancel retained a superseded rollback authorization: response=%+v err=%v", response, err)
+				}
+				f.report(p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_ROLLED_BACK, 1)
+			}
+			var completedAt time.Time
+			if err := f.database.QueryRow(`SELECT root_action_completed_at FROM agent_update_assignments WHERE id=?`, f.assignmentID).Scan(&completedAt); err != nil {
+				t.Fatal(err)
+			}
+			conn := &AgentConn{AgentID: f.agent.ID, PublicID: f.agent.PublicID, Done: make(chan struct{}), ConnectedAt: completedAt.Add(time.Millisecond)}
+			if err := f.app.AgentHub.connect(conn); err != nil {
+				t.Fatal(err)
+			}
+			f.app.recordAgentUpdateFreshTunnel(conn)
+			if f.app.isAgentUpdateCordoned(f.agent.ID) {
+				t.Fatal("cancelled recovery could not finish after verified root result and fresh tunnel")
+			}
+		})
+	}
+}
+
+func TestDeepReviewCancelStillReleasesPreAuthorizationDrain(t *testing.T) {
+	database := newServerTestDB(t)
+	app := newAgentUpdateTestApp(t, database)
+	agent := createAgentUpdateTestAgent(t, database, "cancel-preauth-drain")
+	public, _, _ := ed25519.GenerateKey(rand.Reader)
+	rootPublic, _, _ := ed25519.GenerateKey(rand.Reader)
+	insertAgentUpdateIdentity(t, app, database, agent.ID, public, rootPublic)
+	campaignID, assignmentID := insertAgentUpdateTestCampaign(t, database, agent.ID, "staged", "none", false)
+	app.agentUpdateDrainReady = func(int64) bool { return false }
+	x, campaign, err := app.activeAgentUpdateAssignment(context.Background(), agent.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app.tryAdvanceAgentUpdateAssignment(context.Background(), x, campaign)
+	x, _, err = app.activeAgentUpdateAssignment(context.Background(), agent.ID)
+	if err != nil || x.State != "cordoned" || x.DesiredAction != "none" || x.AuthorizationAction != "" || !app.isAgentUpdateCordoned(agent.ID) {
+		t.Fatalf("expected reversible drain: %+v err=%v", x, err)
+	}
+	header := createTestAdminSession(t, app)
+	request := connect.NewRequest(&p2pstreamv1.ChangeAgentUpdateCampaignStateRequest{CampaignId: campaignID, ExpectedGeneration: 1})
+	request.Header().Set("Cookie", header.Get("Cookie"))
+	if _, err := app.CancelAgentUpdateCampaign(context.Background(), request); err != nil {
+		t.Fatal(err)
+	}
+	assertAgentUpdateAssignmentState(t, database, assignmentID, "cancelled")
+	if app.isAgentUpdateCordoned(agent.ID) {
+		t.Fatal("cancellation did not release the reversible pre-authorization drain")
+	}
+}
+
+func TestDeepReviewRetriedRollbackGetsIndependentRootActionDeadline(t *testing.T) {
+	for _, legacyCompletion := range []bool{false, true} {
+		name := "fresh retry"
+		if legacyCompletion {
+			name = "persisted older management retry"
+		}
+		t.Run(name, func(t *testing.T) {
+			f := newDeepRecoveryFixture(t)
+			f.report(p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_ACTIVATED, 1)
+			f.report(p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_FAILED, 0)
+			f.retryResumeAndPoll()
+			old := time.Now().UTC().Add(-agentUpdatePostActionTimeout - time.Second)
+			if legacyCompletion {
+				// Before the fix a retry carried the activation's completion into the
+				// pending rollback. Upgrading management must also recover these rows.
+				if _, err := f.database.Exec(`UPDATE agent_update_assignments SET root_action_completed_at=? WHERE id=?`, old.Add(-time.Minute), f.assignmentID); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if _, err := f.database.Exec(`UPDATE agent_update_assignments SET updated_at=? WHERE id=?`, old, f.assignmentID); err != nil {
+				t.Fatal(err)
+			}
+			f.app.reconcileAgentUpdateMaintenance(context.Background(), time.Now().UTC())
+			var state, action, failure string
+			if err := f.database.QueryRow(`SELECT state,desired_action,failure_code FROM agent_update_assignments WHERE id=?`, f.assignmentID).Scan(&state, &action, &failure); err != nil {
+				t.Fatal(err)
+			}
+			if state != "blocked" || action != "none" || failure != "root_action_timeout" {
+				t.Fatalf("previous activation receipt disabled rollback watchdog: state=%s action=%s failure=%s", state, action, failure)
+			}
+			var rootCounter int64
+			if err := f.database.QueryRow(`SELECT last_root_action_counter FROM agent_updater_identities WHERE agent_id=?`, f.agent.ID).Scan(&rootCounter); err != nil {
+				t.Fatal(err)
+			}
+			if rootCounter != 1 || !f.app.isAgentUpdateCordoned(f.agent.ID) {
+				t.Fatalf("recovery reset replay protection or routing fence: rootCounter=%d", rootCounter)
+			}
+			f.retryResumeAndPoll()
+			f.report(p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_ROLLED_BACK, 2)
+			assertAgentUpdateAssignmentState(t, f.database, f.assignmentID, "awaiting_tunnel")
+		})
+	}
+}
+
+func TestDeepReviewLegacyCancelledRollbackRenewsGenerationAuthorization(t *testing.T) {
+	f := newDeepRecoveryFixture(t)
+	f.report(p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_ACTIVATED, 1)
+	f.report(p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_FAILED, 0)
+	f.retryResumeAndPoll()
+	f.report(p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_ROLLED_BACK, 2)
+	// Older cancellation incremented generation while retaining an unexpired
+	// rollback authorization and root receipt from the previous generation.
+	if _, err := f.database.Exec(`UPDATE agent_update_campaigns SET state='cancelled',generation=generation+1 WHERE id=?`, f.campaignID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.database.Exec(`UPDATE agent_update_assignments SET generation=generation+1,desired_action='rollback' WHERE id=?`, f.assignmentID); err != nil {
+		t.Fatal(err)
+	}
+	var completedAt time.Time
+	if err := f.database.QueryRow(`SELECT root_action_completed_at FROM agent_update_assignments WHERE id=?`, f.assignmentID).Scan(&completedAt); err != nil {
+		t.Fatal(err)
+	}
+	conn := &AgentConn{AgentID: f.agent.ID, PublicID: f.agent.PublicID, Done: make(chan struct{}), ConnectedAt: completedAt.Add(time.Millisecond)}
+	if err := f.app.AgentHub.connect(conn); err != nil {
+		t.Fatal(err)
+	}
+	f.app.recordAgentUpdateFreshTunnel(conn)
+	var freshAt sql.NullTime
+	if err := f.database.QueryRow(`SELECT fresh_tunnel_at FROM agent_update_assignments WHERE id=?`, f.assignmentID).Scan(&freshAt); err != nil {
+		t.Fatal(err)
+	}
+	if freshAt.Valid || !f.app.isAgentUpdateCordoned(f.agent.ID) {
+		t.Fatal("old-generation root receipt became evidence for pending rollback")
+	}
+	f.counter++
+	check := &p2pstreamv1.CheckAgentUpdateRequest{AgentPublicId: f.agent.PublicID, Counter: f.counter}
+	check.Signature = ed25519.Sign(f.updaterPrivate, agentupdateauth.CheckPayload(check.AgentPublicId, check.Counter))
+	response, err := f.app.CheckAgentUpdate(context.Background(), connect.NewRequest(check))
+	if err != nil || response.Msg.Authorization == nil || response.Msg.Generation != response.Msg.Authorization.Generation || response.Msg.Authorization.CommandSequence != 3 {
+		t.Fatalf("persisted superseded rollback authorization blocked recovery: response=%+v err=%v", response, err)
+	}
+	f.report(p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_ROLLED_BACK, 3)
+	assertAgentUpdateAssignmentState(t, f.database, f.assignmentID, "awaiting_tunnel")
+}
+
+func TestDeepReviewRecoveryCampaignPrecedesTerminalHistory(t *testing.T) {
+	f := newDeepRecoveryFixture(t)
+	if _, err := f.database.Exec(`UPDATE agent_update_campaigns SET state='cancelled' WHERE id=?`, f.campaignID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.database.Exec(`UPDATE agent_update_assignments SET state='blocked',desired_action='none' WHERE id=?`, f.assignmentID); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 100; i++ {
+		id, _ := insertAgentUpdateTestCampaign(t, f.database, f.agent.ID, "succeeded", "none", false)
+		if _, err := f.database.Exec(`UPDATE agent_update_campaigns SET state='completed' WHERE id=?`, id); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, limit := range []int64{0, 1, 100} {
+		request := connect.NewRequest(&p2pstreamv1.ListAgentUpdateCampaignsRequest{Limit: limit})
+		request.Header().Set("Cookie", f.cookie)
+		response, err := f.app.ListAgentUpdateCampaigns(context.Background(), request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(response.Msg.Campaigns) == 0 || response.Msg.Campaigns[0].Id != f.campaignID || response.Msg.Campaigns[0].State != p2pstreamv1.AgentUpdateCampaignState_AGENT_UPDATE_CAMPAIGN_STATE_CANCELLED {
+			t.Fatalf("limit %d hid the cancelled campaign that still reserves the agent", limit)
+		}
+	}
+}
+
+func TestDeepReviewPreviewRejectsCurrentlyRunningTarget(t *testing.T) {
+	f := newDeepRecoveryFixture(t)
+	campaign, err := f.app.getAgentUpdateCampaignProto(context.Background(), f.campaignID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.database.Exec(`UPDATE agent_update_assignments SET state='succeeded',desired_action='none',cordoned=0 WHERE id=?`, f.assignmentID); err != nil {
+		t.Fatal(err)
+	}
+	f.app.clearAgentUpdateCordon(f.agent.ID)
+	for _, tc := range []struct {
+		name    string
+		version string
+		commit  string
+		blocked bool
+	}{
+		{name: "same authenticated build", version: campaign.Target.Version, commit: campaign.Target.Commit, blocked: true},
+		{name: "older build", version: "v1.0.0", commit: strings.Repeat("d", 40)},
+		{name: "legacy build headers absent"},
+		{name: "same version different commit", version: campaign.Target.Version, commit: strings.Repeat("d", 40)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := &AgentConn{AgentID: f.agent.ID, PublicID: f.agent.PublicID, Done: make(chan struct{}), ConnectedAt: time.Now(), BuildVersion: tc.version, BuildCommit: tc.commit}
+			if err := f.app.AgentHub.connect(conn); err != nil {
+				t.Fatal(err)
+			}
+			defer f.app.AgentHub.disconnect(conn)
+			preview, err := f.app.previewAgentUpdateAgents(context.Background(), []int64{f.agent.ID}, campaign.Target, 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if slices.Contains(preview[0].Blockers, "already_on_target") != tc.blocked || preview[0].Eligible == tc.blocked {
+				t.Fatalf("live-target preview eligibility mismatch: %+v", preview[0])
+			}
+		})
+	}
+}
+
+func TestDeepReviewPendingAuthorizationSurvivesManagementUpgrade(t *testing.T) {
+	for _, rollback := range []bool{false, true} {
+		name := "activation"
+		if rollback {
+			name = "rollback"
+		}
+		t.Run(name, func(t *testing.T) {
+			f := newDeepRecoveryFixture(t)
+			if rollback {
+				f.report(p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_FAILED, 0)
+				f.retryResumeAndPoll()
+			}
+			old, _, err := f.app.activeAgentUpdateAssignment(context.Background(), f.agent.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// The root command may already be staged/executing when management restarts
+			// into the next version. Preserve that exact signed command until completion.
+			buildinfo.Version = "v0.0.1-test"
+			f.counter++
+			check := &p2pstreamv1.CheckAgentUpdateRequest{AgentPublicId: f.agent.PublicID, Counter: f.counter}
+			check.Signature = ed25519.Sign(f.updaterPrivate, agentupdateauth.CheckPayload(check.AgentPublicId, check.Counter))
+			response, err := f.app.CheckAgentUpdate(context.Background(), connect.NewRequest(check))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if response.Msg.Authorization == nil || response.Msg.ServerVersion != response.Msg.Authorization.ServerVersion || response.Msg.Authorization.CommandSequence != uint64(old.CommandSequence) || string(response.Msg.Authorization.CanonicalPayload) != string(old.AuthorizationPayload) {
+				t.Fatalf("management upgrade changed an escaped command context: %+v", response.Msg)
+			}
+			state := p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_ACTIVATED
+			if rollback {
+				state = p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_ROLLED_BACK
+			}
+			f.report(state, 1)
+			assertAgentUpdateAssignmentState(t, f.database, f.assignmentID, "awaiting_tunnel")
+			if !f.app.isAgentUpdateCordoned(f.agent.ID) {
+				t.Fatal("management restart bypassed post-action tunnel evidence")
+			}
+		})
+	}
+}
+
+func TestDeepReviewLateExecutionFailureCannotReplaceCommittedRootResult(t *testing.T) {
+	for _, rollback := range []bool{false, true} {
+		name, failureCode := "activation", "activation_failed"
+		if rollback {
+			name, failureCode = "rollback", "rollback_failed"
+		}
+		t.Run(name, func(t *testing.T) {
+			f := newDeepRecoveryFixture(t)
+			state := p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_ACTIVATED
+			if rollback {
+				f.report(p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_FAILED, 0)
+				f.retryResumeAndPoll()
+				state = p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_ROLLED_BACK
+			}
+			f.report(state, 1)
+			before, campaign, err := f.app.activeAgentUpdateAssignment(context.Background(), f.agent.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			f.counter++
+			report := &p2pstreamv1.ReportAgentUpdateRequest{AgentPublicId: f.agent.PublicID, AssignmentId: before.ID, Generation: before.Generation, Counter: f.counter,
+				State: p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_FAILED, FailureCode: failureCode,
+				FailureDetail: "verify signed root-action authorization: assignment authorization command sequence was replayed"}
+			signAgentUpdateTestReport(report, f.updaterPrivate)
+			report.Signature[0] ^= 1
+			if _, err := f.app.ReportAgentUpdate(context.Background(), connect.NewRequest(report)); connect.CodeOf(err) != connect.CodeUnauthenticated {
+				t.Fatalf("invalid worker signature accepted: %v", err)
+			}
+			report.Signature[0] ^= 1
+			response, err := f.app.ReportAgentUpdate(context.Background(), connect.NewRequest(report))
+			if err != nil || response.Msg.State != p2pstreamv1.AgentUpdateAssignmentState_AGENT_UPDATE_ASSIGNMENT_STATE_AWAITING_TUNNEL {
+				t.Fatalf("late execution failure replaced signed root success: response=%+v err=%v", response, err)
+			}
+			after, afterCampaign, err := f.app.activeAgentUpdateAssignment(context.Background(), f.agent.ID)
+			if err != nil || after.State != before.State || after.DesiredAction != before.DesiredAction || after.FailureCode != before.FailureCode ||
+				!after.UpdatedAt.Equal(before.UpdatedAt) || after.RootActionCounter != before.RootActionCounter ||
+				string(after.RootActionReceiptPayload) != string(before.RootActionReceiptPayload) || afterCampaign.State != campaign.State || !f.app.isAgentUpdateCordoned(f.agent.ID) {
+				t.Fatalf("obsolete failure changed proof, deadline or routing fence: after=%+v err=%v", after, err)
+			}
+			// The acknowledgment is idempotent and lets an older worker remove its
+			// durable failure file instead of starving normal checks forever.
+			if _, err := f.app.ReportAgentUpdate(context.Background(), connect.NewRequest(report)); err != nil {
+				t.Fatalf("lost-response obsolete failure retry was rejected: %v", err)
+			}
+			if !rollback {
+				report.Counter++
+				report.FailureCode = "post_activation_health_failed"
+				report.FailureDetail = "the activated service subsequently failed health checks"
+				signAgentUpdateTestReport(report, f.updaterPrivate)
+				if _, err := f.app.ReportAgentUpdate(context.Background(), connect.NewRequest(report)); err != nil {
+					t.Fatal(err)
+				}
+				assertAgentUpdateAssignmentState(t, f.database, f.assignmentID, "blocked")
+			}
+		})
+	}
+}

--- a/internal/server/agent_update_records.go
+++ b/internal/server/agent_update_records.go
@@ -155,18 +155,23 @@ func (a *App) ensureAgentUpdateAssignmentAuthorization(ctx context.Context, agen
 		return agentUpdateAssignmentRow{}, agentUpdateCampaignRow{}, connect.NewError(connect.CodeFailedPrecondition, errors.New("campaign state does not permit privileged update authorization"))
 	}
 	now := time.Now().UTC().Truncate(time.Millisecond)
-	if assignment.AuthorizationAction == action && assignment.AuthorizationExpiresAt.Valid && assignment.AuthorizationExpiresAt.Time.After(now) {
-		return assignment, campaign, nil
-	}
 	identity, err := agentUpdaterIdentityByAgentID(ctx, tx, agentID)
 	if err != nil {
 		return agentUpdateAssignmentRow{}, agentUpdateCampaignRow{}, publicDBError(err)
+	}
+	if assignment.AuthorizationAction == action && assignment.AuthorizationExpiresAt.Valid && assignment.AuthorizationExpiresAt.Time.After(now) {
+		// Older cancellation could advance the assignment generation while
+		// retaining an unexpired rollback authorization. Its canonical state
+		// must still match before reuse; otherwise mint a fresh command below.
+		if _, err := storedAssignmentAuthorization(assignment, campaign, identity); err == nil {
+			return assignment, campaign, nil
+		}
 	}
 	authorization, err := a.issueAssignmentAuthorizationTx(ctx, tx, identity, assignment, campaign, action, now)
 	if err != nil {
 		return agentUpdateAssignmentRow{}, agentUpdateCampaignRow{}, err
 	}
-	result, err := tx.ExecContext(ctx, `UPDATE agent_update_assignments SET authorization_action=?,authorization_server_version=?,command_sequence=?,authorization_nonce=?,authorization_sha256=?,authorization_payload=?,authorization_signature=?,authorization_issued_at=?,authorization_expires_at=?,updated_at=? WHERE id=? AND generation=? AND desired_action=? AND (authorization_action<>? OR authorization_expires_at IS NULL OR authorization_expires_at<=?) AND EXISTS (SELECT 1 FROM agent_update_campaigns WHERE id=? AND state=?)`, action, authorization.Value.ServerVersion, int64(authorization.Value.CommandSequence), authorization.Value.Nonce, authorization.SHA256, authorization.Payload, authorization.Signature, time.UnixMilli(authorization.Value.IssuedAtUnixMillis), time.UnixMilli(authorization.Value.ExpiresAtUnixMillis), now, assignment.ID, assignment.Generation, action, action, now, campaign.ID, campaign.State)
+	result, err := tx.ExecContext(ctx, `UPDATE agent_update_assignments SET authorization_action=?,authorization_server_version=?,command_sequence=?,authorization_nonce=?,authorization_sha256=?,authorization_payload=?,authorization_signature=?,authorization_issued_at=?,authorization_expires_at=?,updated_at=? WHERE id=? AND generation=? AND desired_action=? AND EXISTS (SELECT 1 FROM agent_update_campaigns WHERE id=? AND state=?)`, action, authorization.Value.ServerVersion, int64(authorization.Value.CommandSequence), authorization.Value.Nonce, authorization.SHA256, authorization.Payload, authorization.Signature, time.UnixMilli(authorization.Value.IssuedAtUnixMillis), time.UnixMilli(authorization.Value.ExpiresAtUnixMillis), now, assignment.ID, assignment.Generation, action, campaign.ID, campaign.State)
 	if err != nil {
 		return agentUpdateAssignmentRow{}, agentUpdateCampaignRow{}, publicDBError(err)
 	}
@@ -335,6 +340,22 @@ func verifyAgentUpdateRootActionReceipt(identity agentUpdaterIdentityRow, assign
 		}
 	}
 	return receipt, payload, signature, nil
+}
+
+// agentUpdateReportMatchesRootResult compares the worker envelope only after
+// its signature and the root receipt have been verified. Older pinned workers
+// omitted all four duplicated result fields for rollback. Accept that exact
+// legacy shape; persist results from the signed receipt, never from omissions.
+// Partial or conflicting envelopes and activation reports still require an
+// exact match. Receipt authorization, replay and tunnel gates are unchanged.
+func agentUpdateReportMatchesRootResult(report *p2pstreamv1.ReportAgentUpdateRequest, receipt agentupdateauth.RootActionReceipt) bool {
+	if report.State == p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_ROLLED_BACK &&
+		receipt.Action == agentupdateauth.AssignmentActionRollback &&
+		report.ManifestSha256 == "" && report.BinarySha256 == "" && report.RunningVersion == "" && report.RunningCommit == "" {
+		return true
+	}
+	return report.ManifestSha256 == receipt.ResultManifestSHA256 && report.BinarySha256 == receipt.ResultArtifactSHA256 &&
+		report.RunningVersion == receipt.ResultVersion && report.RunningCommit == receipt.ResultCommit
 }
 
 func consumeRootActionCounter(ctx context.Context, query db.DBTX, identity agentUpdaterIdentityRow, counter uint64, now time.Time) error {

--- a/internal/server/agent_update_systemd_integration_test.go
+++ b/internal/server/agent_update_systemd_integration_test.go
@@ -1,0 +1,442 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/proto"
+
+	p2pstreamv1 "p2pstream/gen/proto/p2pstream/v1"
+	"p2pstream/internal/agentupdate"
+	"p2pstream/internal/buildinfo"
+)
+
+// This test provisions the production paths and users. It is deliberately
+// opt-in and requires the disposable-VM marker made by the companion script.
+// Network distribution is a VM-local TLS mirror; installer, binaries, release
+// verification, management handlers, signatures, tunnels and systemd are real.
+func TestManagedUpdatesSystemdLifecycle(t *testing.T) {
+	if os.Getenv("P2PSTREAM_SYSTEMD_INTEGRATION") != "1" {
+		t.Skip("run scripts/test-managed-updates-systemd.sh in a disposable Multipass VM")
+	}
+	marker, err := os.ReadFile("/run/p2pstream-systemd-test-vm")
+	hostname, _ := os.Hostname()
+	if err != nil || string(marker) != "disposable-p2pstream-update-test\n" || os.Geteuid() != 0 || !strings.HasPrefix(hostname, "p2pstream-update-review") {
+		t.Fatal("refusing to provision system paths outside the disposable test VM")
+	}
+	for _, path := range []string{"/etc/p2pstream", "/etc/p2pstream-updater", "/opt/p2pstream-agent", "/var/lib/p2pstream-updater", "/var/lib/p2pstream-agent"} {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Fatalf("VM must have no existing agent installation: %s", path)
+		}
+	}
+	root := os.Getenv("P2PSTREAM_SYSTEMD_FIXTURE_DIR")
+	if !filepath.IsAbs(root) {
+		t.Fatal("absolute P2PSTREAM_SYSTEMD_FIXTURE_DIR is required")
+	}
+	legacy := filepath.Join(root, "p2pstream-legacy-worker")
+	if _, err := os.Stat(legacy); err != nil {
+		t.Fatalf("real legacy worker fixture is required: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	defer cancel()
+	defer func() {
+		cmd := exec.Command("journalctl", "-u", "p2pstream-agent", "-u", "p2pstream-updater", "-u", "p2pstream-updater-activate", "--no-pager", "-n", "240")
+		if output, err := cmd.CombinedOutput(); err == nil {
+			_ = os.WriteFile(filepath.Join(root, "systemd-journal.log"), output, 0600)
+			if t.Failed() {
+				t.Logf("systemd journal:\n%s", output)
+			}
+		}
+		_ = exec.Command("systemctl", "stop", "p2pstream-updater.timer", "p2pstream-updater-activate.path", "p2pstream-updater.service", "p2pstream-updater-activate.service", "p2pstream-agent.service").Run()
+	}()
+
+	database := newServerTestDB(t)
+	app := newAgentUpdateTestApp(t, database)
+	buildinfo.Version = "v1.5.0"
+	app.agentUpdateDrainReady = nil // Exercise actual tunnel/request draining.
+	app.AgentUpdateBootstrap = agentUpdateTestBootstrapProvider{repository: "test/systemd"}
+	agent := createAgentUpdateTestAgent(t, database, "agent-systemd-review")
+	header := createTestAdminSession(t, app)
+	assets := make(map[string][]byte)
+	targets := make(map[string]*p2pstreamv1.AgentUpdateTarget)
+	for i, version := range []string{"v1.1.0", "v1.2.0"} {
+		body := systemdRead(t, filepath.Join(root, "p2pstream-"+version))
+		digest := sha256.Sum256(body)
+		artifact := agentupdate.Artifact{OS: "linux", Arch: "amd64", Name: "p2pstream_" + version + "_linux_amd64", Size: uint64(len(body)), SHA256: hex.EncodeToString(digest[:])}
+		manifest := agentupdate.Manifest{
+			SchemaVersion: 1, Channel: "stable", Version: version, Commit: strings.Repeat(string(rune('a'+i)), 40), Sequence: uint64(i + 2),
+			PublishedAt: time.Now().UTC().Add(-time.Minute).Format(time.RFC3339), ExpiresAt: time.Now().UTC().Add(time.Hour).Format(time.RFC3339),
+			MinimumSafeVersion: "v1.0.0", SecurityEpoch: 1,
+			Compatibility: agentupdate.Compatibility{Server: agentupdate.VersionRange{Min: "v1.0.0", Max: "v2.0.0"}, Updater: agentupdate.VersionRange{Min: "v1.0.0", Max: "v2.0.0"}, Protocol: agentupdate.ProtocolRange{Min: 1, Max: 1}},
+			Artifacts:     []agentupdate.Artifact{artifact},
+		}
+		data, err := agentupdate.CanonicalManifest(manifest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		manifestDigest := sha256.Sum256(data)
+		target := &p2pstreamv1.AgentUpdateTarget{Version: version, Commit: manifest.Commit, ManifestSha256: hex.EncodeToString(manifestDigest[:]), ReleaseSequence: int64(manifest.Sequence), SecurityEpoch: 1, MinimumUpdaterVersion: "v1.0.0", MinimumTunnelProtocol: 1, MaximumTunnelProtocol: 1,
+			Artifacts: []*p2pstreamv1.AgentUpdateArtifact{{Os: artifact.OS, Arch: artifact.Arch, Name: artifact.Name, SizeBytes: int64(artifact.Size), Sha256: artifact.SHA256}}}
+		targets[version] = target
+		base := "/test/systemd/releases/download/" + version + "/"
+		assets[base+artifact.Name], assets[base+"p2pstream_agent_update_manifest.json"] = body, data
+	}
+	app.TrustedAgentUpdates = systemdTestCatalog{targets: targets}
+	mux := http.NewServeMux()
+	app.RegisterManagementRoutes(mux)
+	certificate, certPEM := systemdTestCertificate(t)
+	var loseRollbackResponse atomic.Bool
+	var droppedSuccessfulRollbackResponse atomic.Bool
+	var rollbackReportsMu sync.Mutex
+	var rollbackReports []*p2pstreamv1.ReportAgentUpdateRequest
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Host == "github.com" {
+			if body, ok := assets[r.URL.Path]; ok {
+				w.Header().Set("Content-Type", "application/octet-stream")
+				w.Header().Set("Content-Length", fmt.Sprint(len(body)))
+				_, _ = w.Write(body)
+				return
+			}
+			http.NotFound(w, r)
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/ReportAgentUpdate") {
+			body, err := io.ReadAll(io.LimitReader(r.Body, 256<<10))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			r.Body = io.NopCloser(bytes.NewReader(body))
+			var report p2pstreamv1.ReportAgentUpdateRequest
+			if proto.Unmarshal(body, &report) == nil && report.State == p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_ROLLED_BACK {
+				rollbackReportsMu.Lock()
+				rollbackReports = append(rollbackReports, proto.Clone(&report).(*p2pstreamv1.ReportAgentUpdateRequest))
+				rollbackReportsMu.Unlock()
+				if loseRollbackResponse.CompareAndSwap(true, false) {
+					recorder := httptest.NewRecorder()
+					mux.ServeHTTP(recorder, r)
+					if recorder.Code == http.StatusOK {
+						// Commit in real management, then lose its successful response.
+						droppedSuccessfulRollbackResponse.Store(true)
+						http.Error(w, "injected lost rollback response", http.StatusServiceUnavailable)
+						return
+					}
+					for key, values := range recorder.Header() {
+						w.Header()[key] = values
+					}
+					w.WriteHeader(recorder.Code)
+					_, _ = w.Write(recorder.Body.Bytes())
+					return
+				}
+			}
+		}
+		mux.ServeHTTP(w, r)
+	}))
+	_ = server.Listener.Close()
+	server.Listener, err = net.Listen("tcp", "127.0.0.1:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server.TLS = &tls.Config{Certificates: []tls.Certificate{certificate}, MinVersion: tls.VersionTLS12}
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	defer server.Close()
+	hosts := systemdRead(t, "/etc/hosts")
+	systemdWrite(t, "/etc/hosts", append(hosts, []byte("\n127.0.0.1 management.test github.com\n")...), 0644)
+	defer systemdWrite(t, "/etc/hosts", hosts, 0644)
+	systemdWrite(t, "/usr/local/share/ca-certificates/p2pstream-review.crt", certPEM, 0644)
+	systemdCommand(t, ctx, "update-ca-certificates")
+
+	token, _, err := app.createAgentUpdaterEnrollmentToken(ctx, agent.ID, 10*time.Minute, agentUpdateBootstrap{PinnedRepository: "test/systemd"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	authority := app.AgentUpdateAuthority.Identity()
+	install := exec.CommandContext(ctx, "bash", filepath.Join(root, "install-agent.sh"))
+	install.Env = append(os.Environ(),
+		"P2PSTREAM_VERSION=v1.0.0", "P2PSTREAM_AGENT_BINARY_FILE="+filepath.Join(root, "p2pstream-v1.0.0"),
+		"P2PSTREAM_REPOSITORY=test/systemd", "MANAGEMENT_URL=https://management.test", "AGENT_ID="+agent.PublicID, "AGENT_TOKEN=test-token-"+agent.PublicID,
+		"AGENT_ALLOW_TARGETS=127.0.0.1:9000", "P2PSTREAM_ENABLE_MANAGED_UPDATES=true", "P2PSTREAM_AGENT_UPDATE_CHANNEL=stable",
+		"P2PSTREAM_UPDATER_ENROLLMENT_TOKEN="+token, "P2PSTREAM_AGENT_UPDATE_AUTHORITY_PUBLIC_KEY_BASE64="+base64.StdEncoding.EncodeToString(authority.PublicKey),
+		"P2PSTREAM_AGENT_UPDATE_AUTHORITY_KEY_ID="+authority.KeyID, "P2PSTREAM_AGENT_UPDATE_AUTHORITY_EPOCH=1",
+		"MANAGEMENT_CA_PEM_BASE64="+base64.StdEncoding.EncodeToString(certPEM))
+	if output, err := install.CombinedOutput(); err != nil {
+		t.Fatalf("real installer failed: %v\n%s", err, output)
+	}
+	// Drive the worker explicitly to keep the test bounded; the production
+	// activation path and service hardening remain unchanged.
+	systemdCommand(t, ctx, "systemctl", "stop", "p2pstream-updater.timer")
+	waitForAgentHubConnection(t, app, agent.ID, true)
+	originalEnv := systemdRead(t, "/etc/p2pstream/agent.env")
+
+	startCampaign := func(version string) int64 {
+		t.Helper()
+		req := connect.NewRequest(&p2pstreamv1.CreateAgentUpdateCampaignRequest{Name: "systemd " + version, AgentIds: []int64{agent.ID}, Target: &p2pstreamv1.AgentUpdateTarget{ManifestSha256: targets[version].ManifestSha256}, Policy: &p2pstreamv1.AgentUpdatePolicy{MaxUnavailable: 1, MinimumEligibleAgentsPerRoute: 1, CanaryCount: 1, WaveSize: 1, HealthyDwellMillis: 10000}})
+		req.Header().Set("Cookie", header.Get("Cookie"))
+		response, err := app.CreateAgentUpdateCampaign(ctx, req)
+		if err != nil {
+			t.Fatalf("create %s campaign: %v", version, err)
+		}
+		return response.Msg.Campaign.Id
+	}
+	var lastWorkerStart time.Time
+	waitCampaign := func(campaignID int64, want string) {
+		t.Helper()
+		deadline := time.Now().Add(90 * time.Second)
+		last := ""
+		for time.Now().Before(deadline) && ctx.Err() == nil {
+			var state, action, failure string
+			var cordoned int
+			if err := database.QueryRow(`SELECT state,desired_action,failure_code,cordoned FROM agent_update_assignments WHERE campaign_id=?`, campaignID).Scan(&state, &action, &failure, &cordoned); err != nil {
+				t.Fatal(err)
+			}
+			current := state + "/" + action + "/" + failure
+			if current != last {
+				t.Logf("campaign %d: %s", campaignID, current)
+				last = current
+			}
+			if state == want && (want != "failed" || (action == "none" && cordoned == 0)) {
+				return
+			}
+			if state == "blocked" {
+				t.Fatalf("campaign blocked: %s", current)
+			}
+			if time.Since(lastWorkerStart) >= 5*time.Second {
+				lastWorkerStart = time.Now()
+				if output, err := exec.CommandContext(ctx, "systemctl", "start", "p2pstream-updater.service").CombinedOutput(); err != nil {
+					if want != "failed" {
+						t.Fatalf("real worker failed: %v\n%s", err, output)
+					}
+					// A single injected lost response should be recovered by the next
+					// invocation. Persistent errors still fail the bounded phase below.
+					t.Logf("rollback worker retry after failed invocation: %v", err)
+				}
+			}
+			app.reconcileAgentUpdateMaintenance(ctx, time.Now().UTC())
+			time.Sleep(250 * time.Millisecond)
+		}
+		t.Fatalf("campaign %d did not reach %s; last %s", campaignID, want, last)
+	}
+	assertLive := func(version string) {
+		t.Helper()
+		conn := app.AgentHub.connectedByID(agent.ID)
+		if conn == nil || conn.BuildVersion != version || app.isAgentUpdateCordoned(agent.ID) {
+			t.Fatalf("live tunnel did not prove %s or remained cordoned: %+v", version, conn)
+		}
+		pid := strings.TrimSpace(systemdCommand(t, ctx, "systemctl", "show", "p2pstream-agent", "--property=MainPID", "--value"))
+		exe, err := os.Readlink("/proc/" + pid + "/exe")
+		if err != nil || !strings.Contains(exe, "/slots/"+version+"/p2pstream") {
+			t.Fatalf("running service executable = %s, %v", exe, err)
+		}
+		if string(originalEnv) != string(systemdRead(t, "/etc/p2pstream/agent.env")) {
+			t.Fatal("rollout changed the existing agent token or network permissions")
+		}
+		systemdCommand(t, ctx, "runuser", "-u", "p2pstream-updater", "--", "test", "-r", "/var/lib/p2pstream-updater/floor.json")
+		if result := strings.TrimSpace(systemdCommand(t, ctx, "systemctl", "show", "p2pstream-updater-activate.service", "--property=Result", "--value")); result != "success" {
+			t.Fatalf("privileged helper did not finish successfully: %s", result)
+		}
+		t.Logf("verified real agent process %s, fresh tunnel, readable floor, unchanged configuration", version)
+	}
+
+	first := startCampaign("v1.1.0")
+	waitCampaign(first, "succeeded")
+	assertLive("v1.1.0")
+	second := startCampaign("v1.2.0")
+	waitCampaign(second, "healthy_dwell")
+	// Exercise the installed .84 worker's actual report serialization against
+	// current management while retaining the fixed root activator.
+	if err := os.MkdirAll("/etc/systemd/system/p2pstream-updater.service.d", 0755); err != nil {
+		t.Fatal(err)
+	}
+	systemdWrite(t, "/etc/systemd/system/p2pstream-updater.service.d/review.conf", []byte("[Service]\nExecStart=\nExecStart="+legacy+" updater stage\n"), 0644)
+	systemdCommand(t, ctx, "systemctl", "daemon-reload")
+	campaign, err := app.getAgentUpdateCampaignProto(ctx, second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancelRequest := connect.NewRequest(&p2pstreamv1.ChangeAgentUpdateCampaignStateRequest{CampaignId: second, ExpectedGeneration: campaign.Generation})
+	cancelRequest.Header().Set("Cookie", header.Get("Cookie"))
+	loseRollbackResponse.Store(true)
+	if _, err := app.CancelAgentUpdateCampaign(ctx, cancelRequest); err != nil {
+		t.Fatal(err)
+	}
+	waitCampaign(second, "failed")
+	systemdCommand(t, ctx, "systemctl", "start", "p2pstream-updater.service")
+	rollbackReportsMu.Lock()
+	if !droppedSuccessfulRollbackResponse.Load() {
+		t.Error("lost-response injection did not replace a committed successful rollback response")
+	}
+	if len(rollbackReports) < 2 || rollbackReports[0].RootActionReceipt == nil || rollbackReports[1].RootActionReceipt == nil || !bytes.Equal(rollbackReports[0].RootActionReceipt.CanonicalPayload, rollbackReports[1].RootActionReceipt.CanonicalPayload) || rollbackReports[0].Counter >= rollbackReports[1].Counter {
+		t.Errorf("lost response did not retry the exact root proof with a fresh worker counter (%d reports)", len(rollbackReports))
+	}
+	if len(rollbackReports) > 0 {
+		legacyReport := rollbackReports[0]
+		if legacyReport.BinarySha256 != "" || legacyReport.ManifestSha256 != "" || legacyReport.RunningVersion != "" || legacyReport.RunningCommit != "" || legacyReport.RootActionReceipt == nil || len(legacyReport.RootActionReceipt.CanonicalPayload) == 0 {
+			t.Error("legacy worker fixture did not exercise the empty rollback envelope with signed proof")
+		}
+	}
+	rollbackReportsMu.Unlock()
+	if _, err := os.Stat("/var/lib/p2pstream-updater/staging/rollback-result.json"); !os.IsNotExist(err) {
+		t.Fatalf("acknowledged result still blocks polling: %v", err)
+	}
+	assertLive("v1.1.0")
+	if err := os.Remove("/etc/systemd/system/p2pstream-updater.service.d/review.conf"); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	systemdCommand(t, ctx, "systemctl", "daemon-reload")
+	// Reproduce a previously exhausted crash budget. Only the fault injection
+	// resets counters here; recovery below must be performed by the installer.
+	systemdCommand(t, ctx, "systemctl", "stop", "p2pstream-updater-activate.path", "p2pstream-updater-activate.service")
+	failureDropIn := "/etc/systemd/system/p2pstream-updater-activate.service.d/review-failure.conf"
+	if err := os.MkdirAll(filepath.Dir(failureDropIn), 0755); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.Remove(failureDropIn)
+		_ = exec.Command("systemctl", "daemon-reload").Run()
+	}()
+	failureCount := "/var/lib/p2pstream-updater/root/review-failure-count"
+	failingHelper := filepath.Join(root, "failing-helper.sh")
+	systemdWrite(t, failingHelper, []byte("#!/bin/sh\nprintf x >>"+failureCount+"\nexit 1\n"), 0755)
+	systemdWrite(t, failureDropIn, []byte("[Service]\nExecStart=\nExecStart=/bin/sh "+failingHelper+"\nExecStartPost=\nExecStopPost=\nRestart=no\n"), 0644)
+	systemdCommand(t, ctx, "systemctl", "daemon-reload")
+	systemdCommand(t, ctx, "systemctl", "reset-failed", "p2pstream-updater-activate.service")
+	for i := 0; i < 6; i++ {
+		if err := exec.CommandContext(ctx, "systemctl", "start", "p2pstream-updater-activate.service").Run(); err == nil {
+			t.Fatal("injected failing helper unexpectedly succeeded")
+		}
+	}
+	// systemd may retain Result=exit-code after refusing a subsequent start.
+	// Count actual executions to prove the sixth attempt was rate-limited.
+	if executions := len(systemdRead(t, failureCount)); executions != 5 {
+		t.Fatalf("crash throttle allowed %d executions for six failed starts; want five", executions)
+	}
+	if err := os.Remove(failureDropIn); err != nil {
+		t.Fatal(err)
+	}
+	systemdCommand(t, ctx, "systemctl", "daemon-reload")
+	// Repair the pinned rescue runner without supplying/rotating the existing
+	// agent token or replacing its recovered live binary and destination policy.
+	repairToken, _, err := app.createAgentUpdaterEnrollmentToken(ctx, agent.ID, 10*time.Minute, agentUpdateBootstrap{PinnedRepository: "test/systemd"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	repair := exec.CommandContext(ctx, "bash", filepath.Join(root, "install-agent.sh"))
+	for _, value := range install.Env {
+		if strings.HasPrefix(value, "AGENT_TOKEN=") || strings.HasPrefix(value, "P2PSTREAM_VERSION=") || strings.HasPrefix(value, "P2PSTREAM_AGENT_BINARY_FILE=") || strings.HasPrefix(value, "P2PSTREAM_UPDATER_ENROLLMENT_TOKEN=") {
+			continue
+		}
+		repair.Env = append(repair.Env, value)
+	}
+	repair.Env = append(repair.Env, "P2PSTREAM_VERSION=v1.1.0", "P2PSTREAM_AGENT_BINARY_FILE="+filepath.Join(root, "p2pstream-v1.1.0"), "P2PSTREAM_UPDATER_ENROLLMENT_TOKEN="+repairToken)
+	if output, err := repair.CombinedOutput(); err != nil {
+		t.Fatalf("real pinned-updater repair failed: %v\n%s", err, output)
+	}
+	if sha256.Sum256(systemdRead(t, "/opt/p2pstream-agent/updater/p2pstream")) != sha256.Sum256(systemdRead(t, filepath.Join(root, "p2pstream-v1.1.0"))) {
+		t.Fatal("repair did not replace the pinned updater with the selected verified binary")
+	}
+	var enrolledUpdaterVersion string
+	if err := database.QueryRow(`SELECT updater_version FROM agent_updater_identities WHERE agent_id=?`, agent.ID).Scan(&enrolledUpdaterVersion); err != nil || enrolledUpdaterVersion != "v1.1.0" {
+		t.Fatalf("repair did not promote enrolled updater version: %q, %v", enrolledUpdaterVersion, err)
+	}
+	systemdCommand(t, ctx, "systemctl", "stop", "p2pstream-updater.timer")
+	waitForAgentHubConnection(t, app, agent.ID, true)
+	assertLive("v1.1.0")
+	third := startCampaign("v1.2.0")
+	waitCampaign(third, "succeeded")
+	assertLive("v1.2.0")
+	t.Log("PASS: real install/enrollment, two upgrades, signed cancellation rollback, legacy worker report/lost-response retry, crash throttle, pinned-updater repair, and exact-target retry")
+}
+
+type systemdTestCatalog struct {
+	targets map[string]*p2pstreamv1.AgentUpdateTarget
+}
+
+func (c systemdTestCatalog) ListTrustedAgentUpdateTargets(context.Context) ([]*p2pstreamv1.AgentUpdateTarget, error) {
+	var targets []*p2pstreamv1.AgentUpdateTarget
+	for _, target := range c.targets {
+		targets = append(targets, proto.Clone(target).(*p2pstreamv1.AgentUpdateTarget))
+	}
+	return targets, nil
+}
+
+func (c systemdTestCatalog) ResolveTrustedAgentUpdateTarget(_ context.Context, digest string) (*p2pstreamv1.AgentUpdateTarget, error) {
+	for _, target := range c.targets {
+		if target.ManifestSha256 == digest {
+			return proto.Clone(target).(*p2pstreamv1.AgentUpdateTarget), nil
+		}
+	}
+	return nil, fmt.Errorf("unknown test manifest %s", digest)
+}
+
+func systemdTestCertificate(t *testing.T) (tls.Certificate, []byte) {
+	t.Helper()
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert := &x509.Certificate{SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "disposable update test"}, DNSNames: []string{"management.test", "github.com"}, IPAddresses: []net.IP{net.ParseIP("127.0.0.1")}, NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(time.Hour), IsCA: true, BasicConstraintsValid: true, KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign, ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}}
+	der, err := x509.CreateCertificate(rand.Reader, cert, cert, public, private)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := x509.MarshalPKCS8PrivateKey(private)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	pair, err := tls.X509KeyPair(certPEM, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: key}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pair, certPEM
+}
+
+func systemdRead(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func systemdWrite(t *testing.T, path string, data []byte, mode os.FileMode) {
+	t.Helper()
+	if err := os.WriteFile(path, data, mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func systemdCommand(t *testing.T, ctx context.Context, name string, args ...string) string {
+	t.Helper()
+	output, err := exec.CommandContext(ctx, name, args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %v: %v\n%s", name, args, err, output)
+	}
+	return string(output)
+}

--- a/internal/server/agent_updates.go
+++ b/internal/server/agent_updates.go
@@ -58,6 +58,11 @@ const (
 	agentUpdateReportMaxRequestBytes  = int64(256 << 10)
 )
 
+// A new recovery generation must not inherit the previous root action's
+// completion or tunnel evidence. Monotonic replay floors live on the enrolled
+// identity and are deliberately not reset by either cancellation or retry.
+const agentUpdateResetRootEvidenceSQL = `root_action_counter=0,root_action_receipt_payload=X'',root_action_receipt_signature=X'',root_action_completed_at=NULL,root_result_kind='',root_result_manifest_sha256='',root_result_version='',root_result_commit='',root_result_release_sequence=0,root_result_security_epoch=0,root_result_os='',root_result_arch='',root_result_artifact_name='',root_result_artifact_size=0,root_result_artifact_sha256='',attested_manifest_sha256='',attested_binary_sha256='',attested_activation_counter=0,activation_nonce_hash='',fresh_tunnel_at=NULL,healthy_at=NULL,observed_version='',observed_commit=''`
+
 type agentUpdateAdmissionContextKey struct{}
 
 var (
@@ -506,7 +511,9 @@ func (a *App) ListAgentUpdateCampaigns(ctx context.Context, req *connect.Request
 	if limit < 1 || limit > 100 {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("limit must be between 1 and 100"))
 	}
-	rows, err := a.DB.QueryContext(ctx, `SELECT id FROM agent_update_campaigns ORDER BY id DESC LIMIT ?`, limit)
+	// Recovery controls must remain discoverable even after many later finished
+	// campaigns. A cancelled campaign can still own a cordoned assignment.
+	rows, err := a.DB.QueryContext(ctx, `SELECT c.id FROM agent_update_campaigns c ORDER BY (c.state IN ('running','paused') OR EXISTS (SELECT 1 FROM agent_update_assignments x WHERE x.campaign_id=c.id AND (x.cordoned=1 OR x.state NOT IN ('succeeded','failed','cancelled') OR (x.state='failed' AND x.desired_action='rollback')))) DESC,c.id DESC LIMIT ?`, limit)
 	if err != nil {
 		return nil, publicDBError(err)
 	}
@@ -580,7 +587,16 @@ func (a *App) changeAgentUpdateCampaignState(ctx context.Context, req *connect.R
 		// activated_at=NULL as proof that the host stayed on the old binary. Keep
 		// such agents cordoned and supersede the activation with a separately
 		// signed rollback authorization on their next authenticated Check.
-		if _, err := tx.ExecContext(ctx, `UPDATE agent_update_assignments SET state=CASE WHEN activated_at IS NULL AND authorization_action<>'activate' AND desired_action<>'activate' THEN 'cancelled' ELSE state END,desired_action=CASE WHEN activated_at IS NULL AND authorization_action<>'activate' AND desired_action<>'activate' THEN 'none' ELSE 'rollback' END,generation=generation+1,cordoned=CASE WHEN activated_at IS NULL AND authorization_action<>'activate' AND desired_action<>'activate' THEN 0 ELSE 1 END,updated_at=? WHERE campaign_id=? AND state NOT IN ('succeeded','failed','cancelled')`, now, req.Msg.CampaignId); err != nil {
+		// Only an uncordoned assignment or a reversible pre-authorization drain
+		// can be released immediately. A failed rollback may have overwritten
+		// the earlier activation authorization without ever setting activated_at.
+		if _, err := tx.ExecContext(ctx, `UPDATE agent_update_assignments SET state='cancelled',desired_action='none',generation=generation+1,cordoned=0,updated_at=? WHERE campaign_id=? AND state NOT IN ('succeeded','failed','cancelled') AND activated_at IS NULL AND authorization_action='' AND desired_action NOT IN ('activate','rollback') AND (cordoned=0 OR state='cordoned')`, now, req.Msg.CampaignId); err != nil {
+			return nil, publicDBError(err)
+		}
+		// Already verified rollback must retain its receipt and exact generation
+		// while awaiting a fresh tunnel; cancellation cannot replace that proof
+		// or release its fence. Other unsafe phases get a new rollback command.
+		if _, err := tx.ExecContext(ctx, `UPDATE agent_update_assignments SET desired_action='rollback',generation=generation+1,cordoned=1,authorization_action='',authorization_server_version='',command_sequence=0,authorization_nonce=X'',authorization_sha256='',authorization_payload=X'',authorization_signature=X'',authorization_issued_at=NULL,authorization_expires_at=NULL,`+agentUpdateResetRootEvidenceSQL+`,last_report_at=NULL,updated_at=? WHERE campaign_id=? AND state NOT IN ('succeeded','failed','cancelled') AND NOT (state='awaiting_tunnel' AND desired_action='none' AND authorization_action='rollback' AND root_action_completed_at IS NOT NULL)`, now, req.Msg.CampaignId); err != nil {
 			return nil, publicDBError(err)
 		}
 	} else if state == "paused" {
@@ -704,7 +720,7 @@ func (a *App) RetryAgentUpdateAssignments(ctx context.Context, req *connect.Requ
 	for _, id := range ids {
 		var result sql.Result
 		if retries[id] == retryRollback {
-			result, err = tx.ExecContext(ctx, `UPDATE agent_update_assignments SET state='failed',desired_action='rollback',generation=generation+1,failure_code='',failure_detail='',authorization_action='',authorization_server_version='',command_sequence=0,authorization_nonce=X'',authorization_sha256='',authorization_payload=X'',authorization_signature=X'',authorization_issued_at=NULL,authorization_expires_at=NULL,fresh_tunnel_at=NULL,healthy_at=NULL,last_report_at=NULL,updated_at=? WHERE id=? AND campaign_id=? AND state='blocked' AND cordoned=1`, now, id, req.Msg.CampaignId)
+			result, err = tx.ExecContext(ctx, `UPDATE agent_update_assignments SET state='failed',desired_action='rollback',generation=generation+1,failure_code='',failure_detail='',authorization_action='',authorization_server_version='',command_sequence=0,authorization_nonce=X'',authorization_sha256='',authorization_payload=X'',authorization_signature=X'',authorization_issued_at=NULL,authorization_expires_at=NULL,`+agentUpdateResetRootEvidenceSQL+`,last_report_at=NULL,updated_at=? WHERE id=? AND campaign_id=? AND state='blocked' AND cordoned=1`, now, id, req.Msg.CampaignId)
 		} else {
 			// A retried stage returns to the neutral pending state. Only the
 			// transactional cohort scheduler may release it, otherwise an
@@ -791,8 +807,7 @@ func (a *App) CheckAgentUpdate(ctx context.Context, req *connect.Request[p2pstre
 			return nil, publicDBError(err)
 		}
 	}
-	if campaignAllowsAgentUpdateAuthorization(campaign.State, assignment.DesiredAction) &&
-		(assignment.AuthorizationAction != assignment.DesiredAction || !assignment.AuthorizationExpiresAt.Valid || !assignment.AuthorizationExpiresAt.Time.After(time.Now().UTC())) {
+	if campaignAllowsAgentUpdateAuthorization(campaign.State, assignment.DesiredAction) {
 		assignment, campaign, err = a.ensureAgentUpdateAssignmentAuthorization(ctx, identity.AgentID, assignment.ID, assignment.Generation, assignment.DesiredAction)
 		if err != nil {
 			return nil, err
@@ -822,6 +837,11 @@ func (a *App) CheckAgentUpdate(ctx context.Context, req *connect.Request[p2pstre
 			return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("stored management authorization is invalid: %w", verifyErr))
 		}
 		response.Authorization = assignmentAuthorizationProto(record)
+		// An in-flight command can outlive a management process upgrade. Its
+		// signed compatibility context must remain identical in this envelope;
+		// reminting it could invalidate the root result already being produced.
+		// New staging checks and newly issued authorizations use buildinfo.Version.
+		response.ServerVersion = record.Value.ServerVersion
 	}
 	return connect.NewResponse(response), nil
 }
@@ -889,6 +909,16 @@ func (a *App) ReportAgentUpdate(ctx context.Context, req *connect.Request[p2pstr
 		}
 		return a.acknowledgeSupersededAgentUpdateReport(ctx, tx, identity, m)
 	}
+	// A duplicated root-service edge can report an execution error after that
+	// exact action already committed a signed success receipt. Acknowledge the
+	// stale execution failure so old workers can drain their durable file, while
+	// preserving the proof, health deadline and routing fence. Later health
+	// failures remain actionable; they are not failures to execute this action.
+	matchesCommittedOutcome := m.State == p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_FAILED &&
+		assignment.DesiredAction == "none" && assignment.RootActionCompletedAt.Valid && len(assignment.RootActionReceiptPayload) > 0 &&
+		(assignment.State == "awaiting_tunnel" || assignment.State == "healthy_dwell" || assignment.State == "blocked") &&
+		((assignment.AuthorizationAction == "activate" && m.FailureCode == "activation_failed") ||
+			(assignment.AuthorizationAction == "rollback" && m.FailureCode == "rollback_failed"))
 	if assignment.State == "blocked" && assignment.DesiredAction == "none" {
 		matchesCommittedFailure := m.State == p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_FAILED &&
 			m.FailureCode == assignment.FailureCode && m.FailureDetail == assignment.FailureDetail
@@ -896,20 +926,21 @@ func (a *App) ReportAgentUpdate(ctx context.Context, req *connect.Request[p2pstr
 			assignment.RootActionCompletedAt.Valid && m.ManifestSha256 == assignment.RootResultManifestSha256 &&
 			m.BinarySha256 == assignment.RootResultArtifactSha256 && m.RunningVersion == assignment.RootResultVersion &&
 			m.RunningCommit == assignment.RootResultCommit
-		if matchesCommittedFailure || matchesCommittedHealth {
-			if m.Counter < uint64(identity.LastCounter) {
-				return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("updater counter was replayed"))
-			}
-			if m.Counter > uint64(identity.LastCounter) {
-				if err := consumeAgentUpdaterCounter(ctx, tx, identity.AgentID, m.Counter, time.Now().UTC()); err != nil {
-					return nil, err
-				}
-			}
-			if err := tx.Commit(); err != nil {
-				return nil, publicDBError(err)
-			}
-			return connect.NewResponse(&p2pstreamv1.ReportAgentUpdateResponse{State: assignmentStateProto(assignment.State), DesiredAction: desiredActionProto(assignment.DesiredAction), Generation: assignment.Generation, RetryAfterMillis: agentUpdatePollInterval.Milliseconds()}), nil
+		matchesCommittedOutcome = matchesCommittedOutcome || matchesCommittedFailure || matchesCommittedHealth
+	}
+	if matchesCommittedOutcome {
+		if m.Counter < uint64(identity.LastCounter) {
+			return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("updater counter was replayed"))
 		}
+		if m.Counter > uint64(identity.LastCounter) {
+			if err := consumeAgentUpdaterCounter(ctx, tx, identity.AgentID, m.Counter, time.Now().UTC()); err != nil {
+				return nil, err
+			}
+		}
+		if err := tx.Commit(); err != nil {
+			return nil, publicDBError(err)
+		}
+		return connect.NewResponse(&p2pstreamv1.ReportAgentUpdateResponse{State: assignmentStateProto(assignment.State), DesiredAction: desiredActionProto(assignment.DesiredAction), Generation: assignment.Generation, RetryAfterMillis: agentUpdatePollInterval.Milliseconds()}), nil
 	}
 	now := time.Now().UTC()
 	state, action, cordoned := assignment.State, assignment.DesiredAction, assignment.Cordoned
@@ -939,7 +970,7 @@ func (a *App) ReportAgentUpdate(ctx context.Context, req *connect.Request[p2pstr
 			// lost response. Exact stored canonical bytes make this idempotent; a
 			// newer worker counter is consumed, while an exact HTTP retry may reuse
 			// the last counter without mutating durable state.
-			if m.ManifestSha256 != candidate.ResultManifestSHA256 || m.BinarySha256 != candidate.ResultArtifactSHA256 || m.RunningVersion != candidate.ResultVersion || m.RunningCommit != candidate.ResultCommit || m.Counter < uint64(identity.LastCounter) {
+			if !agentUpdateReportMatchesRootResult(m, candidate) || m.Counter < uint64(identity.LastCounter) {
 				return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("root action report retry does not match the committed receipt"))
 			}
 			if m.Counter > uint64(identity.LastCounter) {
@@ -956,7 +987,7 @@ func (a *App) ReportAgentUpdate(ctx context.Context, req *connect.Request[p2pstr
 		if err != nil {
 			return nil, err
 		}
-		if m.ManifestSha256 != rootReceipt.ResultManifestSHA256 || m.BinarySha256 != rootReceipt.ResultArtifactSHA256 || m.RunningVersion != rootReceipt.ResultVersion || m.RunningCommit != rootReceipt.ResultCommit {
+		if !agentUpdateReportMatchesRootResult(m, rootReceipt) {
 			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("root action report does not match its signed result receipt"))
 		}
 	} else if m.State == p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_HEALTHY {
@@ -1005,13 +1036,16 @@ func (a *App) ReportAgentUpdate(ctx context.Context, req *connect.Request[p2pstr
 			state, action, pauseCampaignForFailure = "blocked", "none", true
 		case action == "none" && cordoned == 1 && assignment.ActivatedAt.Valid && (state == "awaiting_tunnel" || state == "healthy_dwell"):
 			state, action, pauseCampaignForFailure = "blocked", "none", true
-		case action == "rollback" && cordoned == 1 && (state == "failed" || state == "cordoned" || state == "activating" || state == "awaiting_tunnel" || state == "healthy_dwell"):
+		case action == "rollback" && cordoned == 1 && (state == "failed" || state == "blocked" || state == "cordoned" || state == "activating" || state == "awaiting_tunnel" || state == "healthy_dwell"):
 			state, action, pauseCampaignForFailure = "blocked", "none", true
 		default:
 			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("assignment is not accepting a failure report in its current phase"))
 		}
 	case p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_ROLLED_BACK:
-		if action != "rollback" || cordoned != 1 || (state != "failed" && state != "cordoned" && state != "activating" && state != "awaiting_tunnel" && state != "healthy_dwell") {
+		// Administrator cancellation can request rollback while preserving the
+		// blocked phase. Accept its verified root receipt, including assignments
+		// persisted by older servers, and retain the fresh-tunnel recovery gate.
+		if action != "rollback" || cordoned != 1 || (state != "failed" && state != "blocked" && state != "cordoned" && state != "activating" && state != "awaiting_tunnel" && state != "healthy_dwell") {
 			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("assignment is not cordoned for rollback"))
 		}
 		state, action, cordoned = "awaiting_tunnel", "none", 1
@@ -1344,13 +1378,16 @@ func (a *App) reconcileAgentUpdateMaintenance(ctx context.Context, now time.Time
 			}
 			campaigns[item.campaignID] = c
 			a.tryAdvanceAgentUpdateAssignmentLocked(ctx, x, c)
-		case item.rootCompleted.Valid && (item.state == "awaiting_tunnel" || item.state == "healthy_dwell"):
+		case item.action == "none" && item.rootCompleted.Valid && (item.state == "awaiting_tunnel" || item.state == "healthy_dwell"):
 			a.reconcileAgentUpdateSuccessLocked(ctx, item.agentID)
 		case item.campaignState == "running" && item.cordoned == 0 &&
 			item.action == "stage" && (item.state == "pending" || item.state == "staging") &&
 			!now.Before(item.updated.Add(agentUpdateStageTimeout)):
 			a.blockTimedOutAgentUpdateStageLocked(ctx, item, now)
-		case item.cordoned == 1 && (item.action == "activate" || item.action == "rollback") && !item.rootCompleted.Valid && !now.Before(item.updated.Add(agentUpdatePostActionTimeout)):
+		case item.cordoned == 1 && (item.action == "activate" || item.action == "rollback") && !now.Before(item.updated.Add(agentUpdatePostActionTimeout)):
+			// A committed receipt changes desired_action to none. Any remaining
+			// root completion belongs to an older action (including rows left by
+			// older management versions) and cannot disable this action's timer.
 			a.blockTimedOutAgentUpdateRootActionLocked(ctx, item, now)
 		}
 	}
@@ -1406,7 +1443,7 @@ func (a *App) blockTimedOutAgentUpdateRootActionLocked(ctx context.Context, item
 		return
 	}
 	defer tx.Rollback()
-	result, err := tx.ExecContext(ctx, `UPDATE agent_update_assignments SET state='blocked',desired_action='none',failure_code='root_action_timeout',failure_detail='the signed root action did not complete before the deadline',updated_at=? WHERE id=? AND desired_action=? AND cordoned=1 AND root_action_completed_at IS NULL AND updated_at=?`, now, item.id, item.action, item.updated)
+	result, err := tx.ExecContext(ctx, `UPDATE agent_update_assignments SET state='blocked',desired_action='none',failure_code='root_action_timeout',failure_detail='the signed root action did not complete before the deadline',updated_at=? WHERE id=? AND desired_action=? AND cordoned=1 AND updated_at=?`, now, item.id, item.action, item.updated)
 	if err != nil {
 		return
 	}
@@ -1605,8 +1642,14 @@ func (a *App) previewAgentUpdateAgents(ctx context.Context, requested []int64, t
 				item.Blockers = append(item.Blockers, "updater_version_incompatible")
 			}
 		}
-		if a.AgentHub == nil || a.AgentHub.connectedByID(id) == nil {
+		var conn *AgentConn
+		if a.AgentHub != nil {
+			conn = a.AgentHub.connectedByID(id)
+		}
+		if conn == nil {
 			item.Blockers = append(item.Blockers, "agent_disconnected")
+		} else if target.Version != "" && target.Commit != "" && conn.BuildVersion == target.Version && conn.BuildCommit == target.Commit {
+			item.Blockers = append(item.Blockers, "already_on_target")
 		}
 		if activeAssignments[id] > 0 {
 			item.Blockers = append(item.Blockers, "active_assignment")
@@ -2233,7 +2276,7 @@ func (a *App) persistAgentUpdateFreshTunnelLocked(ctx context.Context, conn *Age
 	// A new post-action connection invalidates build evidence from every older
 	// session. Repeated observations of the same live connection are no-ops so
 	// they cannot keep moving the health-dwell anchor.
-	_, err := exec(ctx, `UPDATE agent_update_assignments SET fresh_tunnel_at=?,observed_version=?,observed_commit=?,updated_at=? WHERE agent_id=? AND cordoned=1 AND root_action_completed_at IS NOT NULL AND root_action_completed_at<? AND state IN ('awaiting_tunnel','healthy_dwell') AND (fresh_tunnel_at IS NULL OR fresh_tunnel_at<>?)`, conn.ConnectedAt, conn.BuildVersion, conn.BuildCommit, conn.ConnectedAt, conn.AgentID, conn.ConnectedAt, conn.ConnectedAt)
+	_, err := exec(ctx, `UPDATE agent_update_assignments SET fresh_tunnel_at=?,observed_version=?,observed_commit=?,updated_at=? WHERE agent_id=? AND cordoned=1 AND desired_action='none' AND root_action_completed_at IS NOT NULL AND root_action_completed_at<? AND state IN ('awaiting_tunnel','healthy_dwell') AND (fresh_tunnel_at IS NULL OR fresh_tunnel_at<>?)`, conn.ConnectedAt, conn.BuildVersion, conn.BuildCommit, conn.ConnectedAt, conn.AgentID, conn.ConnectedAt, conn.ConnectedAt)
 	return err
 }
 
@@ -2258,7 +2301,7 @@ func (a *App) recordAgentUpdateObservedBuild(agentID int64, _ agentBuildIdentity
 }
 func (a *App) reconcileAgentUpdateSuccessLocked(ctx context.Context, agentID int64) {
 	x, c, err := a.activeAgentUpdateAssignment(ctx, agentID)
-	if err != nil {
+	if err != nil || x.DesiredAction != "none" {
 		return
 	}
 	var conn *AgentConn

--- a/internal/server/agent_updates_test.go
+++ b/internal/server/agent_updates_test.go
@@ -617,9 +617,20 @@ func TestAgentUpdateRootActionReportLostResponseRetryIsIdempotent(t *testing.T) 
 		RunningVersion: "v1.2.3", RunningCommit: strings.Repeat("c", 40),
 	}
 	report.RootActionReceipt = newAgentUpdateTestRootActionReceipt(t, app, agent.ID, activatorPrivate, agentupdateauth.AssignmentActionActivate, 1)
+	// The legacy rollback exception must never admit incomplete activation
+	// reports, either at first acceptance or during a lost-response retry.
+	empty := proto.Clone(report).(*p2pstreamv1.ReportAgentUpdateRequest)
+	empty.ManifestSha256, empty.BinarySha256, empty.RunningVersion, empty.RunningCommit = "", "", "", ""
+	signAgentUpdateTestReport(empty, updaterPrivate)
+	if _, err := app.ReportAgentUpdate(ctx, connect.NewRequest(empty)); connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Fatalf("activation accepted omitted result fields: %v", err)
+	}
 	signAgentUpdateTestReport(report, updaterPrivate)
 	if _, err := app.ReportAgentUpdate(ctx, connect.NewRequest(report)); err != nil {
 		t.Fatal(err)
+	}
+	if _, err := app.ReportAgentUpdate(ctx, connect.NewRequest(empty)); connect.CodeOf(err) != connect.CodeUnauthenticated {
+		t.Fatalf("activation retry accepted omitted result fields: %v", err)
 	}
 	if retry, err := app.ReportAgentUpdate(ctx, connect.NewRequest(report)); err != nil || retry.Msg.State != p2pstreamv1.AgentUpdateAssignmentState_AGENT_UPDATE_ASSIGNMENT_STATE_AWAITING_TUNNEL {
 		t.Fatalf("exact lost-response retry = %+v, %v", retry, err)
@@ -824,7 +835,7 @@ func TestCancelCampaignKeepsEscapedActivationCordonedAndSupersedesItWithRollback
 	if err := database.QueryRowContext(ctx, `SELECT state,desired_action,authorization_action,generation,cordoned FROM agent_update_assignments WHERE id=?`, assignmentID).Scan(&state, &action, &authorizationAction, &generation, &cordoned); err != nil {
 		t.Fatal(err)
 	}
-	if state != "cordoned" || action != "rollback" || authorizationAction != "activate" || generation != 2 || cordoned != 1 || !app.isAgentUpdateCordoned(agent.ID) {
+	if state != "cordoned" || action != "rollback" || authorizationAction != "" || generation != 2 || cordoned != 1 || !app.isAgentUpdateCordoned(agent.ID) {
 		t.Fatalf("cancelled escaped activation = state:%s action:%s auth:%s generation:%d cordoned:%d", state, action, authorizationAction, generation, cordoned)
 	}
 

--- a/internal/updater/activate.go
+++ b/internal/updater/activate.go
@@ -99,6 +99,16 @@ func Activate(ctx context.Context, options ActivateOptions) (Result, error) {
 	if !validVersion(ready.ServerVersion) {
 		return Result{}, errors.New("staged ready record has an invalid management server version")
 	}
+	commandFloor, err := loadRootCommandFloor(options.Paths)
+	if err != nil {
+		return Result{}, err
+	}
+	if ready.Authorization.Authorization.CommandSequence <= commandFloor.Sequence {
+		if ready.Authorization.Authorization.CommandSequence != commandFloor.Sequence {
+			return Result{}, errors.New("activation management authorization was superseded or replayed")
+		}
+		return replayCompletedActivation(options.Paths, ready, commandFloor, readyPath)
+	}
 	options.Policy.ServerVersion = ready.ServerVersion
 	manifest, err := readRegularNoFollow(filepath.Join(options.Paths.candidateDir(), "manifest.json"), defaultMaxMetadata)
 	if err != nil {
@@ -152,6 +162,16 @@ func Activate(ctx context.Context, options ActivateOptions) (Result, error) {
 		return Result{}, err
 	}
 	candidate := filepath.ToSlash(filepath.Join("slots", release.Version, "p2pstream"))
+	if previous == candidate {
+		// Reinstalling the exact active target must retain its distinct recovery
+		// slot. Otherwise a subsequent rollback would restore the failed target
+		// to itself and make recovery impossible.
+		previousSlot, err = previousSlotForReactivation(options.Paths, previousSlot)
+		if err != nil {
+			return Result{}, err
+		}
+		previous = previousSlot.Target
+	}
 	authorizationDigest, err := agentupdateauth.AssignmentAuthorizationDigest(ready.Authorization.Authorization)
 	if err != nil {
 		return Result{}, err
@@ -426,6 +446,89 @@ func loadCurrentSlotMetadata(paths Paths, target string) (slotMetadata, error) {
 	return slot, nil
 }
 
+func previousSlotForReactivation(paths Paths, current slotMetadata) (slotMetadata, error) {
+	data, err := readRegularNoFollow(paths.lastActivationPath(), 256<<10)
+	if err != nil {
+		return slotMetadata{}, fmt.Errorf("read previous activation for exact-target reinstall: %w", err)
+	}
+	var activation completedActivation
+	if err := strictJSON(data, &activation); err != nil {
+		return slotMetadata{}, err
+	}
+	counter, err := loadRootActionCounter(paths.rootActionCounterPath())
+	if err != nil {
+		return slotMetadata{}, err
+	}
+	if counter == 0 || activation.Receipt.Receipt.RootActionCounter != counter || activation.ActivatedSlot != current ||
+		activation.Receipt.Receipt.Action != agentupdateauth.AssignmentActionActivate ||
+		!receiptResultMatchesSlot(activation.Receipt.Receipt, current) || activation.PreviousSlot.Target == current.Target {
+		return slotMetadata{}, errors.New("exact-target reinstall has no distinct authenticated recovery slot")
+	}
+	if err := verifyRootActionReceiptRecord(paths, activation.Receipt, activation.Authorization, counter-1, time.Now().UTC()); err != nil {
+		return slotMetadata{}, err
+	}
+	if err := validateSlotMetadata(activation.PreviousSlot); err != nil {
+		return slotMetadata{}, err
+	}
+	return activation.PreviousSlot, nil
+}
+
+func replayCompletedActivation(paths Paths, ready readyRecord, floor rootCommandFloor, readyPath string) (Result, error) {
+	a := ready.Authorization.Authorization
+	digest, err := agentupdateauth.AssignmentAuthorizationDigest(a)
+	if err != nil || floor.AuthorizationSHA256 != hex.EncodeToString(digest[:]) {
+		return Result{}, errors.New("replayed activation command has a different authorization digest")
+	}
+	data, err := readRegularNoFollow(paths.lastActivationPath(), 256<<10)
+	if err != nil {
+		return Result{}, fmt.Errorf("completed activation receipt is unavailable for command replay: %w", err)
+	}
+	var activation completedActivation
+	if err := strictJSON(data, &activation); err != nil {
+		return Result{}, err
+	}
+	if !sameAssignmentAuthorizationRecord(activation.Authorization, ready.Authorization) ||
+		ready.AgentPublicID != a.AgentPublicID || ready.AssignmentID != a.AssignmentID || ready.Generation != a.Generation ||
+		ready.Nonce != base64.StdEncoding.EncodeToString(a.Nonce) || ready.ServerVersion != a.ServerVersion ||
+		ready.Version != a.TargetVersion || ready.Commit != a.TargetCommit || ready.ManifestSHA != a.ManifestSHA256 ||
+		ready.Sequence != a.ReleaseSequence || ready.SecurityEpoch != a.SecurityEpoch ||
+		ready.ArtifactName != a.ArtifactName || ready.ArtifactSize != a.ArtifactSize || ready.ArtifactSHA != a.ArtifactSHA256 {
+		return Result{}, errors.New("completed activation command does not match its exact authorization")
+	}
+	counter, err := loadRootActionCounter(paths.rootActionCounterPath())
+	if err != nil {
+		return Result{}, err
+	}
+	r := activation.Receipt.Receipt
+	if counter == 0 || r.RootActionCounter != counter || r.Action != agentupdateauth.AssignmentActionActivate {
+		return Result{}, errors.New("completed activation receipt does not match the latest root action")
+	}
+	if err := verifyAssignmentAuthorizationRecord(paths, ready.Authorization, agentupdateauth.AssignmentActionActivate, time.UnixMilli(a.IssuedAtUnixMillis), 0); err != nil {
+		return Result{}, err
+	}
+	if err := verifyRootActionReceiptRecord(paths, activation.Receipt, ready.Authorization, counter-1, time.Now().UTC()); err != nil {
+		return Result{}, err
+	}
+	current, err := currentTarget(paths)
+	if err != nil {
+		return Result{}, err
+	}
+	slot, err := loadCurrentSlotMetadata(paths, current)
+	if err != nil {
+		return Result{}, err
+	}
+	if slot != activation.ActivatedSlot || !receiptResultMatchesSlot(r, slot) {
+		return Result{}, errors.New("completed activation receipt does not describe the current slot")
+	}
+	if err := atomicJSON(paths.rootActionReceiptPath(), activation.Receipt, 0644); err != nil {
+		return Result{}, err
+	}
+	if err := clearStagedIfMatchingAuthorization(paths, readyPath, ready.Authorization); err != nil {
+		return Result{}, err
+	}
+	return Result{Version: r.ResultVersion, Sequence: r.ResultReleaseSequence, SecurityEpoch: r.ResultSecurityEpoch}, nil
+}
+
 func recoverActivation(ctx context.Context, options ActivateOptions) error {
 	data, err := readRegularNoFollow(options.Paths.journalPath(), 64<<10)
 	if errors.Is(err, os.ErrNotExist) {
@@ -457,6 +560,9 @@ func rollback(ctx context.Context, options ActivateOptions, journal activationJo
 	}
 	if err := restartAndCheck(ctx, options.Service); err != nil {
 		return fmt.Errorf("previous slot failed health check: %w", err)
+	}
+	if err := atomicJSON(options.Paths.currentSlotMetadataPath(), journal.PreviousSlot, 0600); err != nil {
+		return err
 	}
 	return removeAndSync(options.Paths.journalPath())
 }
@@ -490,6 +596,40 @@ func clearStagedIfMatchingAuthorization(paths Paths, readyPath string, expected 
 	if readyPath == "" {
 		readyPath = paths.readyPath()
 	}
+	// The worker can be publishing the next candidate while root finishes an
+	// earlier action. Open its existing lock read-only: creating it as root
+	// would prevent later unprivileged polls from acquiring their own lock.
+	removeOldClaim := func() error {
+		if readyPath == paths.readyPath() {
+			return nil
+		}
+		data, err := readRegularNoFollow(readyPath, 64<<10)
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		var ready readyRecord
+		if strictJSON(data, &ready) != nil || !sameAssignmentAuthorizationRecord(ready.Authorization, expected) {
+			return nil
+		}
+		return removeAndSync(readyPath)
+	}
+	lock, err := openRegularNoFollow(filepath.Join(paths.workerStateDir(), "worker.lock"), 64<<10)
+	if errors.Is(err, os.ErrNotExist) {
+		return removeOldClaim()
+	}
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+	if err := unix.Flock(int(lock.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+			return removeOldClaim()
+		}
+		return err
+	}
 	data, err := readRegularNoFollow(readyPath, 64<<10)
 	if errors.Is(err, os.ErrNotExist) {
 		// A stale completed journal must never treat a later campaign's shared
@@ -504,12 +644,43 @@ func clearStagedIfMatchingAuthorization(paths Paths, readyPath string, expected 
 		return nil
 	}
 	if readyPath != paths.readyPath() {
-		if _, liveErr := os.Lstat(paths.readyPath()); liveErr == nil {
-			// A newer staging command owns the shared candidate directory.
+		liveData, liveErr := readRegularNoFollow(paths.readyPath(), 64<<10)
+		if errors.Is(liveErr, os.ErrNotExist) {
+			// staged.json has no assignment binding. Even identical release
+			// metadata may belong to a new generation that has no ready edge yet.
+			// Retain that bounded candidate cache and consume only our root claim.
 			return removeAndSync(readyPath)
-		} else if !errors.Is(liveErr, os.ErrNotExist) {
+		}
+		if liveErr != nil {
 			return liveErr
 		}
+		var live readyRecord
+		if strictJSON(liveData, &live) != nil || !sameAssignmentAuthorizationRecord(live.Authorization, expected) {
+			return removeAndSync(readyPath)
+		}
 	}
-	return clearStaged(paths, readyPath)
+	stagedData, err := readRegularNoFollow(paths.stagedPath(), 64<<10)
+	if errors.Is(err, os.ErrNotExist) {
+		return removeAndSync(readyPath)
+	}
+	if err != nil {
+		return err
+	}
+	var staged stagedRecord
+	a := expected.Authorization
+	want := stagedRecord{Version: a.TargetVersion, Commit: a.TargetCommit, ManifestSHA: a.ManifestSHA256,
+		Sequence: a.ReleaseSequence, SecurityEpoch: a.SecurityEpoch, ArtifactName: a.ArtifactName,
+		ArtifactSize: a.ArtifactSize, ArtifactSHA: a.ArtifactSHA256, ServerVersion: a.ServerVersion}
+	if strictJSON(stagedData, &staged) != nil || staged != want {
+		return removeAndSync(readyPath)
+	}
+	// Under the worker lock, this matching live ready edge proves ownership:
+	// Stage always removes it before it starts publishing another candidate.
+	if err := clearStaged(paths, paths.readyPath()); err != nil {
+		return err
+	}
+	if readyPath != paths.readyPath() {
+		return removeAndSync(readyPath)
+	}
+	return nil
 }

--- a/internal/updater/agentupdate_adapter.go
+++ b/internal/updater/agentupdate_adapter.go
@@ -22,6 +22,7 @@ func (AgentUpdateVerifier) Verify(manifestJSON []byte, policy VerifyPolicy) (Ver
 		CurrentSecurityEpoch:      policy.CurrentSecurityEpoch,
 		CurrentMinimumSafeVersion: policy.CurrentMinimumSafeVersion,
 		CurrentVersion:            policy.CurrentVersion,
+		CurrentManifestSHA256:     policy.CurrentManifestSHA256,
 		ServerVersion:             policy.ServerVersion,
 		UpdaterVersion:            policy.UpdaterVersion,
 		ProtocolVersion:           policy.ProtocolVersion,

--- a/internal/updater/attestation.go
+++ b/internal/updater/attestation.go
@@ -218,8 +218,9 @@ func persistHealthyActivation(paths Paths, journal activationJournal, readyPath 
 	if err := atomicJSON(paths.rootActionCounterPath(), rootActionCounter{Counter: journal.Receipt.Receipt.RootActionCounter}, 0600); err != nil {
 		return err
 	}
-	floor := Floor{Sequence: journal.Sequence, SecurityEpoch: journal.SecurityEpoch, MinimumSafeVersion: journal.MinimumSafeVersion, Version: journal.Version}
-	if err := atomicJSON(paths.floorPath(), floor, 0640); err != nil {
+	floor := Floor{Sequence: journal.Sequence, SecurityEpoch: journal.SecurityEpoch, MinimumSafeVersion: journal.MinimumSafeVersion,
+		Version: journal.Version, ManifestSHA256: journal.Receipt.Receipt.ResultManifestSHA256}
+	if err := persistFloor(paths, floor); err != nil {
 		return err
 	}
 	if err := atomicJSON(paths.previousSlotPath(), journal.PreviousSlot, 0600); err != nil {
@@ -264,6 +265,14 @@ func validateSlotMetadata(slot slotMetadata) error {
 		return errors.New("slot metadata result kind is invalid")
 	}
 	return nil
+}
+
+func receiptResultMatchesSlot(receipt agentupdateauth.RootActionReceipt, slot slotMetadata) bool {
+	return receipt.ResultKind == slot.ResultKind && receipt.ResultManifestSHA256 == slot.ManifestSHA256 &&
+		receipt.ResultVersion == slot.BuildVersion && receipt.ResultCommit == slot.BuildCommit &&
+		receipt.ResultReleaseSequence == slot.ReleaseSequence && receipt.ResultSecurityEpoch == slot.SecurityEpoch &&
+		receipt.ResultOS == slot.OS && receipt.ResultArch == slot.Arch && receipt.ResultArtifactName == slot.ArtifactName &&
+		receipt.ResultArtifactSize == slot.ArtifactSize && receipt.ResultArtifactSHA256 == slot.ArtifactSHA256
 }
 
 func LoadRootActionReceipt(paths Paths) (rootActionReceiptRecord, error) {

--- a/internal/updater/control.go
+++ b/internal/updater/control.go
@@ -137,6 +137,11 @@ func (c WorkerControl) Enroll(ctx context.Context, config HostConfig) error {
 	if c.API == nil {
 		return errors.New("updater control API is required")
 	}
+	lock, err := acquireLock(filepath.Join(c.Paths.workerStateDir(), "worker.lock"))
+	if err != nil {
+		return fmt.Errorf("lock updater enrollment state: %w", err)
+	}
+	defer lock.Close()
 	private, err := c.privateKey()
 	if err != nil {
 		return err
@@ -429,6 +434,23 @@ func FinalizeEnrollment(paths Paths) error {
 	}
 	if err := removeAndSync(paths.enrollmentTokenPath()); err != nil {
 		return err
+	}
+	// Explicit verified repair must also recover units previously stopped by
+	// systemd's start limit. Otherwise enabling the corrected runner leaves the
+	// activator/path failed and the next signed action never executes.
+	for _, unit := range []string{"p2pstream-updater.service", "p2pstream-updater-activate.service", "p2pstream-updater-activate.path"} {
+		// reset-failed rejects never-loaded units on a fresh install. Load and
+		// validate only our installed units before resetting their exact names.
+		state, err := exec.Command("/usr/bin/systemctl", "show", "--property=LoadState", "--value", unit).Output()
+		if err != nil {
+			return fmt.Errorf("load repaired updater unit %s: %w", unit, err)
+		}
+		if strings.TrimSpace(string(state)) != "loaded" {
+			return fmt.Errorf("repaired updater unit %s is not loaded", unit)
+		}
+	}
+	if err := exec.Command("/usr/bin/systemctl", "reset-failed", "p2pstream-updater.service", "p2pstream-updater-activate.service", "p2pstream-updater-activate.path").Run(); err != nil {
+		return fmt.Errorf("reset repaired updater units: %w", err)
 	}
 	if err := exec.Command("/usr/bin/systemctl", "start", "p2pstream-updater.timer", "p2pstream-updater-activate.path").Run(); err != nil {
 		return fmt.Errorf("start updater units: %w", err)

--- a/internal/updater/deep_review_test.go
+++ b/internal/updater/deep_review_test.go
@@ -1,0 +1,842 @@
+package updater
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"p2pstream/internal/agentupdate"
+	"p2pstream/internal/agentupdateauth"
+	"p2pstream/internal/buildinfo"
+)
+
+// This test must also run in the isolated root-owned host test environment:
+// ordinary same-user filesystem tests cannot detect the worker losing access
+// to files atomically replaced by the root activator.
+func TestActivationKeepsFloorReadableByWorker(t *testing.T) {
+	if floorPath := os.Getenv("P2PSTREAM_DEEP_REVIEW_READ_FLOOR"); floorPath != "" {
+		if _, err := loadFloor(floorPath); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	if os.Geteuid() != 0 {
+		t.Skip("requires an isolated root test environment to model separate activator and worker users")
+	}
+	f := newFixture(t)
+	const workerID = 23456
+	fixtureRoot := filepath.Dir(f.paths.StateDir)
+	for _, dir := range []string{filepath.Dir(fixtureRoot), fixtureRoot} {
+		if err := os.Chmod(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Chown(f.paths.StateDir, 0, workerID); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(f.paths.StateDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	// Model bootstrap's root:p2pstream-updater 0640 floor exactly.
+	if err := os.Chown(f.paths.floorPath(), 0, workerID); err != nil {
+		t.Fatal(err)
+	}
+	readAsWorker := func() ([]byte, error) {
+		cmd := exec.Command(os.Args[0], "-test.run=^TestActivationKeepsFloorReadableByWorker$")
+		cmd.Env = append(os.Environ(), "P2PSTREAM_DEEP_REVIEW_READ_FLOOR="+f.paths.floorPath())
+		cmd.SysProcAttr = &syscall.SysProcAttr{Credential: &syscall.Credential{Uid: workerID, Gid: workerID}}
+		return cmd.CombinedOutput()
+	}
+	if output, err := readAsWorker(); err != nil {
+		t.Fatalf("bootstrap floor is not readable by worker: %v\n%s", err, output)
+	}
+	stageAndRequestActivation(t, f)
+	if _, err := Activate(context.Background(), ActivateOptions{
+		Paths: f.paths, Verifier: f.verifier, Service: &fakeService{}, DiskPreflight: allowDisk,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if output, err := readAsWorker(); err != nil {
+		info, _ := os.Stat(f.paths.floorPath())
+		t.Fatalf("activation made security floor unreadable to the worker (mode/owner=%+v): %v\n%s", info.Sys(), err, output)
+	}
+}
+
+func TestRetrySameTargetAfterManagedRollback(t *testing.T) {
+	f := productionVerifierFixture(t)
+	policy := VerifyPolicy{ServerVersion: "v1.5.0", UpdaterVersion: "v1.0.0", ProtocolVersion: 1}
+	if _, err := Stage(context.Background(), StageOptions{
+		Paths: f.paths, Source: f.source, Verifier: AgentUpdateVerifier{}, Policy: policy, DiskPreflight: allowDisk,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	requestFixtureActivation(t, f)
+	if _, err := Activate(context.Background(), ActivateOptions{
+		Paths: f.paths, Verifier: AgentUpdateVerifier{}, Service: &fakeService{}, Policy: policy, DiskPreflight: allowDisk,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	assignment := f.assignment
+	assignment.Generation++
+	rollbackAuthorization := signedFixtureAuthorization(t, f.authorityPrivate, f.authorization.Authorization.AuthorityKeyID,
+		assignment, f.release, agentupdateauth.AssignmentActionRollback, 2)
+	if err := RequestRollback(f.paths, rollbackAuthorization); err != nil {
+		t.Fatal(err)
+	}
+	if err := Rollback(context.Background(), f.paths, &fakeService{}); err != nil {
+		t.Fatal(err)
+	}
+	current, err := currentTarget(f.paths)
+	if err != nil || current != f.bootstrap.Target {
+		t.Fatalf("managed rollback did not restore bootstrap slot: %q, %v", current, err)
+	}
+	// Retry uses a new management command, but the immutable target remains the
+	// same. A rollback must not make that permitted retry impossible to stage.
+	result, err := Stage(context.Background(), StageOptions{
+		Paths: f.paths, Source: f.source, Verifier: AgentUpdateVerifier{},
+		Policy: policy, DiskPreflight: allowDisk,
+	})
+	if err != nil {
+		t.Fatalf("same-target retry after managed rollback cannot stage: %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("same-target retry did not restage the candidate removed by completed activation")
+	}
+	requestFixtureActivation(t, f)
+	if _, err := Activate(context.Background(), ActivateOptions{
+		Paths: f.paths, Verifier: AgentUpdateVerifier{}, Service: &fakeService{}, Policy: policy, DiskPreflight: allowDisk,
+	}); err == nil || !strings.Contains(err.Error(), "replayed") {
+		t.Fatalf("same-target retry accepted the consumed authorization: %v", err)
+	}
+	assignment.Generation++
+	f.assignment = assignment
+	f.authorization = signedFixtureAuthorization(t, f.authorityPrivate, f.authorization.Authorization.AuthorityKeyID,
+		assignment, f.release, agentupdateauth.AssignmentActionActivate, 3)
+	requestFixtureActivation(t, f)
+	if _, err := Activate(context.Background(), ActivateOptions{
+		Paths: f.paths, Verifier: AgentUpdateVerifier{}, Service: &fakeService{}, Policy: policy, DiskPreflight: allowDisk,
+	}); err != nil {
+		t.Fatalf("same-target retry after managed rollback cannot activate: %v", err)
+	}
+}
+
+func productionVerifierFixture(t *testing.T) fixture {
+	t.Helper()
+	f := newFixture(t)
+	now := time.Now().UTC()
+	manifest := agentupdate.Manifest{
+		SchemaVersion: agentupdate.SchemaVersion, Channel: "stable", Version: f.release.Version,
+		Commit: f.release.Commit, Sequence: f.release.Sequence, SecurityEpoch: f.release.SecurityEpoch,
+		MinimumSafeVersion: f.release.MinimumSafeVersion,
+		PublishedAt:        now.Add(-time.Hour).Format(time.RFC3339), ExpiresAt: now.Add(24 * time.Hour).Format(time.RFC3339),
+		Compatibility: agentupdate.Compatibility{
+			Server:   agentupdate.VersionRange{Min: "v1.0.0", Max: "v2.0.0"},
+			Updater:  agentupdate.VersionRange{Min: "v1.0.0", Max: "v2.0.0"},
+			Protocol: agentupdate.ProtocolRange{Min: 1, Max: 2},
+		},
+		Artifacts: []agentupdate.Artifact{{OS: runtime.GOOS, Arch: runtime.GOARCH, Name: f.release.Artifact.Name,
+			Size: uint64(f.release.Artifact.Size), SHA256: artifactHex(f.release.Artifact)}},
+	}
+	data, err := agentupdate.CanonicalManifest(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(data)
+	f.release.ManifestSHA256 = hex.EncodeToString(digest[:])
+	f.source.manifest = data
+	f.verifier.release = f.release
+	f.authorization = signedFixtureAuthorization(t, f.authorityPrivate, f.authorization.Authorization.AuthorityKeyID,
+		f.assignment, f.release, agentupdateauth.AssignmentActionActivate, 1)
+	return f
+}
+
+func TestRepeatRollbackUsesFreshAuthorizationAndSameKnownGoodSlot(t *testing.T) {
+	f := newFixture(t)
+	stageAndRequestActivation(t, f)
+	staleReady, err := os.ReadFile(f.paths.readyPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Activate(context.Background(), ActivateOptions{
+		Paths: f.paths, Verifier: f.verifier, Service: &fakeService{}, DiskPreflight: allowDisk,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for sequence := uint64(2); sequence <= 3; sequence++ {
+		assignment := f.assignment
+		assignment.Generation += int64(sequence)
+		authorization := signedFixtureAuthorization(t, f.authorityPrivate, f.authorization.Authorization.AuthorityKeyID,
+			assignment, f.release, agentupdateauth.AssignmentActionRollback, sequence)
+		if sequence == 3 {
+			if err := os.WriteFile(f.paths.readyPath(), staleReady, 0600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := RequestRollback(f.paths, authorization); err != nil {
+			t.Fatal(err)
+		}
+		if err := Rollback(context.Background(), f.paths, &fakeService{}); err != nil {
+			t.Fatal(err)
+		}
+		current, err := currentTarget(f.paths)
+		if err != nil || current != f.bootstrap.Target {
+			t.Fatalf("rollback %d changed known-good slot: %q, %v", sequence, current, err)
+		}
+		data, err := os.ReadFile(f.paths.rollbackResultPath())
+		if err != nil {
+			t.Fatal(err)
+		}
+		var result rollbackRecord
+		if err := strictJSON(data, &result); err != nil {
+			t.Fatal(err)
+		}
+		if result.Receipt.Receipt.RootActionCounter != sequence || result.Receipt.Receipt.Generation != assignment.Generation ||
+			result.Receipt.Receipt.ResultArtifactSHA256 != f.bootstrap.ArtifactSHA256 || result.Receipt.Receipt.ResultVersion != f.bootstrap.BuildVersion {
+			t.Fatalf("rollback %d receipt does not bind fresh authorization and bootstrap: %+v", sequence, result.Receipt.Receipt)
+		}
+	}
+	if _, err := os.Stat(f.paths.readyPath()); !os.IsNotExist(err) {
+		t.Fatalf("repeat rollback retained superseded activation edge: %v", err)
+	}
+}
+
+func TestRollbackDoesNotExecuteSameCompletedAuthorizationTwice(t *testing.T) {
+	f := newFixture(t)
+	authorization := signedFixtureAuthorization(t, f.authorityPrivate, f.authorization.Authorization.AuthorityKeyID,
+		f.assignment, f.release, agentupdateauth.AssignmentActionRollback, 1)
+	if err := RequestRollback(f.paths, authorization); err != nil {
+		t.Fatal(err)
+	}
+	service := &fakeService{}
+	if err := Rollback(context.Background(), f.paths, service); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(f.paths.rollbackResultPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A second worker check may race with the helper completing the first one.
+	if err := RequestRollback(f.paths, authorization); err != nil {
+		t.Fatal(err)
+	}
+	if err := Rollback(context.Background(), f.paths, service); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(f.paths.rollbackResultPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Fatal("a replayed completed rollback authorization executed again and replaced its signed receipt")
+	}
+	if service.restarts != 1 {
+		t.Fatalf("completed rollback replay restarted the agent %d times", service.restarts)
+	}
+}
+
+func TestReinstallExactActiveTargetPreservesDistinctRollbackSlot(t *testing.T) {
+	for _, failReinstall := range []bool{false, true} {
+		name := "managed rollback"
+		if failReinstall {
+			name = "local health rollback"
+		}
+		t.Run(name, func(t *testing.T) {
+			f := productionVerifierFixture(t)
+			policy := VerifyPolicy{ServerVersion: "v1.5.0", UpdaterVersion: "v1.0.0", ProtocolVersion: 1}
+			for sequence := uint64(1); sequence <= 2; sequence++ {
+				f.assignment.Generation++
+				f.authorization = signedFixtureAuthorization(t, f.authorityPrivate, f.authorization.Authorization.AuthorityKeyID,
+					f.assignment, f.release, agentupdateauth.AssignmentActionActivate, sequence)
+				if _, err := Stage(context.Background(), StageOptions{
+					Paths: f.paths, Source: f.source, Verifier: AgentUpdateVerifier{}, Policy: policy, DiskPreflight: allowDisk,
+				}); err != nil {
+					t.Fatal(err)
+				}
+				requestFixtureActivation(t, f)
+				_, err := Activate(context.Background(), ActivateOptions{
+					Paths: f.paths, Verifier: AgentUpdateVerifier{}, Service: &fakeService{failHealth: failReinstall && sequence == 2},
+					Policy: policy, DiskPreflight: allowDisk,
+				})
+				if failReinstall && sequence == 2 {
+					if err == nil || !strings.Contains(err.Error(), "rolled back") {
+						t.Fatalf("reinstall health failure did not roll back: %v", err)
+					}
+				} else if err != nil {
+					t.Fatal(err)
+				}
+			}
+			f.assignment.Generation++
+			authorization := signedFixtureAuthorization(t, f.authorityPrivate, f.authorization.Authorization.AuthorityKeyID,
+				f.assignment, f.release, agentupdateauth.AssignmentActionRollback, 3)
+			if err := RequestRollback(f.paths, authorization); err != nil {
+				t.Fatal(err)
+			}
+			if err := Rollback(context.Background(), f.paths, &fakeService{}); err != nil {
+				t.Fatal(err)
+			}
+			current, err := currentTarget(f.paths)
+			if err != nil || current != f.bootstrap.Target {
+				t.Fatalf("reinstall discarded original known-good slot: %q, %v", current, err)
+			}
+			metadata, err := loadCurrentSlotMetadata(f.paths, current)
+			if err != nil || metadata != f.bootstrap {
+				t.Fatalf("rollback current metadata does not describe the recovered slot: %+v, %v", metadata, err)
+			}
+		})
+	}
+}
+
+func TestLegacyFloorManifestMigrationRequiresMatchingAuthenticatedReceipt(t *testing.T) {
+	for _, kind := range []string{"matching activation", "after rollback", "missing receipt", "newer floor", "tampered root receipt", "tampered authorization", "ahead root counter", "wrong signed result"} {
+		t.Run(kind, func(t *testing.T) {
+			f := newFixture(t)
+			stageAndRequestActivation(t, f)
+			if _, err := Activate(context.Background(), ActivateOptions{
+				Paths: f.paths, Verifier: f.verifier, Service: &fakeService{}, DiskPreflight: allowDisk,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			floor, err := loadFloor(f.paths.floorPath())
+			if err != nil {
+				t.Fatal(err)
+			}
+			floor.ManifestSHA256 = ""
+			if kind == "newer floor" {
+				floor.Sequence++
+				floor.Version = "v1.2.0"
+			}
+			if err := atomicJSON(f.paths.floorPath(), floor, 0640); err != nil {
+				t.Fatal(err)
+			}
+			wantError := false
+			switch kind {
+			case "after rollback":
+				assignment := f.assignment
+				assignment.Generation++
+				authorization := signedFixtureAuthorization(t, f.authorityPrivate, f.authorization.Authorization.AuthorityKeyID,
+					assignment, f.release, agentupdateauth.AssignmentActionRollback, 2)
+				if err := RequestRollback(f.paths, authorization); err != nil {
+					t.Fatal(err)
+				}
+				if err := Rollback(context.Background(), f.paths, &fakeService{}); err != nil {
+					t.Fatal(err)
+				}
+			case "missing receipt":
+				if err := os.Remove(f.paths.lastActivationPath()); err != nil {
+					t.Fatal(err)
+				}
+			case "ahead root counter":
+				wantError = true
+				if err := atomicJSON(f.paths.rootActionCounterPath(), rootActionCounter{}, 0600); err != nil {
+					t.Fatal(err)
+				}
+			case "tampered root receipt", "tampered authorization", "wrong signed result":
+				wantError = true
+				data, err := os.ReadFile(f.paths.lastActivationPath())
+				if err != nil {
+					t.Fatal(err)
+				}
+				var record completedActivation
+				if err := strictJSON(data, &record); err != nil {
+					t.Fatal(err)
+				}
+				if kind == "tampered root receipt" {
+					record.Receipt.Signature[0] ^= 1
+				} else if kind == "tampered authorization" {
+					record.Authorization.Signature[0] ^= 1
+				} else {
+					record.Receipt.Receipt.ResultArtifactSHA256 = strings.Repeat("f", 64)
+					private, err := loadActivatorPrivateKey(f.paths.activatorPrivateKeyPath())
+					if err != nil {
+						t.Fatal(err)
+					}
+					record.Receipt.CanonicalPayload, err = agentupdateauth.RootActionReceiptPayload(record.Receipt.Receipt)
+					if err != nil {
+						t.Fatal(err)
+					}
+					record.Receipt.Signature, err = agentupdateauth.SignRootActionReceipt(private, record.Receipt.Receipt)
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+				if err := atomicJSON(f.paths.lastActivationPath(), record, 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			err = restoreFloorManifestPin(f.paths)
+			if (err != nil) != wantError {
+				t.Fatalf("floor migration error = %v, wantError=%v", err, wantError)
+			}
+			got, err := loadFloor(f.paths.floorPath())
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := floor
+			if kind == "matching activation" || kind == "after rollback" {
+				want.ManifestSHA256 = f.release.ManifestSHA256
+			}
+			if got != want {
+				t.Fatalf("migration modified the floor without matching evidence: got %+v, want %+v", got, want)
+			}
+		})
+	}
+}
+
+func TestCompletedRollbackReplayKeepsProofAndRejectsSubstitution(t *testing.T) {
+	for _, kind := range []string{"lost worker publication", "legacy fallback", "forged legacy fallback", "different authorization", "superseded command"} {
+		t.Run(kind, func(t *testing.T) {
+			f := newFixture(t)
+			authorization := signedFixtureAuthorization(t, f.authorityPrivate, f.authorization.Authorization.AuthorityKeyID,
+				f.assignment, f.release, agentupdateauth.AssignmentActionRollback, 1)
+			if err := RequestRollback(f.paths, authorization); err != nil {
+				t.Fatal(err)
+			}
+			if err := Rollback(context.Background(), f.paths, &fakeService{}); err != nil {
+				t.Fatal(err)
+			}
+			original, err := os.ReadFile(f.paths.rollbackResultPath())
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantError, wantCounter := false, uint64(1)
+			switch kind {
+			case "lost worker publication":
+				if err := os.Remove(f.paths.rollbackResultPath()); err != nil {
+					t.Fatal(err)
+				}
+			case "legacy fallback", "forged legacy fallback":
+				if err := os.Remove(f.paths.lastRollbackPath()); err != nil {
+					t.Fatal(err)
+				}
+				if kind == "forged legacy fallback" {
+					wantError = true
+					var result rollbackRecord
+					if err := strictJSON(original, &result); err != nil {
+						t.Fatal(err)
+					}
+					result.Receipt.Signature[0] ^= 1
+					if err := atomicJSON(f.paths.rollbackResultPath(), result, 0644); err != nil {
+						t.Fatal(err)
+					}
+				}
+			case "different authorization":
+				wantError = true
+				assignment := f.assignment
+				assignment.Generation++
+				authorization = signedFixtureAuthorization(t, f.authorityPrivate, f.authorization.Authorization.AuthorityKeyID,
+					assignment, f.release, agentupdateauth.AssignmentActionRollback, 1)
+			case "superseded command":
+				wantError, wantCounter = true, 2
+				assignment := f.assignment
+				assignment.Generation++
+				newer := signedFixtureAuthorization(t, f.authorityPrivate, f.authorization.Authorization.AuthorityKeyID,
+					assignment, f.release, agentupdateauth.AssignmentActionRollback, 2)
+				if err := RequestRollback(f.paths, newer); err != nil {
+					t.Fatal(err)
+				}
+				if err := Rollback(context.Background(), f.paths, &fakeService{}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := RequestRollback(f.paths, authorization); err != nil {
+				t.Fatal(err)
+			}
+			service := &fakeService{}
+			err = Rollback(context.Background(), f.paths, service)
+			if (err != nil) != wantError {
+				t.Fatalf("replay error = %v, wantError=%v", err, wantError)
+			}
+			counter, err := loadRootActionCounter(f.paths.rootActionCounterPath())
+			if err != nil || counter != wantCounter || service.restarts != 0 {
+				t.Fatalf("replay changed counter or restarted: counter=%d, restarts=%d, err=%v", counter, service.restarts, err)
+			}
+			if !wantError {
+				replayed, err := os.ReadFile(f.paths.rollbackResultPath())
+				if err != nil || string(replayed) != string(original) {
+					t.Fatalf("replay did not restore the original signed result: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestNewlyEnrolledOldTunnelCanUpgradeToRescueRelease(t *testing.T) {
+	f := productionVerifierFixture(t)
+	if err := pinBootstrapState(f.paths, bootstrapVersionFloor(f.release.Version, f.bootstrap.BuildVersion), true, os.Geteuid(), os.Getegid()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Stage(context.Background(), StageOptions{
+		Paths: f.paths, Source: f.source, Verifier: AgentUpdateVerifier{},
+		Policy: VerifyPolicy{ServerVersion: "v1.5.0", UpdaterVersion: f.release.Version, ProtocolVersion: 1}, DiskPreflight: allowDisk,
+	}); err != nil {
+		t.Fatalf("new rescue runner prevents preserved older tunnel upgrading to current release: %v", err)
+	}
+}
+
+func TestActivationRefreshesStagedManagementVersionOnlyAfterReverification(t *testing.T) {
+	previousVersion := buildinfo.Version
+	buildinfo.Version = "v1.0.0"
+	t.Cleanup(func() { buildinfo.Version = previousVersion })
+	for _, kind := range []string{"compatible server", "incompatible server", "forged authorization", "changed staged manifest"} {
+		t.Run(kind, func(t *testing.T) {
+			f := productionVerifierFixture(t)
+			policy := VerifyPolicy{ServerVersion: "v1.5.0", UpdaterVersion: "v1.0.0", ProtocolVersion: 1}
+			if _, err := Stage(context.Background(), StageOptions{
+				Paths: f.paths, Source: f.source, Verifier: AgentUpdateVerifier{}, Policy: policy, DiskPreflight: allowDisk,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			before, err := os.ReadFile(f.paths.stagedPath())
+			if err != nil {
+				t.Fatal(err)
+			}
+			serverVersion := "v1.5.1"
+			if kind == "incompatible server" {
+				serverVersion = "v2.1.0"
+			}
+			f.authorization.Authorization.ServerVersion = serverVersion
+			f.authorization.CanonicalPayload, err = agentupdateauth.AssignmentAuthorizationPayload(f.authorization.Authorization)
+			if err != nil {
+				t.Fatal(err)
+			}
+			f.authorization.Signature, err = agentupdateauth.SignAssignmentAuthorization(f.authorityPrivate, f.authorization.Authorization)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if kind == "forged authorization" {
+				f.authorization.Signature[0] ^= 1
+			}
+			if kind == "changed staged manifest" {
+				manifest, err := agentupdate.ParseManifest(f.source.manifest)
+				if err != nil {
+					t.Fatal(err)
+				}
+				manifest.Commit = strings.Repeat("c", 40)
+				data, err := agentupdate.CanonicalManifest(manifest)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := atomicWrite(filepath.Join(f.paths.candidateDir(), "manifest.json"), data, 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			err = RequestActivation(f.paths, f.authorization, f.release, serverVersion)
+			if kind != "compatible server" {
+				if err == nil {
+					t.Fatal("unsafe management context change armed activation")
+				}
+				after, readErr := os.ReadFile(f.paths.stagedPath())
+				if readErr != nil || string(before) != string(after) {
+					t.Fatalf("rejected management context changed staged state: %v", readErr)
+				}
+				if _, statErr := os.Stat(f.paths.readyPath()); !os.IsNotExist(statErr) {
+					t.Fatalf("rejected management context published ready marker: %v", statErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			data, err := os.ReadFile(f.paths.stagedPath())
+			if err != nil {
+				t.Fatal(err)
+			}
+			var staged stagedRecord
+			if err := strictJSON(data, &staged); err != nil || staged.ServerVersion != serverVersion {
+				t.Fatalf("management context was not refreshed: %+v, %v", staged, err)
+			}
+			if _, err := Activate(context.Background(), ActivateOptions{
+				Paths: f.paths, Verifier: AgentUpdateVerifier{}, Service: &fakeService{}, Policy: policy, DiskPreflight: allowDisk,
+			}); err != nil {
+				t.Fatalf("root could not activate after independent management context verification: %v", err)
+			}
+		})
+	}
+}
+
+func TestCompletedActivationReplayDoesNotRestartOrDestroyNewerStaging(t *testing.T) {
+	for _, kind := range []string{"duplicate edge", "consumed worker receipt", "newer staged edge", "expired completed command", "different authorization", "forged root proof", "wrong current slot"} {
+		t.Run(kind, func(t *testing.T) {
+			f := newFixture(t)
+			stageAndRequestActivation(t, f)
+			data, err := os.ReadFile(f.paths.readyPath())
+			if err != nil {
+				t.Fatal(err)
+			}
+			var ready readyRecord
+			if err := strictJSON(data, &ready); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Activate(context.Background(), ActivateOptions{
+				Paths: f.paths, Verifier: f.verifier, Service: &fakeService{}, DiskPreflight: allowDisk,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			expected, err := os.ReadFile(f.paths.rootActionReceiptPath())
+			if err != nil {
+				t.Fatal(err)
+			}
+			readyPath := f.paths.readyPath()
+			wantError := false
+			switch kind {
+			case "consumed worker receipt":
+				if err := os.Remove(f.paths.rootActionReceiptPath()); err != nil {
+					t.Fatal(err)
+				}
+			case "newer staged edge":
+				readyPath = f.paths.activationClaimPath()
+				newer := ready
+				assignment := f.assignment
+				assignment.Generation++
+				newer.Authorization = signedFixtureAuthorization(t, f.authorityPrivate, f.authorization.Authorization.AuthorityKeyID,
+					assignment, f.release, agentupdateauth.AssignmentActionActivate, 2)
+				newer.Generation = assignment.Generation
+				if err := atomicJSON(f.paths.readyPath(), newer, 0600); err != nil {
+					t.Fatal(err)
+				}
+				if err := atomicWrite(filepath.Join(f.paths.candidateDir(), "manifest.json"), []byte("later candidate bytes"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			case "expired completed command", "forged root proof":
+				data, err := os.ReadFile(f.paths.lastActivationPath())
+				if err != nil {
+					t.Fatal(err)
+				}
+				var activation completedActivation
+				if err := strictJSON(data, &activation); err != nil {
+					t.Fatal(err)
+				}
+				if kind == "forged root proof" {
+					wantError = true
+					activation.Receipt.Signature[0] ^= 1
+				} else {
+					makeCompletedActionHistorical(t, f, &activation.Authorization, &activation.Receipt)
+					ready.Authorization = activation.Authorization
+					if err := atomicJSON(f.paths.rootActionReceiptPath(), activation.Receipt, 0644); err != nil {
+						t.Fatal(err)
+					}
+					expected, err = os.ReadFile(f.paths.rootActionReceiptPath())
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+				if err := atomicJSON(f.paths.lastActivationPath(), activation, 0600); err != nil {
+					t.Fatal(err)
+				}
+			case "different authorization":
+				wantError = true
+				assignment := f.assignment
+				assignment.Generation++
+				ready.Authorization = signedFixtureAuthorization(t, f.authorityPrivate, f.authorization.Authorization.AuthorityKeyID,
+					assignment, f.release, agentupdateauth.AssignmentActionActivate, 1)
+				ready.Generation = assignment.Generation
+			case "wrong current slot":
+				wantError = true
+				if err := switchCurrent(f.paths, f.bootstrap.Target); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := atomicJSON(readyPath, ready, 0600); err != nil {
+				t.Fatal(err)
+			}
+			service := &fakeService{}
+			_, err = Activate(context.Background(), ActivateOptions{
+				Paths: f.paths, ReadyPath: readyPath, Verifier: f.verifier, Service: service, DiskPreflight: allowDisk,
+			})
+			if (err != nil) != wantError {
+				t.Fatalf("completed activation replay error=%v, wantError=%v", err, wantError)
+			}
+			counter, counterErr := loadRootActionCounter(f.paths.rootActionCounterPath())
+			if service.restarts != 0 || counterErr != nil || counter != 1 {
+				t.Fatalf("replay restarted or changed root counter: restarts=%d counter=%d err=%v", service.restarts, counter, counterErr)
+			}
+			if !wantError {
+				got, err := os.ReadFile(f.paths.rootActionReceiptPath())
+				if err != nil || string(got) != string(expected) {
+					t.Fatalf("replay changed completed root proof: %v", err)
+				}
+				if _, err := os.Stat(readyPath); !os.IsNotExist(err) {
+					t.Fatalf("replay left its old activation edge: %v", err)
+				}
+			}
+			if kind == "newer staged edge" {
+				if _, err := os.Stat(f.paths.readyPath()); err != nil {
+					t.Fatalf("old replay consumed newer ready edge: %v", err)
+				}
+				data, err := os.ReadFile(filepath.Join(f.paths.candidateDir(), "manifest.json"))
+				if err != nil || string(data) != "later candidate bytes" {
+					t.Fatalf("old replay removed newer candidate: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func makeCompletedActionHistorical(t *testing.T, f fixture, authorization *assignmentAuthorizationRecord, receipt *rootActionReceiptRecord) {
+	t.Helper()
+	authorization.Authorization.IssuedAtUnixMillis = time.Now().Add(-2 * time.Hour).UnixMilli()
+	authorization.Authorization.ExpiresAtUnixMillis = time.Now().Add(-time.Hour).UnixMilli()
+	var err error
+	authorization.CanonicalPayload, err = agentupdateauth.AssignmentAuthorizationPayload(authorization.Authorization)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorization.Signature, err = agentupdateauth.SignAssignmentAuthorization(f.authorityPrivate, authorization.Authorization)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := agentupdateauth.AssignmentAuthorizationDigest(authorization.Authorization)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt.Receipt.AuthorizationSHA256 = hex.EncodeToString(digest[:])
+	receipt.Receipt.CompletedAtUnixMillis = authorization.Authorization.ExpiresAtUnixMillis - 1000
+	receipt.CanonicalPayload, err = agentupdateauth.RootActionReceiptPayload(receipt.Receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	private, err := loadActivatorPrivateKey(f.paths.activatorPrivateKeyPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt.Signature, err = agentupdateauth.SignRootActionReceipt(private, receipt.Receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := atomicJSON(f.paths.rootCommandFloorPath(), rootCommandFloor{
+		Sequence: authorization.Authorization.CommandSequence, AuthorizationSHA256: receipt.Receipt.AuthorizationSHA256,
+	}, 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnrollmentDoesNotRaceActiveWorker(t *testing.T) {
+	f := newFixture(t)
+	if err := os.MkdirAll(f.paths.workerStateDir(), 0700); err != nil {
+		t.Fatal(err)
+	}
+	lock, err := acquireLock(filepath.Join(f.paths.workerStateDir(), "worker.lock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.Close()
+	api := &fakeControlAPI{t: t}
+	control := WorkerControl{Paths: f.paths, API: api}
+	if err := control.Enroll(context.Background(), HostConfig{}); err == nil || !strings.Contains(err.Error(), "lock updater enrollment state") {
+		t.Fatalf("enrollment raced a live worker: %v", err)
+	}
+	if api.enrollCalls != 0 {
+		t.Fatal("enrollment consumed a token while a worker held its state lock")
+	}
+}
+
+func TestBootstrapDoesNotRaceRootAction(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires an isolated root host with the updater account")
+	}
+	if _, err := user.Lookup(DefaultUpdaterUser); err != nil {
+		t.Skip("isolated host has no updater account")
+	}
+	f := newFixture(t)
+	lock, err := acquireLock(f.paths.lockPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.Close()
+	oldVersion := buildinfo.Version
+	buildinfo.Version = f.release.Version
+	t.Cleanup(func() { buildinfo.Version = oldVersion })
+	config, err := LoadHostConfig(f.paths.ConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(f.paths.floorPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = BootstrapHost(BootstrapOptions{
+		Paths: f.paths, UpdaterUser: DefaultUpdaterUser, Config: config, EnrollmentToken: "one-use",
+		CurrentVersion: f.release.Version,
+	})
+	if err == nil || !strings.Contains(err.Error(), "lock updater bootstrap state") {
+		t.Fatalf("bootstrap raced active root action: %v", err)
+	}
+	after, err := os.ReadFile(f.paths.floorPath())
+	if err != nil || string(before) != string(after) {
+		t.Fatalf("bootstrap modified security floor during root action: %v", err)
+	}
+}
+
+func TestExpiredCompletedRollbackOnlyAcknowledgesPastExecution(t *testing.T) {
+	f := newFixture(t)
+	authorization := signedFixtureAuthorization(t, f.authorityPrivate, f.authorization.Authorization.AuthorityKeyID,
+		f.assignment, f.release, agentupdateauth.AssignmentActionRollback, 1)
+	if err := RequestRollback(f.paths, authorization); err != nil {
+		t.Fatal(err)
+	}
+	if err := Rollback(context.Background(), f.paths, &fakeService{}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(f.paths.lastRollbackPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result rollbackRecord
+	if err := strictJSON(data, &result); err != nil {
+		t.Fatal(err)
+	}
+	makeCompletedActionHistorical(t, f, &result.Authorization, &result.Receipt)
+	if err := atomicJSON(f.paths.lastRollbackPath(), result, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := atomicJSON(f.paths.rollbackResultPath(), result, 0644); err != nil {
+		t.Fatal(err)
+	}
+	expected, err := os.ReadFile(f.paths.rollbackResultPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// This command was already queued when it was valid, then processed late.
+	if err := atomicJSON(f.paths.rollbackPath(), rollbackRequest{Authorization: result.Authorization}, 0600); err != nil {
+		t.Fatal(err)
+	}
+	service := &fakeService{}
+	if err := Rollback(context.Background(), f.paths, service); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(f.paths.rollbackResultPath())
+	if err != nil || string(got) != string(expected) || service.restarts != 0 {
+		t.Fatalf("expired completed rollback was not acknowledged exactly: restarts=%d err=%v", service.restarts, err)
+	}
+	fresh := result.Authorization
+	fresh.Authorization.CommandSequence++
+	fresh.CanonicalPayload, err = agentupdateauth.AssignmentAuthorizationPayload(fresh.Authorization)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fresh.Signature, err = agentupdateauth.SignAssignmentAuthorization(f.authorityPrivate, fresh.Authorization)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := RequestRollback(f.paths, fresh); err == nil {
+		t.Fatal("worker accepted a fresh expired rollback command")
+	}
+	if err := atomicJSON(f.paths.rollbackPath(), rollbackRequest{Authorization: fresh}, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := Rollback(context.Background(), f.paths, service); err == nil || !strings.Contains(err.Error(), "not currently valid") {
+		t.Fatalf("root accepted a fresh expired rollback command: %v", err)
+	}
+	if service.restarts != 0 {
+		t.Fatal("expired rollback command restarted the agent")
+	}
+}

--- a/internal/updater/files.go
+++ b/internal/updater/files.go
@@ -48,6 +48,12 @@ func validateArtifact(a Artifact) error {
 func artifactHex(a Artifact) string { return hex.EncodeToString(a.SHA256[:]) }
 
 func atomicWrite(path string, data []byte, mode os.FileMode) error {
+	return atomicWriteOwned(path, data, mode, -1, -1)
+}
+
+// Set ownership before publishing the replacement, so a root write cannot
+// temporarily or permanently remove the reader group's access.
+func atomicWriteOwned(path string, data []byte, mode os.FileMode, uid, gid int) error {
 	dir := filepath.Dir(path)
 	f, err := os.CreateTemp(dir, ".write-*")
 	if err != nil {
@@ -61,6 +67,11 @@ func atomicWrite(path string, data []byte, mode os.FileMode) error {
 			_ = os.Remove(tmp)
 		}
 	}()
+	if uid != -1 || gid != -1 {
+		if err := f.Chown(uid, gid); err != nil {
+			return err
+		}
+	}
 	if err := f.Chmod(mode); err != nil {
 		return err
 	}
@@ -84,12 +95,16 @@ func atomicWrite(path string, data []byte, mode os.FileMode) error {
 }
 
 func atomicJSON(path string, value any, mode os.FileMode) error {
+	return atomicJSONOwned(path, value, mode, -1, -1)
+}
+
+func atomicJSONOwned(path string, value any, mode os.FileMode, uid, gid int) error {
 	data, err := json.Marshal(value)
 	if err != nil {
 		return err
 	}
 	data = append(data, '\n')
-	return atomicWrite(path, data, mode)
+	return atomicWriteOwned(path, data, mode, uid, gid)
 }
 
 func strictJSON(data []byte, value any) error {

--- a/internal/updater/floor.go
+++ b/internal/updater/floor.go
@@ -1,0 +1,61 @@
+package updater
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"p2pstream/internal/agentupdateauth"
+)
+
+// Explicit re-enrollment may upgrade an older rescue runner whose security
+// floor predates manifest pins. Recover only an exact authenticated completed
+// activation matching that floor. Missing evidence keeps strict upgrade-only
+// behavior; no version, sequence, epoch or minimum-safe floor is lowered.
+func restoreFloorManifestPin(paths Paths) error {
+	floor, err := loadFloor(paths.floorPath())
+	if err != nil || floor.ManifestSHA256 != "" || floor.Sequence == 0 {
+		return err
+	}
+	data, err := readRegularNoFollow(paths.lastActivationPath(), 256<<10)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	var activation completedActivation
+	if err := strictJSON(data, &activation); err != nil {
+		return fmt.Errorf("read completed activation for security floor migration: %w", err)
+	}
+	r := activation.Receipt.Receipt
+	if r.RootActionCounter == 0 || r.Action != agentupdateauth.AssignmentActionActivate || r.ResultKind != agentupdateauth.RootActionResultRelease {
+		return errors.New("security floor migration requires a completed activation receipt")
+	}
+	counter, err := loadRootActionCounter(paths.rootActionCounterPath())
+	if err != nil {
+		return err
+	}
+	if r.RootActionCounter > counter {
+		return errors.New("security floor migration receipt exceeds the committed root counter")
+	}
+	a := activation.Authorization.Authorization
+	if err := verifyAssignmentAuthorizationRecord(paths, activation.Authorization, agentupdateauth.AssignmentActionActivate, time.UnixMilli(a.IssuedAtUnixMillis), 0); err != nil {
+		return fmt.Errorf("authenticate security floor migration authorization: %w", err)
+	}
+	if err := verifyRootActionReceiptRecord(paths, activation.Receipt, activation.Authorization, r.RootActionCounter-1, time.Now().UTC()); err != nil {
+		return fmt.Errorf("authenticate security floor migration receipt: %w", err)
+	}
+	if r.ResultManifestSHA256 != a.ManifestSHA256 || r.ResultVersion != a.TargetVersion || r.ResultCommit != a.TargetCommit ||
+		r.ResultReleaseSequence != a.ReleaseSequence || r.ResultSecurityEpoch != a.SecurityEpoch ||
+		r.ResultOS != a.OS || r.ResultArch != a.Arch || r.ResultArtifactName != a.ArtifactName ||
+		r.ResultArtifactSize != a.ArtifactSize || r.ResultArtifactSHA256 != a.ArtifactSHA256 {
+		return errors.New("security floor migration receipt does not match the activated release")
+	}
+	if floor.Version != r.ResultVersion || floor.Sequence != r.ResultReleaseSequence || floor.SecurityEpoch != r.ResultSecurityEpoch {
+		return nil
+	}
+	floor.ManifestSHA256 = r.ResultManifestSHA256
+	return persistFloor(paths, floor)
+}

--- a/internal/updater/identity.go
+++ b/internal/updater/identity.go
@@ -121,6 +121,11 @@ func BootstrapHost(options BootstrapOptions) (PublicIdentities, error) {
 			return PublicIdentities{}, err
 		}
 	}
+	lock, err := acquireLock(paths.lockPath())
+	if err != nil {
+		return PublicIdentities{}, fmt.Errorf("lock updater bootstrap state: %w", err)
+	}
+	defer lock.Close()
 	// Validate immutable config pins before mutating enrollment tokens or
 	// identities, so a rejected re-bootstrap leaves the existing host intact.
 	if options.Reenroll {
@@ -137,6 +142,11 @@ func BootstrapHost(options BootstrapOptions) (PublicIdentities, error) {
 	}
 	if err := pinManagementAuthority(paths, options.AuthorityPublicKey, options.AuthorityKeyID, options.AuthorityEpoch, 0, gid); err != nil {
 		return PublicIdentities{}, err
+	}
+	if options.Reenroll {
+		if err := restoreFloorManifestPin(paths); err != nil {
+			return PublicIdentities{}, err
+		}
 	}
 	if !options.Reenroll {
 		buildVersion, buildCommit := buildinfo.Version, buildinfo.Commit
@@ -177,7 +187,10 @@ func parseAccountID(value string) (int, error) {
 }
 
 func bootstrapVersionFloor(rescueVersion, existingTunnelVersion string) string {
-	if existingTunnelVersion != "" && semver.Compare(existingTunnelVersion, rescueVersion) > 0 {
+	// The rescue runner has its own compatibility version. When enrollment
+	// preserves an existing tunnel, its newer rescue binary must not make the
+	// first rollout to that same release look like a tunnel downgrade.
+	if existingTunnelVersion != "" {
 		return existingTunnelVersion
 	}
 	return rescueVersion
@@ -249,11 +262,9 @@ func pinBootstrapState(paths Paths, currentVersion string, advanceVersionFloor b
 	}
 	if advanceVersionFloor && (floor.Version == "" || semver.Compare(currentVersion, floor.Version) > 0) {
 		floor.Version = currentVersion
+		floor.ManifestSHA256 = ""
 	}
-	if err := atomicJSON(paths.floorPath(), floor, 0640); err != nil {
-		return err
-	}
-	return os.Chown(paths.floorPath(), owner, group)
+	return atomicJSONOwned(paths.floorPath(), floor, 0640, owner, group)
 }
 
 func pinHostConfig(path string, config HostConfig, owner, group int) error {

--- a/internal/updater/identity_test.go
+++ b/internal/updater/identity_test.go
@@ -92,7 +92,7 @@ func TestBootstrapVersionFloorIncludesNewerExistingTunnel(t *testing.T) {
 		name, rescue, tunnel, want string
 	}{
 		{name: "newer tunnel", rescue: "v1.5.0", tunnel: "v2.0.0", want: "v2.0.0"},
-		{name: "newer rescue", rescue: "v2.1.0", tunnel: "v2.0.0", want: "v2.1.0"},
+		{name: "newer rescue preserves live tunnel floor", rescue: "v2.1.0", tunnel: "v2.0.0", want: "v2.0.0"},
 		{name: "new install", rescue: "v1.5.0", want: "v1.5.0"},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/updater/rollback.go
+++ b/internal/updater/rollback.go
@@ -48,6 +48,9 @@ func (p Paths) rollbackResultPath() string {
 func (p Paths) rollbackJournalPath() string {
 	return filepath.Join(p.rootStateDir(), "rollback-journal.json")
 }
+func (p Paths) lastRollbackPath() string {
+	return filepath.Join(p.rootStateDir(), "last-rollback.json")
+}
 
 func RequestRollback(paths Paths, authorization assignmentAuthorizationRecord) error {
 	if err := paths.validate(); err != nil {
@@ -84,6 +87,16 @@ func rollbackFromPath(ctx context.Context, paths Paths, service ServiceControlle
 	var request rollbackRequest
 	if err := strictJSON(requestData, &request); err != nil {
 		return errors.New("invalid rollback request")
+	}
+	commandFloor, err := loadRootCommandFloor(paths)
+	if err != nil {
+		return err
+	}
+	if request.Authorization.Authorization.CommandSequence <= commandFloor.Sequence {
+		if request.Authorization.Authorization.CommandSequence != commandFloor.Sequence {
+			return errors.New("rollback management authorization was superseded or replayed")
+		}
+		return replayCompletedRollback(paths, request.Authorization, commandFloor, requestPath)
 	}
 	if err := verifyAssignmentAuthorizationRecord(paths, request.Authorization, agentupdateauth.AssignmentActionRollback, time.Now().UTC(), 0); err != nil {
 		return err
@@ -366,5 +379,67 @@ func persistRollbackResult(paths Paths, result rollbackRecord, current slotMetad
 	if err := atomicJSON(paths.currentSlotMetadataPath(), current, 0600); err != nil {
 		return err
 	}
+	if err := atomicJSON(paths.lastRollbackPath(), result, 0600); err != nil {
+		return err
+	}
 	return atomicJSON(paths.rollbackResultPath(), result, 0644)
+}
+
+func replayCompletedRollback(paths Paths, authorization assignmentAuthorizationRecord, floor rootCommandFloor, requestPath string) error {
+	digest, err := agentupdateauth.AssignmentAuthorizationDigest(authorization.Authorization)
+	if err != nil || floor.AuthorizationSHA256 != fmt.Sprintf("%x", digest) {
+		return errors.New("consumed rollback command has a different authorization digest")
+	}
+	data, err := readRegularNoFollow(paths.lastRollbackPath(), 256<<10)
+	if errors.Is(err, os.ErrNotExist) {
+		// A legacy helper may only have published the worker-visible receipt.
+		// Its signature and all durable root state are verified below before use.
+		data, err = readRegularNoFollow(paths.rollbackResultPath(), 256<<10)
+	}
+	if err != nil {
+		return fmt.Errorf("completed rollback receipt is unavailable for command replay: %w", err)
+	}
+	var result rollbackRecord
+	if err := strictJSON(data, &result); err != nil {
+		return err
+	}
+	if !sameAssignmentAuthorizationRecord(result.Authorization, authorization) {
+		return errors.New("completed rollback receipt belongs to a different authorization")
+	}
+	// This acknowledges past execution; expiry still rejects every fresh
+	// command, but an exact completed proof may be republished after a delay.
+	if err := verifyAssignmentAuthorizationRecord(paths, authorization, agentupdateauth.AssignmentActionRollback, time.UnixMilli(authorization.Authorization.IssuedAtUnixMillis), 0); err != nil {
+		return err
+	}
+	counter, err := loadRootActionCounter(paths.rootActionCounterPath())
+	if err != nil {
+		return err
+	}
+	if counter == 0 || result.Receipt.Receipt.RootActionCounter != counter {
+		return errors.New("completed rollback receipt does not match the latest root action")
+	}
+	if err := verifyRootActionReceiptRecord(paths, result.Receipt, authorization, counter-1, time.Now().UTC()); err != nil {
+		return err
+	}
+	current, err := currentTarget(paths)
+	if err != nil {
+		return err
+	}
+	slot, err := loadCurrentSlotMetadata(paths, current)
+	if err != nil {
+		return err
+	}
+	if !receiptResultMatchesSlot(result.Receipt.Receipt, slot) {
+		return errors.New("completed rollback receipt does not describe the current slot")
+	}
+	if err := atomicJSON(paths.lastRollbackPath(), result, 0600); err != nil {
+		return err
+	}
+	if err := atomicJSON(paths.rollbackResultPath(), result, 0644); err != nil {
+		return err
+	}
+	if err := clearSupersededActivationForRollback(paths, authorization); err != nil {
+		return err
+	}
+	return removeMatchingRollbackRequest(requestPath, authorization)
 }

--- a/internal/updater/rollback_report_test.go
+++ b/internal/updater/rollback_report_test.go
@@ -1,0 +1,76 @@
+package updater
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"os"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	p2pstreamv1 "p2pstream/gen/proto/p2pstream/v1"
+	"p2pstream/internal/agentupdateauth"
+)
+
+func TestWorkerReportsRollbackReceiptResultsAndResumesPolling(t *testing.T) {
+	f := newFixture(t)
+	stageAndRequestActivation(t, f)
+	assignment := f.assignment
+	assignment.Generation++
+	authorization := signedFixtureAuthorization(t, f.authorityPrivate, f.authorization.Authorization.AuthorityKeyID, assignment, f.release, agentupdateauth.AssignmentActionRollback, 2)
+	if err := RequestRollback(f.paths, authorization); err != nil {
+		t.Fatal(err)
+	}
+	if err := Rollback(context.Background(), f.paths, &fakeService{}); err != nil {
+		t.Fatal(err)
+	}
+	durable, err := os.ReadFile(f.paths.rollbackResultPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(f.paths.workerStateDir(), 0700); err != nil {
+		t.Fatal(err)
+	}
+	public, private, _ := ed25519.GenerateKey(rand.Reader)
+	writeTestPrivateKey(t, f.paths.workerPrivateKeyPath(), private)
+	api := &fakeControlAPI{t: t, updaterPublic: public, failFirstReport: true}
+	worker := Worker{
+		Paths: f.paths, Config: HostConfig{AgentPublicID: assignment.AgentPublicID},
+		Control: WorkerControl{Paths: f.paths, API: api},
+	}
+	if err := worker.Run(context.Background()); connect.CodeOf(err) != connect.CodeUnavailable {
+		t.Fatalf("lost response = %v", err)
+	}
+	report := api.lastReport
+	if report == nil || report.RootActionReceipt == nil || report.State != p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_ROLLED_BACK {
+		t.Fatalf("rollback report = %+v", report)
+	}
+	receipt := report.RootActionReceipt
+	if report.ManifestSha256 != receipt.ResultManifestSha256 || report.BinarySha256 != receipt.ResultArtifactSha256 ||
+		report.RunningVersion != receipt.ResultVersion || report.RunningCommit != receipt.ResultCommit {
+		t.Fatalf("rollback report results differ from signed receipt: report version=%q digest=%q; receipt version=%q digest=%q",
+			report.RunningVersion, report.BinarySha256, receipt.ResultVersion, receipt.ResultArtifactSha256)
+	}
+	if data, err := os.ReadFile(f.paths.rollbackResultPath()); err != nil || !bytes.Equal(data, durable) {
+		t.Fatalf("lost response did not preserve the exact durable result: %v", err)
+	}
+	if err := worker.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(f.paths.rollbackResultPath()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("acknowledged rollback result was retained: %v", err)
+	}
+	if len(api.reportCounters) != 2 || api.reportCounters[1] <= api.reportCounters[0] ||
+		len(api.rootReceiptPayloads) != 2 || !bytes.Equal(api.rootReceiptPayloads[0], api.rootReceiptPayloads[1]) {
+		t.Fatalf("rollback retry changed the root proof or reused a worker counter: %v", api.reportCounters)
+	}
+	if err := worker.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.checkCounters) != 1 || api.checkCounters[0] <= api.reportCounters[1] {
+		t.Fatalf("worker did not resume polling after receipt acknowledgement: %v", api.checkCounters)
+	}
+}

--- a/internal/updater/runtime.go
+++ b/internal/updater/runtime.go
@@ -126,7 +126,9 @@ func (w *Worker) reportRollback(ctx context.Context) (bool, error) {
 	}
 	_, err = w.Control.ReportRootAction(ctx, agentupdateauth.Report{
 		AgentPublicID: w.Config.AgentPublicID, AssignmentID: result.Authorization.Authorization.AssignmentID, Generation: result.Authorization.Authorization.Generation,
-		State: int32(p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_ROLLED_BACK),
+		State:          int32(p2pstreamv1.AgentUpdaterReportState_AGENT_UPDATER_REPORT_STATE_ROLLED_BACK),
+		ManifestSHA256: result.Receipt.Receipt.ResultManifestSHA256, BinarySHA256: result.Receipt.Receipt.ResultArtifactSHA256,
+		RunningVersion: result.Receipt.Receipt.ResultVersion, RunningCommit: result.Receipt.Receipt.ResultCommit,
 	}, result.Receipt)
 	if err != nil {
 		return true, err

--- a/internal/updater/stage.go
+++ b/internal/updater/stage.go
@@ -8,9 +8,12 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"syscall"
 	"time"
 
 	"p2pstream/internal/agentupdateauth"
+	"p2pstream/internal/buildinfo"
+	"p2pstream/internal/tunnel"
 )
 
 type StageOptions struct {
@@ -85,9 +88,6 @@ func Stage(ctx context.Context, options StageOptions) (Result, error) {
 	}
 	if err := validateRelease(release); err != nil {
 		return Result{}, err
-	}
-	if release.Sequence == floor.Sequence && release.SecurityEpoch == floor.SecurityEpoch && release.Version == floor.Version {
-		return Result{Version: release.Version, Sequence: release.Sequence, SecurityEpoch: release.SecurityEpoch}, nil
 	}
 	if err := os.MkdirAll(options.Paths.stagingDir(), 0700); err != nil {
 		return Result{}, err
@@ -199,7 +199,7 @@ func RequestActivation(paths Paths, authorization assignmentAuthorizationRecord,
 		Version: expected.Version, Commit: expected.Commit, ManifestSHA: expected.ManifestSHA256,
 		Sequence: expected.Sequence, SecurityEpoch: expected.SecurityEpoch,
 		ArtifactName: expected.Artifact.Name, ArtifactSize: expected.Artifact.Size,
-		ArtifactSHA: artifactHex(expected.Artifact), ServerVersion: serverVersion,
+		ArtifactSHA: artifactHex(expected.Artifact), ServerVersion: staged.ServerVersion,
 	}
 	if staged != want {
 		return errors.New("activation assignment does not exactly match the staged release")
@@ -209,6 +209,18 @@ func RequestActivation(paths Paths, authorization assignmentAuthorizationRecord,
 	}
 	if err := authorizationMatchesRelease(authorization.Authorization, expected, serverVersion); err != nil {
 		return err
+	}
+	if staged.ServerVersion != serverVersion {
+		// Management may restart onto a newer version after STAGED was reported.
+		// A fresh signed authorization can advance that context only after the
+		// exact staged metadata is independently checked against the new server.
+		if err := verifyStagedManagementContext(paths, expected, serverVersion); err != nil {
+			return err
+		}
+		staged.ServerVersion = serverVersion
+		if err := atomicJSON(paths.stagedPath(), staged, 0600); err != nil {
+			return err
+		}
 	}
 	a := authorization.Authorization
 	ready := readyRecord{
@@ -221,6 +233,29 @@ func RequestActivation(paths Paths, authorization assignmentAuthorizationRecord,
 		ServerVersion: staged.ServerVersion,
 	}
 	return atomicJSON(paths.readyPath(), ready, 0600)
+}
+
+func verifyStagedManagementContext(paths Paths, expected VerifiedRelease, serverVersion string) error {
+	config, err := LoadHostConfig(paths.ConfigPath)
+	if err != nil {
+		return err
+	}
+	floor, err := loadFloor(paths.floorPath())
+	if err != nil {
+		return err
+	}
+	policy := VerifyPolicy{Now: time.Now().UTC(), ServerVersion: serverVersion,
+		UpdaterVersion: buildinfo.Version, ProtocolVersion: uint32(tunnel.ProtocolVersion), RequiredChannel: config.Channel}
+	applyFloor(&policy, floor)
+	manifest, err := readRegularNoFollow(filepath.Join(paths.candidateDir(), "manifest.json"), defaultMaxMetadata)
+	if err != nil {
+		return err
+	}
+	_, err = (exactReleaseVerifier{Verifier: AgentUpdateVerifier{}, expected: expected}).Verify(manifest, policy)
+	if err != nil {
+		return fmt.Errorf("verify staged release against current management version: %w", err)
+	}
+	return nil
 }
 
 func authorizationMatchesRelease(authorization agentupdateauth.AssignmentAuthorization, release VerifiedRelease, serverVersion string) error {
@@ -279,7 +314,24 @@ func loadFloor(path string) (Floor, error) {
 	if floor.MinimumSafeVersion != "" && !validVersion(floor.MinimumSafeVersion) {
 		return Floor{}, errors.New("updater security floor contains an invalid minimum safe version")
 	}
+	if floor.ManifestSHA256 != "" && (!digestPattern.MatchString(floor.ManifestSHA256) || floor.Sequence == 0 || floor.SecurityEpoch == 0 || floor.Version == "") {
+		return Floor{}, errors.New("updater security floor contains an invalid manifest identity")
+	}
 	return floor, nil
+}
+
+func persistFloor(paths Paths, floor Floor) error {
+	// Bootstrap pins the state directory to root:updater. Inherit that trusted
+	// reader group rather than the root activator process's primary group.
+	info, err := os.Lstat(paths.StateDir)
+	if err != nil {
+		return err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || !info.IsDir() || stat.Uid != uint32(os.Geteuid()) || info.Mode().Perm()&0022 != 0 {
+		return errors.New("updater state directory has unsafe ownership or permissions")
+	}
+	return atomicJSONOwned(paths.floorPath(), floor, 0640, int(stat.Uid), int(stat.Gid))
 }
 
 func applyFloor(policy *VerifyPolicy, floor Floor) {
@@ -295,4 +347,5 @@ func applyFloor(policy *VerifyPolicy, floor Floor) {
 	if floor.Version != "" {
 		policy.CurrentVersion = floor.Version
 	}
+	policy.CurrentManifestSHA256 = floor.ManifestSHA256
 }

--- a/internal/updater/staged_cleanup_test.go
+++ b/internal/updater/staged_cleanup_test.go
@@ -1,0 +1,88 @@
+package updater
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCompletedActivationCleanupPreservesUnarmedStaging(t *testing.T) {
+	for _, kind := range []string{"different target", "same target new generation", "worker publishing", "missing worker lock"} {
+		t.Run(kind, func(t *testing.T) {
+			f := newFixture(t)
+			stageAndRequestActivation(t, f)
+			ready, err := os.ReadFile(f.paths.readyPath())
+			if err != nil {
+				t.Fatal(err)
+			}
+			staged, err := os.ReadFile(f.paths.stagedPath())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Activate(context.Background(), ActivateOptions{Paths: f.paths, Verifier: f.verifier, Service: &fakeService{}, DiskPreflight: allowDisk}); err != nil {
+				t.Fatal(err)
+			}
+			// A later Stage owns the shared cache before management authorizes its
+			// ready edge. It can legitimately contain the same target metadata.
+			if kind == "different target" {
+				var newer stagedRecord
+				if err := strictJSON(staged, &newer); err != nil {
+					t.Fatal(err)
+				}
+				newer.Version = "v1.2.0"
+				if err := atomicJSON(f.paths.stagedPath(), newer, 0600); err != nil {
+					t.Fatal(err)
+				}
+				staged, err = os.ReadFile(f.paths.stagedPath())
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else if err := atomicWrite(f.paths.stagedPath(), staged, 0600); err != nil {
+				t.Fatal(err)
+			}
+			candidate := filepath.Join(f.paths.candidateDir(), "manifest.json")
+			if err := atomicWrite(candidate, []byte("new campaign candidate"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if err := atomicWrite(f.paths.activationClaimPath(), ready, 0600); err != nil {
+				t.Fatal(err)
+			}
+			lockPath := filepath.Join(f.paths.workerStateDir(), "worker.lock")
+			if kind == "worker publishing" {
+				lock, err := acquireLock(lockPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer lock.Close()
+			} else if kind == "missing worker lock" {
+				if err := os.Remove(lockPath); err != nil {
+					t.Fatal(err)
+				}
+			}
+			service := &fakeService{}
+			if _, err := Activate(context.Background(), ActivateOptions{Paths: f.paths, ReadyPath: f.paths.activationClaimPath(), Verifier: f.verifier, Service: service, DiskPreflight: allowDisk}); err != nil {
+				t.Fatal(err)
+			}
+			if service.restarts != 0 {
+				t.Fatal("completed command replay restarted service")
+			}
+			if _, err := os.Stat(f.paths.activationClaimPath()); !os.IsNotExist(err) {
+				t.Fatalf("old root claim was not consumed: %v", err)
+			}
+			got, err := os.ReadFile(f.paths.stagedPath())
+			if err != nil || string(got) != string(staged) {
+				t.Fatalf("old completed command destroyed newer unarmed staged record: %v", err)
+			}
+			got, err = os.ReadFile(candidate)
+			if err != nil || string(got) != "new campaign candidate" {
+				t.Fatalf("old completed command destroyed newer candidate: %v", err)
+			}
+			if kind == "missing worker lock" {
+				if _, err := os.Lstat(lockPath); !os.IsNotExist(err) {
+					t.Fatalf("root created a replacement worker lock: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/internal/updater/types.go
+++ b/internal/updater/types.go
@@ -45,6 +45,7 @@ type VerifyPolicy struct {
 	CurrentSecurityEpoch      uint64
 	CurrentMinimumSafeVersion string
 	CurrentVersion            string
+	CurrentManifestSHA256     string
 	ServerVersion             string
 	UpdaterVersion            string
 	ProtocolVersion           uint32
@@ -98,6 +99,7 @@ type Floor struct {
 	SecurityEpoch      uint64 `json:"security_epoch"`
 	MinimumSafeVersion string `json:"minimum_safe_version"`
 	Version            string `json:"version"`
+	ManifestSHA256     string `json:"manifest_sha256,omitempty"`
 }
 
 type Result struct {

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -160,10 +160,15 @@ func newFixture(t testing.TB) fixture {
 		InstallRoot: filepath.Join(root, "install"),
 		CommandPath: filepath.Join(root, "bin", "p2pstream"),
 	}
-	for _, dir := range []string{filepath.Dir(paths.ConfigPath), paths.stagingDir(), paths.rootStateDir(), paths.slotsDir(), filepath.Dir(paths.CommandPath)} {
+	for _, dir := range []string{filepath.Dir(paths.ConfigPath), paths.stagingDir(), paths.workerStateDir(), paths.rootStateDir(), paths.slotsDir(), filepath.Dir(paths.CommandPath)} {
 		if err := os.MkdirAll(dir, 0700); err != nil {
 			t.Fatal(err)
 		}
+	}
+	// Production Worker.Run creates and owns this lock before staging. Root
+	// cleanup opens it read-only and must never create a root-owned replacement.
+	if err := os.WriteFile(filepath.Join(paths.workerStateDir(), "worker.lock"), nil, 0600); err != nil {
+		t.Fatal(err)
 	}
 	body := []byte("raw p2pstream executable\n")
 	digest := sha256.Sum256(body)

--- a/scripts/install-agent.sh
+++ b/scripts/install-agent.sh
@@ -689,6 +689,8 @@ RestartSec=30s
 User=root
 Group=root
 ExecStart=${UPDATER_RUNNER_PATH} updater activate
+# Successful actions must not exhaust the throttle for consecutive failures.
+ExecStartPost=/usr/bin/systemctl reset-failed p2pstream-updater-activate.service p2pstream-updater-activate.path
 ExecStartPost=/usr/bin/systemctl start --no-block p2pstream-updater.service
 ExecStopPost=/usr/bin/systemctl start --no-block p2pstream-updater.service
 UMask=0077
@@ -756,6 +758,17 @@ install_updater_foundation() {
 	install -o root -g root -m 0755 "$P2PSTREAM_AGENT_BINARY_FILE" "$next_runner"
   sync -d "$next_runner"
 
+	# Quiesce both writers before bootstrap rewrites shared enrollment/floor
+	# state. Interrupted root journals remain durable for the new runner.
+	systemctl stop p2pstream-updater.timer p2pstream-updater-activate.path >/dev/null 2>&1 || true
+	# ExecStopPost on the root helper queues the worker, so stop the worker last.
+	systemctl stop p2pstream-updater-activate.service >/dev/null 2>&1 || true
+	systemctl stop p2pstream-updater.service >/dev/null 2>&1 || true
+	if systemctl is-active --quiet p2pstream-updater.timer p2pstream-updater-activate.path p2pstream-updater.service p2pstream-updater-activate.service; then
+		fail "could not stop managed updater units before replacing enrollment state"
+	fi
+	systemctl disable p2pstream-updater.timer p2pstream-updater-activate.path >/dev/null 2>&1 || true
+
   P2PSTREAM_REPOSITORY="$repository" \
   P2PSTREAM_UPDATER_ENROLLMENT_TOKEN="$P2PSTREAM_UPDATER_ENROLLMENT_TOKEN" \
   P2PSTREAM_AGENT_UPDATE_AUTHORITY_PUBLIC_KEY_BASE64="$P2PSTREAM_AGENT_UPDATE_AUTHORITY_PUBLIC_KEY_BASE64" \
@@ -770,8 +783,6 @@ install_updater_foundation() {
   AGENT_ID="$AGENT_ID" \
 		"$next_runner" updater bootstrap-host >"${tmp_dir}/updater-identities.json" \
     || fail "failed to create isolated updater identities"
-	systemctl stop p2pstream-updater.timer p2pstream-updater-activate.path p2pstream-updater.service p2pstream-updater-activate.service >/dev/null 2>&1 || true
-	systemctl disable p2pstream-updater.timer p2pstream-updater-activate.path >/dev/null 2>&1 || true
 	mv -Tf "$next_runner" "$UPDATER_RUNNER_PATH"
 	sync -d "$UPDATER_RUNNER_DIR"
 

--- a/scripts/systemd/p2pstream-updater-activate.service
+++ b/scripts/systemd/p2pstream-updater-activate.service
@@ -13,6 +13,8 @@ RestartSec=30s
 User=root
 Group=root
 ExecStart=/opt/p2pstream-agent/updater/p2pstream updater activate
+# Successful actions must not exhaust the throttle for consecutive failures.
+ExecStartPost=/usr/bin/systemctl reset-failed p2pstream-updater-activate.service p2pstream-updater-activate.path
 ExecStartPost=/usr/bin/systemctl start --no-block p2pstream-updater.service
 ExecStopPost=/usr/bin/systemctl start --no-block p2pstream-updater.service
 UMask=0077

--- a/scripts/test-agent-lifecycle.sh
+++ b/scripts/test-agent-lifecycle.sh
@@ -132,6 +132,7 @@ setup_fixture() {
     'printf "%s" "$*" >>"${FAKE_SYSTEMCTL_LOG:?}"' \
     'printf "\n" >>"${FAKE_SYSTEMCTL_LOG:?}"' \
     'if [[ "${1:-}" == "--version" ]]; then printf "systemd 252\n"; exit 0; fi' \
+    'if [[ "${1:-}" == "is-active" ]]; then [[ "${FAKE_SYSTEMCTL_STILL_ACTIVE:-}" == "1" ]] && exit 0; exit 3; fi' \
     'if [[ "${FAKE_SYSTEMCTL_FAIL_RESTART:-}" == "1" && "${1:-}" == "restart" ]]; then exit 1; fi' \
     'exit 0'
 
@@ -329,6 +330,10 @@ test_existing_install_managed_updater_bootstrap_preserves_env() {
   assert_contains "${SYSTEMD_DIR}/p2pstream-updater.service" "ConditionPathExists=${UPDATER_CONFIG_DIR}/management-authority.json"
   assert_contains "${SYSTEMD_DIR}/p2pstream-updater.service" "ExecStart=${AGENT_INSTALL_ROOT}/updater/p2pstream updater stage"
   assert_contains "${SYSTEMD_DIR}/p2pstream-updater-activate.service" "PrivateNetwork=true"
+  assert_contains "${SYSTEMD_DIR}/p2pstream-updater-activate.service" "StartLimitBurst=5"
+  assert_contains "${SYSTEMD_DIR}/p2pstream-updater-activate.service" "Restart=on-failure"
+  assert_contains "${SYSTEMD_DIR}/p2pstream-updater-activate.service" "ExecStartPost=/usr/bin/systemctl reset-failed p2pstream-updater-activate.service p2pstream-updater-activate.path"
+  assert_contains "${ROOT_DIR}/scripts/systemd/p2pstream-updater-activate.service" "ExecStartPost=/usr/bin/systemctl reset-failed p2pstream-updater-activate.service p2pstream-updater-activate.path"
   assert_contains "${SYSTEMD_DIR}/p2pstream-updater-activate.service" "IPAddressDeny=any"
   assert_contains "${SYSTEMD_DIR}/p2pstream-updater-activate.service" "ExecStart=${AGENT_INSTALL_ROOT}/updater/p2pstream updater activate"
   assert_contains "${SYSTEMD_DIR}/p2pstream-updater.timer" "RandomizedDelaySec=30s"
@@ -460,6 +465,7 @@ test_managed_updater_reenrollment_updates_only_pinned_rescue() {
 	cp -L "$INSTALL_PATH" "${TEST_DIR}/tunnel-before-reenroll"
 	write_executable "$LOCAL_AGENT_BINARY" \
 		'#!/usr/bin/env sh' \
+		'if [ "$*" = "updater bootstrap-host" ]; then grep -Fqx "stop p2pstream-updater.service" "$FAKE_SYSTEMCTL_LOG" || { echo "bootstrap raced live updater services" >&2; exit 1; }; fi' \
 		'if [ -n "${FAKE_COMMAND_LOG:-}" ]; then printf "p2pstream-rescue-v3 %s\n" "$*" >>"$FAKE_COMMAND_LOG"; fi' \
 		'printf p2pstream-rescue-v3'
 	: >"$SYSTEMCTL_LOG"
@@ -476,6 +482,17 @@ test_managed_updater_reenrollment_updates_only_pinned_rescue() {
 		|| fail "rescue re-enrollment did not atomically promote the pinned runner"
 	assert_contains "$COMMAND_LOG" "p2pstream-rescue-v3 updater enroll"
 	assert_not_contains "$SYSTEMCTL_LOG" "restart p2pstream-agent"
+	: >"$COMMAND_LOG"
+	if run_installer \
+		P2PSTREAM_ENABLE_MANAGED_UPDATES="true" \
+		P2PSTREAM_UPDATER_ENROLLMENT_TOKEN="refuse-live-writer" \
+		FAKE_SYSTEMCTL_STILL_ACTIVE="1" \
+		MANAGEMENT_URL="https://mgmt.example.test:8081" \
+		AGENT_ID="agent-one" >"${TEST_DIR}/still-active.out" 2>"${TEST_DIR}/still-active.err"; then
+		fail "re-enrollment proceeded while updater units remained active"
+	fi
+	assert_contains "${TEST_DIR}/still-active.err" "could not stop managed updater units"
+	assert_not_contains "$COMMAND_LOG" "updater bootstrap-host"
 
 	# Reinstall / Repair supplies the existing token and restarts the service,
 	# but re-enrollment must not replace its managed slot or claim an upgrade.

--- a/scripts/test-managed-updates-systemd.sh
+++ b/scripts/test-managed-updates-systemd.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Full managed-update lifecycle in an isolated systemd VM. Never provisions the
+# workstation. A caller-supplied VM must be disposable and have no agent install.
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_dir"
+[[ "$(uname -sm)" == "Linux x86_64" ]] || { echo 'This harness currently requires a Linux amd64 build host.' >&2; exit 1; }
+command -v multipass >/dev/null
+command -v go >/dev/null
+mkdir -p "${repo_dir}/tmp"
+# The Multipass snap cannot read the host's private /tmp namespace.
+build_dir="$(mktemp -d "${repo_dir}/tmp/systemd-build.XXXXXX")"
+output_dir="${P2PSTREAM_SYSTEMD_OUTPUT_DIR:-${repo_dir}/tmp/managed-updates-systemd}"
+mkdir -p "$output_dir"
+vm_name="${P2PSTREAM_SYSTEMD_VM_NAME:-p2pstream-update-review-$(date +%s)-$$}"
+[[ "$vm_name" == p2pstream-update-review* ]] || { echo 'Test VM name must start with p2pstream-update-review.' >&2; exit 1; }
+created_vm=false
+cleanup() {
+  if [[ "$created_vm" == true ]]; then
+    multipass delete --purge "$vm_name" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$build_dir"
+}
+trap cleanup EXIT
+
+printf 'Building real binaries and integration harness...\n'
+for spec in 'v1.0.0 d' 'v1.1.0 a' 'v1.2.0 b'; do
+  read -r version commit_digit <<<"$spec"
+  commit="$(printf '%040d' 0 | tr 0 "$commit_digit")"
+  go build -ldflags "-X p2pstream/internal/buildinfo.Version=${version} -X p2pstream/internal/buildinfo.Commit=${commit}" -o "${build_dir}/p2pstream-${version}" .
+done
+go test -c ./internal/server -o "${build_dir}/server.test"
+
+# Exercise actual older-worker serialization, not a hand-built approximation.
+legacy_ref="${P2PSTREAM_SYSTEMD_LEGACY_REF:-v0.1.53-staging.84}"
+mkdir "${build_dir}/legacy"
+git archive "$legacy_ref" | tar -x -C "${build_dir}/legacy"
+git rev-parse "${legacy_ref}^{commit}" >"${output_dir}/legacy-commit.txt"
+(cd "${build_dir}/legacy" && go build -ldflags '-X p2pstream/internal/buildinfo.Version=v1.0.0 -X p2pstream/internal/buildinfo.Commit=dddddddddddddddddddddddddddddddddddddddd' -o "${build_dir}/p2pstream-legacy-worker" .)
+cp scripts/install-agent.sh scripts/uninstall-agent.sh "$build_dir/"
+tar -czf "${build_dir}/fixture.tar.gz" -C "$build_dir" server.test p2pstream-v1.0.0 p2pstream-v1.1.0 p2pstream-v1.2.0 p2pstream-legacy-worker install-agent.sh uninstall-agent.sh
+
+if [[ -z "${P2PSTREAM_SYSTEMD_VM_NAME:-}" ]]; then
+  multipass launch 24.04 --name "$vm_name" --cpus 2 --memory 4G --disk 12G
+  created_vm=true
+fi
+multipass info "$vm_name" --format json >"${output_dir}/vm.json"
+multipass transfer "${build_dir}/fixture.tar.gz" "${vm_name}:/tmp/p2pstream-review-fixture.tar.gz"
+multipass exec "$vm_name" -- sudo bash -c 'set -e; mkdir -p /opt/p2pstream-systemd-fixture; tar -xzf /tmp/p2pstream-review-fixture.tar.gz -C /opt/p2pstream-systemd-fixture; printf "disposable-p2pstream-update-test\n" >/run/p2pstream-systemd-test-vm'
+printf 'Running installer, real services, legacy reports and repeated rollout in %s...\n' "$vm_name"
+result=0
+multipass exec "$vm_name" -- sudo env P2PSTREAM_SYSTEMD_INTEGRATION=1 P2PSTREAM_SYSTEMD_FIXTURE_DIR=/opt/p2pstream-systemd-fixture /opt/p2pstream-systemd-fixture/server.test -test.run '^TestManagedUpdatesSystemdLifecycle$' -test.v -test.timeout 10m >"${output_dir}/test.log" 2>&1 || result=$?
+multipass exec "$vm_name" -- sudo cat /opt/p2pstream-systemd-fixture/systemd-journal.log >"${output_dir}/systemd-journal.log" 2>/dev/null || true
+cat "${output_dir}/test.log"
+printf 'Logs: %s\n' "$output_dir"
+exit "$result"

--- a/web/management/src/lib/agentUpdateDeepReview.test.ts
+++ b/web/management/src/lib/agentUpdateDeepReview.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+import { create } from "@bufbuild/protobuf";
+import { AgentUpdateAssignmentState as State, AgentUpdateCampaignState as CampaignState, AgentUpdateDesiredAction as Action, AgentUpdateCampaignSchema, AgentUpdateOverviewAgentSchema } from "@/gen/proto/p2pstream/v1/management_pb";
+import { agentIsAlreadyOnUpdateTarget, agentRolloutStatus, agentUpdatePreviewBlockerLabel, canResumeUpdateCampaign, recoverableUpdateAssignments, retryableStageAssignments, updateRecoveryMessage } from "./agentUpdateRecovery";
+import { createAgentUpdatePolling } from "./agentUpdatePolling";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((done, fail) => { resolve = done; reject = fail; });
+  return { promise, resolve, reject };
+}
+
+async function waitFor(condition: () => boolean) {
+  for (let attempt = 0; attempt < 100 && !condition(); attempt += 1) await pause(5);
+  expect(condition()).toBe(true);
+}
+
+function pause(milliseconds: number) { return new Promise<void>((resolve) => setTimeout(resolve, milliseconds)); }
+
+describe("agent update workflow review regressions", () => {
+  test("preview explains same-target and updater compatibility blockers", () => {
+    expect(agentUpdatePreviewBlockerLabel("already_on_target")).toBe("Already running this release");
+    expect(agentUpdatePreviewBlockerLabel("updater_version_incompatible", "v0.1.53-staging.88")).toContain("Repair the pinned updater to v0.1.53-staging.88 or newer");
+    expect(agentUpdatePreviewBlockerLabel("active_assignment")).toContain("existing campaign");
+  });
+
+  test("already-current hosts are identified by both live version and commit", () => {
+    const target = { version: "v0.1.53-staging.88", commit: "a".repeat(40) };
+    const agent = create(AgentUpdateOverviewAgentSchema, { updaterEnrolled: true, connected: true, tunnelVersion: target.version, tunnelCommit: target.commit });
+    expect(agentIsAlreadyOnUpdateTarget(agent, target)).toBe(true);
+    expect(agentRolloutStatus(agent, [], target)).toBe("Already running this release");
+    agent.tunnelCommit = "b".repeat(40);
+    expect(agentIsAlreadyOnUpdateTarget(agent, target)).toBe(false);
+    agent.tunnelCommit = target.commit;
+    agent.connected = false;
+    expect(agentIsAlreadyOnUpdateTarget(agent, target)).toBe(false);
+    expect(agentIsAlreadyOnUpdateTarget(agent, undefined)).toBe(false);
+  });
+  test("recovering reserved hosts does not silently restart other failed rollouts", () => {
+    const campaign = create(AgentUpdateCampaignSchema, {
+      state: CampaignState.PAUSED,
+      assignments: [
+        { id: 1n, state: State.BLOCKED, cordoned: true, desiredAction: Action.NONE },
+        { id: 2n, state: State.FAILED, cordoned: false, desiredAction: Action.NONE },
+        { id: 3n, state: State.FAILED, cordoned: true, desiredAction: Action.ROLLBACK },
+      ],
+    });
+    expect(recoverableUpdateAssignments(campaign).map((item) => item.id)).toEqual([1n]);
+    expect(retryableStageAssignments(campaign).map((item) => item.id)).toEqual([2n]);
+    expect(canResumeUpdateCampaign(campaign)).toBe(false);
+    campaign.assignments[0]!.state = State.FAILED;
+    campaign.assignments[0]!.desiredAction = Action.ROLLBACK;
+    expect(recoverableUpdateAssignments(campaign)).toEqual([]);
+    expect(updateRecoveryMessage(campaign)).toContain("retry the other failed assignments before resuming");
+    expect(canResumeUpdateCampaign(campaign)).toBe(false);
+    campaign.assignments[1]!.state = State.PENDING;
+    expect(canResumeUpdateCampaign(campaign)).toBe(true);
+    campaign.state = CampaignState.CANCELLED;
+    expect(retryableStageAssignments(campaign)).toEqual([]);
+    expect(canResumeUpdateCampaign(campaign)).toBe(false);
+  });
+
+  test("a refresh after a mutation queues one fresh read without overlapping requests", async () => {
+    const responses = [deferred<number>(), deferred<number>()];
+    const applied: number[] = [];
+    let loads = 0;
+    let busy = false;
+    const polling = createAgentUpdatePolling({
+      scope: () => "environment-a",
+      load: () => responses[loads++]!.promise,
+      apply: (value) => applied.push(value),
+      error: () => { throw new Error("Unexpected refresh error"); },
+      loading: (value) => { busy = value; },
+      canPoll: () => true,
+    });
+    try {
+      const first = polling.refresh();
+      const afterMutation = polling.refresh();
+      const duplicate = polling.refresh();
+      expect(loads).toBe(1);
+      responses[0]!.resolve(1);
+      await waitFor(() => loads === 2);
+      expect(busy).toBe(true);
+      responses[1]!.resolve(2);
+      await Promise.all([first, afterMutation, duplicate]);
+      expect(loads).toBe(2);
+      expect(applied).toEqual([1, 2]);
+      expect(busy).toBe(false);
+    } finally { polling.stop(); }
+  });
+
+  test("switching environments discards a late response even if transport ignores abort", async () => {
+    let scope = "environment-a";
+    const oldResponse = deferred<string>();
+    const signals: AbortSignal[] = [];
+    const applied: string[] = [];
+    const errors: unknown[] = [];
+    const polling = createAgentUpdatePolling({
+      scope: () => scope,
+      load: (signal) => { signals.push(signal); return scope === "environment-a" ? oldResponse.promise : Promise.resolve(scope); },
+      apply: (value) => applied.push(value),
+      error: (error) => errors.push(error),
+      loading: () => {},
+      canPoll: () => true,
+    });
+    try {
+      const first = polling.refresh();
+      scope = "environment-b";
+      const next = polling.scopeChanged();
+      expect(signals[0]!.aborted).toBe(true);
+      oldResponse.resolve("environment-a");
+      await Promise.all([first, next]);
+      expect(applied).toEqual(["environment-b"]);
+      expect(errors).toEqual([]);
+    } finally { polling.stop(); }
+  });
+
+  test("stopping the page aborts a pending request and prevents any late writes", async () => {
+    const response = deferred<string>();
+    const applied: string[] = [];
+    const errors: unknown[] = [];
+    let signal: AbortSignal | undefined;
+    let loads = 0;
+    const polling = createAgentUpdatePolling({
+      scope: () => "environment-a",
+      load: (value) => { signal = value; loads += 1; return response.promise; },
+      apply: (value) => applied.push(value),
+      error: (error) => errors.push(error),
+      loading: () => {},
+      canPoll: () => true,
+      intervalMillis: 5,
+    });
+    const pending = polling.start();
+    polling.stop();
+    expect(signal!.aborted).toBe(true);
+    response.reject(new Error("Late transport failure"));
+    await pending;
+    await polling.refresh();
+    await pause(20);
+    expect(applied).toEqual([]);
+    expect(errors).toEqual([]);
+    expect(loads).toBe(1);
+  });
+
+  test("polling reflects completed recovery automatically and pauses while actions are busy", async () => {
+    let canPoll = true;
+    let serverState = "rollback pending";
+    const applied: string[] = [];
+    const polling = createAgentUpdatePolling({
+      scope: () => "environment-a",
+      load: async () => serverState,
+      apply: (value) => applied.push(value),
+      error: () => { throw new Error("Unexpected refresh error"); },
+      loading: () => {},
+      canPoll: () => canPoll,
+      intervalMillis: 5,
+    });
+    try {
+      await polling.start();
+      expect(applied).toEqual(["rollback pending"]);
+      serverState = "recovered; ready for rollout";
+      await waitFor(() => applied.includes(serverState));
+      canPoll = false;
+      const count = applied.length;
+      await pause(20);
+      expect(applied).toHaveLength(count);
+      canPoll = true;
+      await waitFor(() => applied.length > count);
+    } finally { polling.stop(); }
+  });
+});

--- a/web/management/src/lib/agentUpdatePolling.ts
+++ b/web/management/src/lib/agentUpdatePolling.ts
@@ -1,0 +1,90 @@
+type Timer = ReturnType<typeof setTimeout>;
+
+export function createAgentUpdatePolling<T>(options: {
+  scope: () => string;
+  load: (signal: AbortSignal) => Promise<T>;
+  apply: (value: T) => void;
+  error: (error: unknown) => void;
+  loading: (loading: boolean) => void;
+  canPoll: () => boolean;
+  intervalMillis?: number;
+}) {
+  let stopped = false;
+  let started = false;
+  let revision = 0;
+  let timer: Timer | undefined;
+  let controller: AbortController | undefined;
+  let pending: Promise<void> | undefined;
+  let queued = false;
+
+  function clearTimer() {
+    if (timer !== undefined) clearTimeout(timer);
+    timer = undefined;
+  }
+
+  function schedule() {
+    clearTimer();
+    if (!started || stopped) return;
+    timer = setTimeout(() => {
+      timer = undefined;
+      if (options.canPoll()) void refresh();
+      else schedule();
+    }, options.intervalMillis ?? 5000);
+  }
+
+  async function run() {
+    do {
+      queued = false;
+      const requestRevision = revision;
+      const scope = options.scope();
+      const request = new AbortController();
+      controller = request;
+      options.loading(true);
+      const current = () => !stopped && requestRevision === revision && scope === options.scope();
+      try {
+        const value = await options.load(request.signal);
+        if (current()) options.apply(value);
+      } catch (error) {
+        if (current() && !request.signal.aborted) options.error(error);
+      } finally {
+        // A paired request can fail while its sibling is still running.
+        request.abort();
+        if (controller === request) controller = undefined;
+      }
+    } while (queued && !stopped);
+    if (!stopped) options.loading(false);
+  }
+
+  function refresh(): Promise<void> {
+    if (stopped) return Promise.resolve();
+    clearTimer();
+    // An explicit refresh after a mutation must perform a new read even when
+    // an earlier read is still completing. Coalesce multiple callers into one.
+    queued = true;
+    if (!pending) {
+      pending = run().finally(() => {
+        pending = undefined;
+        schedule();
+      });
+    }
+    return pending;
+  }
+
+  return {
+    refresh,
+    start() { started = true; return refresh(); },
+    scopeChanged() {
+      revision += 1;
+      controller?.abort();
+      return refresh();
+    },
+    stop() {
+      stopped = true;
+      revision += 1;
+      queued = false;
+      clearTimer();
+      controller?.abort();
+      options.loading(false);
+    },
+  };
+}

--- a/web/management/src/lib/agentUpdateRecovery.test.ts
+++ b/web/management/src/lib/agentUpdateRecovery.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { create } from "@bufbuild/protobuf";
+import {
+  AgentUpdateAssignmentState as State,
+  AgentUpdateCampaignState as CampaignState,
+  AgentUpdateDesiredAction as Action,
+  AgentUpdateCampaignSchema,
+  AgentUpdateOverviewAgentSchema,
+} from "@/gen/proto/p2pstream/v1/management_pb";
+import { agentRolloutStatus, retryableUpdateAssignments, updateRecoveryMessage } from "./agentUpdateRecovery";
+
+describe("agent update recovery", () => {
+  test("a cancelled campaign recovers fenced hosts without resubmitting terminal or in-flight failures", () => {
+    const campaign = create(AgentUpdateCampaignSchema, {
+      state: CampaignState.CANCELLED,
+      assignments: [
+        { id: 1n, state: State.BLOCKED, cordoned: true, desiredAction: Action.NONE },
+        { id: 2n, state: State.FAILED, cordoned: true, desiredAction: Action.ROLLBACK },
+        { id: 3n, state: State.FAILED, cordoned: false, desiredAction: Action.NONE },
+        { id: 4n, state: State.CANCELLED, cordoned: false, desiredAction: Action.NONE },
+        { id: 5n, state: State.BLOCKED, cordoned: true, desiredAction: Action.ROLLBACK },
+      ],
+    });
+    expect(retryableUpdateAssignments(campaign).map((item) => item.id)).toEqual([1n, 5n]);
+    expect(updateRecoveryMessage(campaign)).toContain("Recover agents");
+    campaign.state = CampaignState.COMPLETED;
+    expect(retryableUpdateAssignments(campaign)).toEqual([]);
+  });
+
+  test("paused staging failures can retry while an already queued rollback is excluded", () => {
+    const campaign = create(AgentUpdateCampaignSchema, {
+      state: CampaignState.PAUSED,
+      assignments: [
+        { id: 1n, state: State.FAILED, desiredAction: Action.NONE },
+        { id: 2n, state: State.FAILED, cordoned: true, desiredAction: Action.ROLLBACK },
+      ],
+    });
+    expect(retryableUpdateAssignments(campaign).map((item) => item.id)).toEqual([1n]);
+    expect(updateRecoveryMessage(campaign)).toContain("retry the other failed assignments before resuming");
+    campaign.state = CampaignState.CANCELLED;
+    expect(retryableUpdateAssignments(campaign)).toEqual([]);
+    expect(updateRecoveryMessage(campaign)).toContain("Waiting for the updater");
+  });
+
+  test("blocked hosts get recovery guidance and release the notice after verified recovery", () => {
+    const campaign = create(AgentUpdateCampaignSchema, {
+      state: CampaignState.CANCELLED,
+      assignments: [{ id: 1n, state: State.BLOCKED, cordoned: true, desiredAction: Action.NONE }],
+    });
+    expect(updateRecoveryMessage(campaign)).toContain("Recover agents");
+    campaign.assignments[0]!.state = State.AWAITING_TUNNEL;
+    expect(updateRecoveryMessage(campaign)).toContain("fresh agent connection");
+    campaign.assignments[0]!.cordoned = false;
+    campaign.assignments[0]!.state = State.FAILED;
+    expect(updateRecoveryMessage(campaign)).toBe("");
+  });
+
+  test("rollout picker distinguishes recovery reservations from ordinary assignments", () => {
+    const campaign = create(AgentUpdateCampaignSchema, {
+      name: "Old campaign", state: CampaignState.CANCELLED,
+      assignments: [{ id: 42n, state: State.BLOCKED, cordoned: true, desiredAction: Action.NONE }],
+    });
+    const agent = create(AgentUpdateOverviewAgentSchema, { updaterEnrolled: true, connected: true, activeAssignmentId: 42n });
+    expect(agentRolloutStatus(agent, [campaign])).toContain("Recovery required");
+    campaign.assignments[0]!.desiredAction = Action.ROLLBACK;
+    expect(agentRolloutStatus(agent, [campaign])).toContain("Rollback recovery pending");
+    agent.activeAssignmentId = 0n;
+    expect(agentRolloutStatus(agent, [campaign])).toBe("Ready for preview");
+    agent.activeAssignmentId = 42n;
+    campaign.assignments[0]!.desiredAction = Action.STAGE;
+    campaign.assignments[0]!.cordoned = false;
+    campaign.assignments[0]!.state = State.STAGING;
+    campaign.state = CampaignState.RUNNING;
+    expect(agentRolloutStatus(agent, [campaign])).toBe("Assigned to Old campaign");
+  });
+});

--- a/web/management/src/lib/agentUpdateRecovery.ts
+++ b/web/management/src/lib/agentUpdateRecovery.ts
@@ -1,0 +1,79 @@
+import {
+  AgentUpdateAssignmentState as AssignmentState,
+  AgentUpdateCampaignState as CampaignState,
+  AgentUpdateDesiredAction as Action,
+  type AgentUpdateCampaign,
+  type AgentUpdateOverviewAgent,
+  type AgentUpdateTarget,
+} from "@/gen/proto/p2pstream/v1/management_pb";
+
+export function retryableUpdateAssignments(campaign: AgentUpdateCampaign) {
+  if (![CampaignState.RUNNING, CampaignState.PAUSED, CampaignState.CANCELLED].includes(campaign.state)) return [];
+  return campaign.assignments.filter((assignment) => {
+    if (assignment.state === AssignmentState.BLOCKED && assignment.cordoned) return true;
+    if (campaign.state === CampaignState.CANCELLED || campaign.state === CampaignState.COMPLETED || assignment.cordoned) return false;
+    return assignment.state === AssignmentState.BLOCKED || assignment.state === AssignmentState.CANCELLED ||
+      (assignment.state === AssignmentState.FAILED && assignment.desiredAction === Action.NONE);
+  });
+}
+
+export function recoverableUpdateAssignments(campaign: AgentUpdateCampaign) {
+  return retryableUpdateAssignments(campaign).filter((assignment) => assignment.cordoned);
+}
+
+export function retryableStageAssignments(campaign: AgentUpdateCampaign) {
+  return retryableUpdateAssignments(campaign).filter((assignment) => !assignment.cordoned);
+}
+
+export function canResumeUpdateCampaign(campaign: AgentUpdateCampaign): boolean {
+  return campaign.state === CampaignState.PAUSED && !campaign.assignments.some((assignment) =>
+    [AssignmentState.FAILED, AssignmentState.BLOCKED].includes(assignment.state) &&
+    !(assignment.cordoned && assignment.desiredAction === Action.ROLLBACK),
+  );
+}
+
+export function agentUpdatePreviewBlockerLabel(blocker: string, minimumUpdaterVersion?: string): string {
+  if (blocker === "already_on_target") return "Already running this release";
+  if (blocker === "updater_version_incompatible") return `Repair the pinned updater to ${minimumUpdaterVersion || "a compatible version"} or newer before rollout`;
+  if (blocker === "updater_not_recently_seen") return "Updater is not checking in; inspect its service before rollout";
+  if (blocker === "active_assignment") return "Finish recovery in the existing campaign before another rollout";
+  return blocker.replaceAll("_", " ");
+}
+
+export function updateRecoveryMessage(campaign: AgentUpdateCampaign): string {
+  const reserved = campaign.assignments.filter((assignment) => assignment.cordoned);
+  if (reserved.some((assignment) => assignment.state === AssignmentState.BLOCKED)) {
+    return "Recovery is required before these hosts can join another rollout. Recover agents requests rollback; the updater must finish and establish a fresh agent connection.";
+  }
+  if (reserved.some((assignment) => assignment.desiredAction === Action.ROLLBACK)) {
+    if (campaign.state === CampaignState.PAUSED) {
+      return retryableStageAssignments(campaign).length
+        ? "Rollback recovery is queued. Cancel this campaign to recover the reserved hosts, or retry the other failed assignments before resuming the rollout."
+        : "Rollback recovery is queued. Resume or cancel this campaign to let the updater complete recovery.";
+    }
+    return "Waiting for the updater to complete rollback and reconnect. Hosts remain reserved until recovery is verified.";
+  }
+  if (reserved.length && campaign.state === CampaignState.CANCELLED) {
+    return "Waiting for recovery evidence and a fresh agent connection before releasing these hosts for another rollout.";
+  }
+  return "";
+}
+
+export function agentIsAlreadyOnUpdateTarget(agent: AgentUpdateOverviewAgent, target?: Pick<AgentUpdateTarget, "version" | "commit"> | null): boolean {
+  return Boolean(agent.connected && target?.version && target.commit && agent.tunnelVersion === target.version && agent.tunnelCommit === target.commit);
+}
+
+export function agentRolloutStatus(agent: AgentUpdateOverviewAgent, campaigns: AgentUpdateCampaign[], target?: Pick<AgentUpdateTarget, "version" | "commit"> | null): string {
+  if (!agent.updaterEnrolled) return "Updater not enrolled";
+  if (agent.activeAssignmentId) {
+    const campaign = campaigns.find((item) => item.assignments.some((assignment) => assignment.id === agent.activeAssignmentId));
+    const assignment = campaign?.assignments.find((item) => item.id === agent.activeAssignmentId);
+    if (assignment?.desiredAction === Action.ROLLBACK) return "Rollback recovery pending — see the existing campaign";
+    if (assignment?.cordoned && (assignment.state === AssignmentState.BLOCKED || campaign?.state === CampaignState.CANCELLED)) {
+      return "Recovery required — see the existing campaign";
+    }
+    return campaign ? `Assigned to ${campaign.name}` : "Already assigned to another update";
+  }
+  if (agentIsAlreadyOnUpdateTarget(agent, target)) return "Already running this release";
+  return agent.connected ? "Ready for preview" : "Disconnected";
+}

--- a/web/management/src/views/AgentUpdates.vue
+++ b/web/management/src/views/AgentUpdates.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, inject, onMounted, ref } from "vue";
+import { computed, inject, onMounted, onUnmounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { NAlert, NButton, NCheckbox, NInput, NInputNumber, NModal, NSpin, NTab, NTabs, NTag } from "naive-ui";
 import {
@@ -14,9 +14,11 @@ import {
   ShieldCheck as ShieldIcon,
   TriangleAlert as WarningIcon,
 } from "@lucide/vue";
-import { dashboardKey, isBusyKey, runManagementActionKey } from "@/composables/managementContextKeys";
+import { dashboardKey, isBusyKey, runManagementActionKey, selectedEnvironmentIdKey, selectedEnvironmentBlockedKey } from "@/composables/managementContextKeys";
 import { useManagementClient } from "@/composables/useManagementClient";
 import { messageFromError } from "@/lib/errors";
+import { agentIsAlreadyOnUpdateTarget, agentRolloutStatus, agentUpdatePreviewBlockerLabel, canResumeUpdateCampaign, recoverableUpdateAssignments, retryableStageAssignments, updateRecoveryMessage } from "@/lib/agentUpdateRecovery";
+import { createAgentUpdatePolling } from "@/lib/agentUpdatePolling";
 import { modalCardStyle, modalScrollableContentStyle } from "@/lib/naiveUi";
 import AgentSetupModal from "@/components/AgentSetupModal.vue";
 import {
@@ -35,6 +37,8 @@ const router = useRouter();
 const dashboard = inject(dashboardKey, computed(() => null));
 const isBusy = inject(isBusyKey, computed(() => false));
 const runManagementAction = inject(runManagementActionKey);
+const selectedEnvironmentId = inject(selectedEnvironmentIdKey, computed(() => "0"));
+const selectedEnvironmentBlocked = inject(selectedEnvironmentBlockedKey, computed(() => ""));
 
 const sections = [
   { key: "fleet", label: "Fleet", path: "/agent" },
@@ -46,6 +50,7 @@ const overview = ref<GetAgentUpdateOverviewResponse | null>(null);
 const campaigns = ref<AgentUpdateCampaign[]>([]);
 const loading = ref(false);
 const operationError = ref("");
+const campaignErrors = ref<Record<string, string>>({});
 const planOpen = ref(false);
 const planError = ref("");
 const planErrorTitle = ref("");
@@ -61,6 +66,7 @@ const preview = ref<AgentUpdatePreviewAgent[]>([]);
 const previewFingerprint = ref("");
 const previewLoading = ref(false);
 const planBusy = computed(() => previewLoading.value || planCreating.value || isBusy.value);
+const campaignBusy = computed(() => isBusy.value || loading.value);
 const setupModal = ref<InstanceType<typeof AgentSetupModal> | null>(null);
 
 const agents = computed(() => overview.value?.agents ?? []);
@@ -85,10 +91,14 @@ const currentPlanFingerprint = computed(() => [
   canaryCount.value,
   waveSize.value,
   healthyDwellSeconds.value,
+  selectedAgentIds.value.map((id) => {
+    const agent = agents.value.find((item) => item.agentId.toString() === id);
+    return agent ? [id, agent.updaterEnrolled, agent.connected, agent.activeAssignmentId, agent.updaterVersion, updaterIsFresh(agent), agent.tunnelVersion, agent.tunnelCommit].join(":") : `${id}:missing`;
+  }).sort().join(","),
 ].join("\u0000"));
 const previewIsCurrent = computed(() => Boolean(previewFingerprint.value) && previewFingerprint.value === currentPlanFingerprint.value);
 const canCreate = computed(() => Boolean(
-  trustedTarget.value && managementAuthority.value && planName.value.trim() && selectedAgentIds.value.length > 0 &&
+  !operationError.value && trustedTarget.value && managementAuthority.value && planName.value.trim() && selectedAgentIds.value.length > 0 &&
   preview.value.length === selectedAgentIds.value.length && previewBlocked.value.length === 0 && previewIsCurrent.value,
 ));
 
@@ -97,30 +107,42 @@ async function selectSection(value: string | number) {
   if (section && section.key !== "updates") await router.push(section.path);
 }
 
-async function refresh() {
-  loading.value = true;
-  operationError.value = "";
-  try {
+const polling = createAgentUpdatePolling({
+  scope: () => `${selectedEnvironmentId.value}\u0000${selectedEnvironmentBlocked.value}`,
+  canPoll: () => !planBusy.value && !selectedEnvironmentBlocked.value && document.visibilityState !== "hidden",
+  load: async (signal) => {
+    if (selectedEnvironmentBlocked.value) throw new Error(selectedEnvironmentBlocked.value);
+    const options = { signal, timeoutMs: 15000 };
     const [nextOverview, campaignList] = await Promise.all([
-      managementClient.getAgentUpdateOverview({}),
-      managementClient.listAgentUpdateCampaigns({ limit: 50n }),
+      managementClient.getAgentUpdateOverview({}, options),
+      managementClient.listAgentUpdateCampaigns({ limit: 50n }, options),
     ]);
+    return { nextOverview, campaignList };
+  },
+  apply: ({ nextOverview, campaignList }) => {
     overview.value = nextOverview;
     campaigns.value = campaignList.campaigns;
-  } catch (error) {
-    operationError.value = messageFromError(error);
-  } finally {
-    loading.value = false;
-  }
+    operationError.value = "";
+  },
+  error: (error) => { operationError.value = messageFromError(error); },
+  loading: (value) => { loading.value = value; },
+});
+
+function refresh() {
+  return polling.refresh();
 }
 
 function openPlan() {
   planError.value = "";
   planName.value = trustedTarget.value ? `Fleet to ${trustedTarget.value.version}` : "Fleet update";
-  selectedAgentIds.value = enrolledAgents.value.filter((agent) => agent.connected && !agent.activeAssignmentId).map((agent) => agent.agentId.toString());
+  selectedAgentIds.value = agents.value.filter((agent) => !agentUnavailableForPlan(agent)).map((agent) => agent.agentId.toString());
   preview.value = [];
   previewFingerprint.value = "";
   planOpen.value = true;
+}
+
+function agentUnavailableForPlan(agent: AgentUpdateOverviewAgent): boolean {
+  return !agent.updaterEnrolled || !agent.connected || Boolean(agent.activeAssignmentId) || agentIsAlreadyOnUpdateTarget(agent, trustedTarget.value);
 }
 
 function policyRequest() {
@@ -186,34 +208,48 @@ async function createPlan() {
 }
 
 async function changeCampaign(campaign: AgentUpdateCampaign, action: "pause" | "resume" | "cancel") {
+  if (campaignBusy.value || (action === "resume" && !canResumeUpdateCampaign(campaign))) return;
   const request = { campaignId: campaign.id, expectedGeneration: campaign.generation };
-  const execute = async () => {
+  await runCampaignAction(campaign, async () => {
     if (action === "pause") await managementClient.pauseAgentUpdateCampaign(request);
     else if (action === "resume") await managementClient.resumeAgentUpdateCampaign(request);
     else await managementClient.cancelAgentUpdateCampaign(request);
-    await refresh();
-  };
-  if (runManagementAction) await runManagementAction(execute, `Campaign ${action}d`);
-  else await execute();
+  }, action === "cancel" ? "Campaign cancelled" : `Campaign ${action}d`);
 }
 
-async function retryFailed(campaign: AgentUpdateCampaign) {
-  const failed = campaign.assignments.filter((assignment) => assignment.state === AgentUpdateAssignmentState.FAILED || assignment.state === AgentUpdateAssignmentState.BLOCKED);
+async function retryFailed(campaign: AgentUpdateCampaign, recovery: boolean) {
+  if (campaignBusy.value) return;
+  const failed = recovery ? recoverableUpdateAssignments(campaign) : retryableStageAssignments(campaign);
   if (!failed.length) return;
-  const execute = async () => {
+  await runCampaignAction(campaign, async () => {
     await managementClient.retryAgentUpdateAssignments({
       campaignId: campaign.id,
       assignmentIds: failed.map((assignment) => assignment.id),
       expectedCampaignGeneration: campaign.generation,
     });
-    await refresh();
+  }, recovery ? "Rollback recovery requested" : "Failed assignments queued again");
+}
+
+async function runCampaignAction(campaign: AgentUpdateCampaign, action: () => Promise<unknown>, successMessage: string) {
+  const key = campaign.id.toString();
+  delete campaignErrors.value[key];
+  const onError = (error: unknown) => { campaignErrors.value[key] = messageFromError(error); };
+  const execute = async () => {
+    try { await action(); }
+    finally { await refresh(); }
   };
-  if (runManagementAction) await runManagementAction(execute, "Failed assignments queued again");
-  else await execute();
+  try {
+    if (runManagementAction) await runManagementAction(execute, successMessage, { onError });
+    else await execute();
+  } catch (error) { onError(error); }
 }
 
 function enableManagedUpdates(agent: AgentUpdateOverviewAgent) {
   void setupModal.value?.openExisting({ id: agent.agentId, publicId: agent.agentPublicId, name: agent.name, version: agent.tunnelVersion, commit: agent.tunnelCommit }, "enable-updates");
+}
+
+function repairUpdater(agent: AgentUpdateOverviewAgent) {
+  void setupModal.value?.openExisting({ id: agent.agentId, publicId: agent.agentPublicId, name: agent.name, version: agent.tunnelVersion, commit: agent.tunnelCommit }, "reinstall");
 }
 
 function toggleAgent(agent: AgentUpdateOverviewAgent, checked: boolean) {
@@ -249,8 +285,9 @@ function enumLabel(value: string): string {
   return value.toLowerCase().replaceAll("_", " ");
 }
 
-function assignmentStateLabel(state: AgentUpdateAssignmentState): string {
-  return enumLabel(AgentUpdateAssignmentState[state] ?? "unknown");
+function assignmentStateLabel(assignment: AgentUpdateAssignment): string {
+  if (assignment.cordoned && assignment.desiredAction === AgentUpdateDesiredAction.ROLLBACK) return "rollback pending";
+  return enumLabel(AgentUpdateAssignmentState[assignment.state] ?? "unknown");
 }
 
 function assignmentActionLabel(action: AgentUpdateDesiredAction): string {
@@ -280,6 +317,10 @@ function assignmentEvidence(assignment: AgentUpdateAssignment): string {
   return "No execution evidence reported yet";
 }
 
+function previewBlockerLabel(blocker: string): string {
+  return agentUpdatePreviewBlockerLabel(blocker, trustedTarget.value?.minimumUpdaterVersion);
+}
+
 function formatTimestamp(value: bigint): string {
   return value ? new Date(Number(value)).toLocaleString() : "—";
 }
@@ -298,7 +339,17 @@ function updaterLastSeenLabel(agent: AgentUpdateOverviewAgent): string {
     : `worker stale since ${observed.toLocaleString()}`;
 }
 
-onMounted(refresh);
+watch([selectedEnvironmentId, selectedEnvironmentBlocked], () => {
+  overview.value = null;
+  campaigns.value = [];
+  campaignErrors.value = {};
+  planOpen.value = false;
+  preview.value = [];
+  previewFingerprint.value = "";
+  void polling.scopeChanged();
+}, { flush: "sync" });
+onMounted(() => { void polling.start(); });
+onUnmounted(() => polling.stop());
 </script>
 
 <template>
@@ -312,7 +363,7 @@ onMounted(refresh);
       <div class="agent-updates__actions">
         <NButton secondary size="small" :loading="loading" :disabled="isBusy" @click="refresh">
           <template #icon><RefreshIcon class="icon-sm" /></template>
-          Refresh catalog
+          Refresh status
         </NButton>
         <NButton type="primary" size="small" :disabled="!trustedTarget || !managementAuthority || !enrolledAgents.length || isBusy" @click="openPlan">
           Plan rollout
@@ -343,7 +394,7 @@ onMounted(refresh);
         <div>
           <p class="stat-label">Management release</p>
           <h4 id="release-deck-title">{{ trustedTarget?.version || serverVersion }}</h4>
-          <p>{{ trustedTarget ? `Signed stable target · sequence ${trustedTarget.releaseSequence}` : "No trusted stable target is currently available." }}</p>
+          <p>{{ trustedTarget ? `Trusted target · sequence ${trustedTarget.releaseSequence}` : "No trusted release target is currently available." }}</p>
         </div>
       </div>
       <div class="agent-release-deck__integrity">
@@ -449,6 +500,7 @@ onMounted(refresh);
         <div>
           <p class="stat-label">Host trust</p>
           <h4>Updater enrollment</h4>
+          <p v-if="trustedTarget" class="muted-text copy-xs">This target requires pinned updater {{ trustedTarget.minimumUpdaterVersion }} or newer. Repair updates the pinned updater and keeps the live tunnel binary.</p>
         </div>
         <NTag size="small" :bordered="false">{{ enrolledAgents.length }}/{{ agents.length }} enrolled</NTag>
       </div>
@@ -462,7 +514,13 @@ onMounted(refresh);
           <div><span>Pinned rescue</span><strong>{{ agent.updaterEnrolled ? (agent.updaterVersion || "enrolled") : "not enrolled" }}</strong><small v-if="agent.updaterEnrolled">{{ updaterLastSeenLabel(agent) }}</small></div>
           <div><span>Live tunnel</span><strong>{{ agent.tunnelVersion || "unreported" }}</strong><small v-if="agent.tunnelCommit" class="mono-text">{{ shortDigest(agent.tunnelCommit) }}</small></div>
           <div><span>Traffic</span><strong>{{ agent.cordoned ? "cordoned" : "eligible" }}</strong></div>
-          <NTag v-if="agent.updaterEnrolled" size="small" :bordered="false" :type="updaterIsFresh(agent) ? 'success' : 'warning'">{{ updaterIsFresh(agent) ? "Managed" : "Worker stale" }}</NTag>
+          <div v-if="agent.updaterEnrolled" class="agent-update-fleet__controls">
+            <NTag size="small" :bordered="false" :type="updaterIsFresh(agent) ? 'success' : 'warning'">{{ updaterIsFresh(agent) ? "Managed" : "Worker stale" }}</NTag>
+            <span :title="agent.activeAssignmentId ? 'Recovery must finish before replacing updater enrollment.' : 'Refresh the pinned updater while preserving the live tunnel binary.'">
+              <NButton secondary size="tiny" :disabled="campaignBusy || Boolean(agent.activeAssignmentId) || !trustedTarget || !managementAuthority" @click="repairUpdater(agent)">Repair updater</NButton>
+            </span>
+            <small v-if="agent.activeAssignmentId">Finish campaign recovery before repair.</small>
+          </div>
           <NButton v-else secondary size="tiny" :disabled="isBusy || !agent.tunnelVersion || !agent.tunnelCommit" @click="enableManagedUpdates(agent)">Enable managed updates</NButton>
         </div>
       </div>
@@ -472,27 +530,30 @@ onMounted(refresh);
     <section class="surface-card agent-update-campaigns">
       <div class="surface-card__header">
         <div>
-          <p class="stat-label">Execution history</p>
+          <p class="stat-label">Execution history · refreshes every 5 seconds</p>
           <h4>Update campaigns</h4>
         </div>
       </div>
       <div v-if="campaigns.length" class="agent-update-campaigns__rows">
         <article v-for="campaign in campaigns" :key="campaign.id.toString()" class="agent-update-campaign">
           <div class="agent-update-campaign__summary">
-            <div>
+            <div class="agent-update-campaign__identity">
               <NTag size="small" :bordered="false" :type="campaignTag(campaign.state)">{{ campaignLabel(campaign.state) }}</NTag>
               <strong>{{ campaign.name }}</strong>
               <small>{{ campaign.target?.version }} · generation {{ campaign.generation }}</small>
             </div>
-            <div class="agent-update-campaign__metric"><span>Proven healthy</span><strong>{{ assignmentProgress(campaign) }}</strong></div>
-            <div class="agent-update-campaign__metric"><span>Wave / unavailable</span><strong>{{ campaign.policy?.waveSize || 0n }} / {{ campaign.policy?.maxUnavailable || 0n }}</strong></div>
+            <div class="agent-update-campaign__metric agent-update-campaign__healthy"><span>Proven healthy</span><strong>{{ assignmentProgress(campaign) }}</strong></div>
+            <div class="agent-update-campaign__metric agent-update-campaign__wave"><span>Wave / unavailable</span><strong>{{ campaign.policy?.waveSize || 0n }} / {{ campaign.policy?.maxUnavailable || 0n }}</strong></div>
             <div class="agent-update-campaign__actions">
-              <NButton v-if="campaign.state === AgentUpdateCampaignState.RUNNING" quaternary size="tiny" :disabled="isBusy" @click="changeCampaign(campaign, 'pause')"><template #icon><PauseIcon /></template>Pause</NButton>
-              <NButton v-if="campaign.state === AgentUpdateCampaignState.PAUSED" quaternary size="tiny" :disabled="isBusy" @click="changeCampaign(campaign, 'resume')"><template #icon><PlayIcon /></template>Resume</NButton>
-              <NButton v-if="campaign.assignments.some((a) => a.state === AgentUpdateAssignmentState.FAILED || a.state === AgentUpdateAssignmentState.BLOCKED)" quaternary size="tiny" :disabled="isBusy" @click="retryFailed(campaign)"><template #icon><RetryIcon /></template>Retry</NButton>
-              <NButton v-if="campaign.state === AgentUpdateCampaignState.RUNNING || campaign.state === AgentUpdateCampaignState.PAUSED" quaternary size="tiny" type="error" :disabled="isBusy" @click="changeCampaign(campaign, 'cancel')">Cancel</NButton>
+              <NButton v-if="campaign.state === AgentUpdateCampaignState.RUNNING" quaternary size="tiny" :disabled="campaignBusy" @click="changeCampaign(campaign, 'pause')"><template #icon><PauseIcon /></template>Pause</NButton>
+              <NButton v-if="campaign.state === AgentUpdateCampaignState.PAUSED" quaternary size="tiny" :disabled="campaignBusy || !canResumeUpdateCampaign(campaign)" :title="canResumeUpdateCampaign(campaign) ? undefined : 'Recover reserved hosts or retry failed assignments before resuming.'" @click="changeCampaign(campaign, 'resume')"><template #icon><PlayIcon /></template>Resume</NButton>
+              <NButton v-if="recoverableUpdateAssignments(campaign).length" quaternary size="tiny" :disabled="campaignBusy" @click="retryFailed(campaign, true)"><template #icon><RetryIcon /></template>Recover agents</NButton>
+              <NButton v-if="retryableStageAssignments(campaign).length" quaternary size="tiny" :disabled="campaignBusy" @click="retryFailed(campaign, false)"><template #icon><RetryIcon /></template>Retry failed</NButton>
+              <NButton v-if="campaign.state === AgentUpdateCampaignState.RUNNING || campaign.state === AgentUpdateCampaignState.PAUSED" quaternary size="tiny" type="error" :disabled="campaignBusy" @click="changeCampaign(campaign, 'cancel')">Cancel</NButton>
             </div>
           </div>
+          <NAlert v-if="campaignErrors[campaign.id.toString()]" type="error" :bordered="false" class="agent-update-campaign__error" closable @close="delete campaignErrors[campaign.id.toString()]">{{ campaignErrors[campaign.id.toString()] }}</NAlert>
+          <p v-if="updateRecoveryMessage(campaign)" class="agent-update-campaign__recovery" role="status">{{ updateRecoveryMessage(campaign) }}</p>
           <details class="agent-update-campaign__details">
             <summary>Inspect {{ campaign.assignments.length }} agent assignment{{ campaign.assignments.length === 1 ? "" : "s" }}</summary>
             <div class="agent-update-assignment-list">
@@ -504,13 +565,13 @@ onMounted(refresh);
                     <small class="mono-text">{{ assignment.agentPublicId }}</small>
                   </div>
                 </div>
-                <div>
+                <div class="agent-update-assignment__state">
                   <span>State</span>
-                  <NTag size="small" :bordered="false" :type="assignmentTag(assignment.state)">{{ assignmentStateLabel(assignment.state) }}</NTag>
+                  <NTag size="small" :bordered="false" :type="assignment.desiredAction === AgentUpdateDesiredAction.ROLLBACK ? 'warning' : assignmentTag(assignment.state)">{{ assignmentStateLabel(assignment) }}</NTag>
                 </div>
-                <div><span>Desired action</span><strong>{{ assignmentActionLabel(assignment.desiredAction) }}</strong></div>
+                <div class="agent-update-assignment__action"><span>Desired action</span><strong>{{ assignmentActionLabel(assignment.desiredAction) }}</strong></div>
                 <div class="agent-update-assignment__evidence"><span>Evidence</span><strong>{{ assignmentEvidence(assignment) }}</strong></div>
-                <div><span>Updated</span><strong>{{ formatTimestamp(assignment.updatedAtUnixMillis) }}</strong></div>
+                <div class="agent-update-assignment__updated"><span>Updated</span><strong>{{ formatTimestamp(assignment.updatedAtUnixMillis) }}</strong></div>
               </div>
             </div>
           </details>
@@ -535,19 +596,19 @@ onMounted(refresh);
         </div>
         <div class="agent-update-agent-picker">
           <p class="stat-label">Agents</p>
-          <label v-for="agent in agents" :key="agent.agentPublicId" :class="{ 'agent-update-agent-picker__blocked': !agent.updaterEnrolled || !agent.connected || Boolean(agent.activeAssignmentId) }">
+          <label v-for="agent in agents" :key="agent.agentPublicId" :class="{ 'agent-update-agent-picker__blocked': agentUnavailableForPlan(agent) }">
             <NCheckbox
               :checked="selectedAgentIds.includes(agent.agentId.toString())"
-              :disabled="planBusy || !agent.updaterEnrolled || !agent.connected || Boolean(agent.activeAssignmentId)"
+              :disabled="planBusy || (!selectedAgentIds.includes(agent.agentId.toString()) && agentUnavailableForPlan(agent))"
               @update:checked="toggleAgent(agent, $event)"
             />
-            <span><strong>{{ agent.name }}</strong><small>{{ !agent.updaterEnrolled ? "Updater not enrolled" : !agent.connected ? "Disconnected" : agent.activeAssignmentId ? "Already assigned" : "Ready for preview" }}</small></span>
+            <span><strong>{{ agent.name }}</strong><small>{{ agentRolloutStatus(agent, campaigns, trustedTarget) }}</small></span>
           </label>
         </div>
         <div v-if="preview.length" class="agent-update-preview">
           <div v-for="agent in preview" :key="agent.agentPublicId" :class="{ 'agent-update-preview--blocked': !agent.eligible }">
             <CheckIcon v-if="agent.eligible" /><WarningIcon v-else />
-            <span><strong>{{ agent.name }}</strong><small>{{ agent.eligible ? "Eligible" : agent.blockers.join(", ") }}</small></span>
+            <span><strong>{{ agent.name }}</strong><small>{{ agent.eligible ? "Eligible" : agent.blockers.map(previewBlockerLabel).join("; ") }}</small></span>
           </div>
         </div>
         <NAlert v-if="preview.length && !previewIsCurrent" type="warning" :bordered="false">
@@ -558,6 +619,9 @@ onMounted(refresh);
         <div class="agent-update-modal__footer">
           <NAlert v-if="planError" type="error" :title="planErrorTitle" :bordered="false" class="agent-update-modal__error">
             {{ planError }}
+          </NAlert>
+          <NAlert v-else-if="operationError" type="error" title="Unable to refresh update status" :bordered="false" class="agent-update-modal__error">
+            {{ operationError }}
           </NAlert>
           <div class="agent-update-modal__actions">
             <NButton :disabled="planBusy" @click="planOpen = false">Cancel</NButton>
@@ -745,9 +809,11 @@ onMounted(refresh);
 .agent-update-campaigns h4 { margin: 0.15rem 0 0; }
 .agent-update-fleet__rows,
 .agent-update-campaigns__rows { display: grid; }
+.agent-update-campaigns { container: update-campaigns / inline-size; }
+.agent-update-campaigns__rows { grid-template-columns: minmax(0, 1fr); }
 .agent-update-fleet__row {
   display: grid;
-  grid-template-columns: auto minmax(13rem, 1.4fr) minmax(8rem, 0.7fr) minmax(7rem, 0.5fr) auto;
+  grid-template-columns: auto minmax(0, 1.4fr) minmax(0, 0.9fr) minmax(0, 0.9fr) minmax(0, 0.5fr) minmax(7rem, 0.7fr);
   align-items: center;
   gap: 1rem;
   border-top: 1px solid var(--app-border-subtle);
@@ -767,6 +833,8 @@ onMounted(refresh);
 .agent-update-fleet__row > div > span,
 .agent-update-campaign__metric span { color: var(--app-text-muted); font-size: 0.64rem; text-transform: uppercase; letter-spacing: 0.045em; }
 .agent-update-fleet__row strong { overflow: hidden; font-size: 0.72rem; text-overflow: ellipsis; white-space: nowrap; }
+.agent-update-fleet__controls { display: flex; flex-direction: column; align-items: flex-start; gap: 0.4rem; }
+.agent-update-fleet__controls small { max-width: 11rem; color: var(--app-text-muted); font-size: 0.65rem; overflow-wrap: anywhere; }
 .agent-update-fleet__identity small,
 .agent-update-campaign small { overflow: hidden; margin-top: 0.12rem; color: var(--app-text-muted); font-size: 0.64rem; text-overflow: ellipsis; white-space: nowrap; }
 .agent-update-campaign {
@@ -774,16 +842,22 @@ onMounted(refresh);
 }
 .agent-update-campaign__summary {
   display: grid;
-  grid-template-columns: minmax(15rem, 1.4fr) minmax(7rem, 0.5fr) minmax(8rem, 0.6fr) auto;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 0.5fr) minmax(0, 0.6fr) auto;
+  grid-template-areas: "identity healthy wave actions";
   align-items: center;
   gap: 1rem;
   padding: 0.9rem 1.2rem;
 }
-.agent-update-campaign__summary > div:first-child { display: grid; grid-template-columns: auto 1fr; align-items: center; gap: 0.45rem; }
-.agent-update-campaign__summary > div:first-child small { grid-column: 1 / -1; }
+.agent-update-campaign__identity { grid-area: identity; display: grid; grid-template-columns: auto minmax(0, 1fr); align-items: center; gap: 0.45rem; }
+.agent-update-campaign__identity strong { overflow-wrap: anywhere; }
+.agent-update-campaign__identity small { grid-column: 1 / -1; white-space: normal; overflow-wrap: anywhere; }
+.agent-update-campaign__healthy { grid-area: healthy; }
+.agent-update-campaign__wave { grid-area: wave; }
 .agent-update-campaign__metric strong { margin-top: 0.15rem; font-family: var(--font-mono); font-size: 0.82rem; }
-.agent-update-campaign__actions { display: flex; justify-content: flex-end; gap: 0.25rem; }
+.agent-update-campaign__actions { grid-area: actions; display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 0.25rem; }
 .agent-update-campaign__actions svg { width: 0.8rem; height: 0.8rem; }
+.agent-update-campaign__recovery { margin: 0; padding: 0 1.2rem 0.9rem; color: var(--app-warning); font-size: 0.72rem; line-height: 1.5; overflow-wrap: anywhere; }
+.agent-update-campaign__error { margin: 0 1.2rem 0.9rem; overflow-wrap: anywhere; }
 .agent-update-campaign__details {
   border-top: 1px solid var(--app-border-subtle);
   background: color-mix(in srgb, var(--app-panel-muted) 62%, transparent);
@@ -797,10 +871,11 @@ onMounted(refresh);
   font-weight: 650;
   list-style-position: inside;
 }
-.agent-update-assignment-list { display: grid; border-top: 1px solid var(--app-border-subtle); }
+.agent-update-assignment-list { display: grid; grid-template-columns: minmax(0, 1fr); border-top: 1px solid var(--app-border-subtle); }
 .agent-update-assignment {
   display: grid;
-  grid-template-columns: minmax(13rem, 1.1fr) minmax(8rem, 0.7fr) minmax(7rem, 0.55fr) minmax(16rem, 1.5fr) minmax(10rem, 0.75fr);
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.7fr) minmax(0, 0.55fr) minmax(0, 1.5fr) minmax(0, 0.75fr);
+  grid-template-areas: "identity state action evidence updated";
   align-items: center;
   gap: 0.85rem;
   padding: 0.75rem 1.2rem;
@@ -810,14 +885,45 @@ onMounted(refresh);
 .agent-update-assignment > div > span,
 .agent-update-assignment > div > strong { display: block; }
 .agent-update-assignment > div > span { margin-bottom: 0.15rem; color: var(--app-text-muted); font-size: 0.59rem; letter-spacing: 0.045em; text-transform: uppercase; }
-.agent-update-assignment > div > strong { overflow: hidden; font-size: 0.68rem; text-overflow: ellipsis; white-space: nowrap; }
-.agent-update-assignment__identity { display: flex; align-items: center; gap: 0.65rem; }
+.agent-update-assignment > div > strong { font-size: 0.68rem; overflow-wrap: anywhere; }
+.agent-update-assignment__identity { grid-area: identity; display: flex; align-items: center; gap: 0.65rem; }
+.agent-update-assignment__identity > span { flex-shrink: 0; }
 .agent-update-assignment__identity > div { min-width: 0; }
 .agent-update-assignment__identity strong,
 .agent-update-assignment__identity small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .agent-update-assignment__identity strong { font-size: 0.7rem; }
 .agent-update-assignment__identity small { margin-top: 0.1rem; font-size: 0.6rem; }
-.agent-update-assignment__evidence strong { white-space: normal; overflow-wrap: anywhere; }
+.agent-update-assignment__state { grid-area: state; }
+.agent-update-assignment__action { grid-area: action; }
+.agent-update-assignment__evidence { grid-area: evidence; }
+.agent-update-assignment__updated { grid-area: updated; }
+
+@container update-campaigns (max-width: 60rem) {
+  .agent-update-campaign__summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
+    grid-template-areas: "identity identity actions" "healthy wave actions";
+  }
+  .agent-update-assignment {
+    grid-template-columns: minmax(0, 0.8fr) minmax(0, 0.8fr) minmax(0, 1.5fr);
+    grid-template-areas: "identity identity updated" "state action evidence";
+    align-items: start;
+  }
+}
+
+@container update-campaigns (max-width: 40rem) {
+  .agent-update-campaign__summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas: "identity identity" "healthy wave" "actions actions";
+    align-items: start;
+  }
+  .agent-update-campaign__actions { justify-content: flex-start; }
+  .agent-update-assignment {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas: "identity identity" "state action" "evidence evidence" "updated updated";
+  }
+  .agent-update-assignment__identity strong,
+  .agent-update-assignment__identity small { white-space: normal; overflow-wrap: anywhere; }
+}
 .agent-update-empty { border-top: 1px solid var(--app-border-subtle); padding: 1.5rem; color: var(--app-text-muted); font-size: 0.72rem; text-align: center; }
 .agent-update-field { display: grid; gap: 0.35rem; }
 .agent-update-field > span { color: var(--app-text-muted); font-size: 0.68rem; font-weight: 600; }
@@ -856,13 +962,8 @@ onMounted(refresh);
   .agent-update-metrics article:nth-child(4) { border-top: 1px solid var(--app-border-subtle); }
   .agent-rollout-rail__steps { grid-template-columns: repeat(2, 1fr); gap: 1.25rem; }
   .agent-rollout-step::after { display: none; }
-  .agent-update-fleet__row { grid-template-columns: auto 1fr auto; }
-  .agent-update-fleet__row > div:not(.agent-update-fleet__identity) { display: none; }
-  .agent-update-campaign__summary { grid-template-columns: 1fr auto; }
-  .agent-update-campaign__metric { display: none; }
-  .agent-update-assignment { grid-template-columns: minmax(12rem, 1fr) minmax(8rem, auto) minmax(12rem, 1fr); }
-  .agent-update-assignment > div:nth-child(3),
-  .agent-update-assignment > div:nth-child(5) { display: none; }
+  .agent-update-fleet__row { grid-template-columns: auto minmax(0, 1fr) minmax(0, auto); }
+  .agent-update-fleet__row > div:not(.agent-update-fleet__identity):not(.agent-update-fleet__controls) { display: none; }
   .agent-update-form-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
@@ -875,11 +976,6 @@ onMounted(refresh);
   .agent-rollout-rail__steps { grid-template-columns: 1fr; }
   .agent-update-form-grid,
   .agent-update-preview { grid-template-columns: 1fr; }
-  .agent-update-campaign__summary { align-items: flex-start; grid-template-columns: 1fr; }
-  .agent-update-campaign__actions { justify-content: flex-start; }
-  .agent-update-assignment { grid-template-columns: 1fr; }
-  .agent-update-assignment > div:nth-child(3),
-  .agent-update-assignment > div:nth-child(5) { display: block; }
   .agent-update-modal__actions { flex-wrap: wrap; }
 }
 </style>


### PR DESCRIPTION
Managed agent updates could remain stuck after cancellation, a lost rollback response from an older worker, or repeated privileged helper invocations. Preserve recovery fences and signed execution evidence, acknowledge exact completed commands without executing them again, and permit retries only for the exact previously authenticated release manifest.

Fix floor ownership, staging cleanup races, management-version handoffs, and installer/service recovery. Keep the existing agent token, live binary and network policy during updater repair. Separate recovery from rollout retry in the UI, refresh status without losing planner input, and keep unresolved campaigns visible. New manifests require the corrected pinned updater starting at `v0.1.53-staging.88`; this baseline remains fixed for later compatible tunnel releases.

Validation: full Go suite and vet, focused race tests, installer lifecycle tests, 257 frontend tests and production build, plus a real Ubuntu 24.04 Multipass lifecycle. The VM verified upgrade, signed cancellation rollback with the actual `.84` worker, loss and retry of an accepted response, crash limiting, pinned-updater repair and another rollout to the same target. Browser checks covered 375/900/1174 pixel widths and preservation of an open rollout draft.

The repeatable VM harness and detailed findings/coverage limits are documented in `docs/operations/managed-updates-review-2026-09-11.md`. Deployment order is management, pending recovery, pinned-updater repair, then a canary rollout.
