### PR TITLE
Fix managed updater timers stopping after repair

### DIFF
--- a/docs/operations/managed-agent-updates.md
+++ b/docs/operations/managed-agent-updates.md
@@ -156,6 +156,30 @@ If a host enrolled successfully but shows **Worker stale**, check `systemctl sta
 
 Re-enrolling or repairing an already managed host updates its rescue runner and keeps its existing agent binary and rollback state. Upgrading that binary requires a rollout campaign. A successful repair message alone does not confirm that the agent upgraded; check **Live tunnel** and the campaign result.
 
+The timer shipped through `v0.1.53-staging.88` can stop scheduling after repair.
+The enrollment command sends its own check-in before systemd starts the worker,
+so management can show the new pinned updater version while subsequent checks
+never arrive. Check `systemctl status p2pstream-updater.timer`: the characteristic
+state is **active (elapsed)** with **Trigger: n/a**. The original timer's boot
+trigger was already consumed, and stopping/reloading the units can discard the
+service activation timestamps needed by `OnUnitActiveSec`. The corrected timer
+adds `OnActiveSec=30s`, giving every timer restart a fresh scheduling deadline.
+
+For an already repaired `.88` host, apply the timer correction directly:
+
+```sh
+sudo install -d -m 0755 /etc/systemd/system/p2pstream-updater.timer.d &&
+printf '[Timer]\nOnActiveSec=30s\n' | sudo tee /etc/systemd/system/p2pstream-updater.timer.d/10-rearm.conf >/dev/null &&
+sudo systemctl daemon-reload &&
+sudo systemctl restart p2pstream-updater.timer &&
+sudo systemctl start p2pstream-updater.service
+```
+
+This preserves the agent credentials, network permissions, signed receipts and
+current campaign. The timer should show a future trigger while waiting; **running**
+is also normal while its worker executes. A failed worker invocation requires
+its journal (`sudo journalctl -u p2pstream-updater.service -n 50 --no-pager`).
+
 If activation reports that the agent service did not become active and rolled back, inspect the agent service journal and the candidate slot permissions. Updater builds through `v0.1.53-staging.86` created the new slot directory with mode `0700`; the activator's `UMask=0077` also restricted the executable to `0700`. The `p2pstream` service user cannot execute that root-owned slot. The corrected updater explicitly applies `0755` to the verified executable and its version directory before promotion, and repairs those permissions on verified existing slots during retry. Its private state still uses the restrictive umask. Install a release containing this correction into each host's pinned rescue updater before attempting further rollouts; changing only the management server or the agent's live binary does not replace that separate runner.
 
 - A failed download, manifest, size, or digest check never reaches the

--- a/docs/operations/managed-updates-review-2026-09-11.md
+++ b/docs/operations/managed-updates-review-2026-09-11.md
@@ -86,3 +86,41 @@ The intended first corrected updater is `.88`; confirm that tag contains these
 fixes when publishing. If another release consumes that tag first, move the fixed
 minimum to the first release that actually contains the corrections. Re-run the
 VM gate before staging changes to execution, recovery, enrollment or units.
+
+## Follow-up: timer stops after `.88` repair
+
+The initial VM test above stopped the updater timer and explicitly started
+workers. That verified execution and recovery but missed periodic scheduling
+after repair. The follow-up removes that shortcut: installed production timers
+now drive the campaigns, including the final rollout after repair, and the test
+rejects an exhausted timer even when `systemctl is-active` reports success.
+
+All four live agents were inspected through the user-provided SSH jump host.
+Each had an enabled timer in `active (elapsed)`, an infinite next deadline, and
+an inactive worker. The new `.88` identity visible in management came from the
+enrollment command's own signed check. The original timer's boot trigger had
+already fired, while repair's stop/reload sequence discarded the service
+activation timestamps needed by `OnUnitActiveSec`. No later poll was scheduled.
+
+Both the installer-generated timer and the checked-in unit now include
+`OnActiveSec=30s`. Existing hosts received the same setting as a persistent
+`/etc/systemd/system/p2pstream-updater.timer.d/10-rearm.conf` override. Only their
+timers were restarted; no manual worker start, token rotation, receipt removal,
+or new campaign was needed. All four resumed recurring checks. Fair Orca's
+existing campaign then completed on `v0.1.53-staging.88`, with 1/1 proven healthy
+at 23:18:36 CEST. The other three hosts remain on their previous live versions
+and are available for subsequent rollout.
+
+| Follow-up check | Result | Evidence |
+| --- | --- | --- |
+| Isolated timer before/after repair | Original timer stopped at 3 executions; the same timer with `OnActiveSec` resumed to 6. A worker longer than its interval also kept recurring. | `tmp/timer-review/timer-probe.log` |
+| Historical missing-condition repair | Original timer stayed exhausted after the condition was corrected; the added restart deadline restored polling. | `tmp/timer-review/legacy-condition-probe.log` |
+| Original full lifecycle, then timer-only intervention | Reproduced the post-repair stall with real binaries and units; replacing only the timer resumed the same campaign to success. This run deliberately includes that intervention. | `tmp/managed-updates-timer-review/stalled-after-repair.log`, `timer-intervention.md`, `test.log` |
+| Fresh full lifecycle using the corrected installer | Passed in 502.81 seconds without mid-run intervention: upgrades, signed legacy rollback and lost-response retry, crash throttling, repair, and exact-target retry. | `tmp/managed-updates-timer-fixed/test.log`, `systemd-status.log`, `systemd-journal.log` |
+| Installer lifecycle, shell syntax, harness compilation and server vet | Passed | `tmp/timer-review/lifecycle.log`, `vet.log` |
+| Live fleet after correction | All four timers repeatedly invoked successful workers; Fair Orca's running executable was the `.88` slot. | `tmp/timer-review/fleet-verification.log` and live campaign result |
+
+The corrected harness retains the prior VM's platform and networking limits.
+Both disposable VMs were removed after collecting evidence. This follow-up
+does not publish a new staging release; the fleet timer correction is already
+applied, and the installer change is ready for the next release.

--- a/internal/server/agent_update_systemd_integration_test.go
+++ b/internal/server/agent_update_systemd_integration_test.go
@@ -61,10 +61,15 @@ func TestManagedUpdatesSystemdLifecycle(t *testing.T) {
 	if _, err := os.Stat(legacy); err != nil {
 		t.Fatalf("real legacy worker fixture is required: %v", err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cancel()
 	defer func() {
-		cmd := exec.Command("journalctl", "-u", "p2pstream-agent", "-u", "p2pstream-updater", "-u", "p2pstream-updater-activate", "--no-pager", "-n", "240")
+		status, _ := exec.Command("systemctl", "status", "p2pstream-updater.timer", "p2pstream-updater.service", "p2pstream-updater-activate.path", "p2pstream-updater-activate.service", "--no-pager", "-l").CombinedOutput()
+		_ = os.WriteFile(filepath.Join(root, "systemd-status.log"), status, 0600)
+		if t.Failed() {
+			t.Logf("systemd status:\n%s", status)
+		}
+		cmd := exec.Command("journalctl", "-u", "p2pstream-agent", "-u", "p2pstream-updater", "-u", "p2pstream-updater.timer", "-u", "p2pstream-updater-activate", "--no-pager", "-n", "400")
 		if output, err := cmd.CombinedOutput(); err == nil {
 			_ = os.WriteFile(filepath.Join(root, "systemd-journal.log"), output, 0600)
 			if t.Failed() {
@@ -187,9 +192,9 @@ func TestManagedUpdatesSystemdLifecycle(t *testing.T) {
 	if output, err := install.CombinedOutput(); err != nil {
 		t.Fatalf("real installer failed: %v\n%s", err, output)
 	}
-	// Drive the worker explicitly to keep the test bounded; the production
-	// activation path and service hardening remain unchanged.
-	systemdCommand(t, ctx, "systemctl", "stop", "p2pstream-updater.timer")
+	// Leave the installed production timer running. Enrollment performs one
+	// signed check itself, which must not mask a broken periodic worker.
+	systemdAssertPollingScheduled(t, ctx)
 	waitForAgentHubConnection(t, app, agent.ID, true)
 	originalEnv := systemdRead(t, "/etc/p2pstream/agent.env")
 
@@ -203,10 +208,9 @@ func TestManagedUpdatesSystemdLifecycle(t *testing.T) {
 		}
 		return response.Msg.Campaign.Id
 	}
-	var lastWorkerStart time.Time
 	waitCampaign := func(campaignID int64, want string) {
 		t.Helper()
-		deadline := time.Now().Add(90 * time.Second)
+		deadline := time.Now().Add(5 * time.Minute)
 		last := ""
 		for time.Now().Before(deadline) && ctx.Err() == nil {
 			var state, action, failure string
@@ -224,17 +228,6 @@ func TestManagedUpdatesSystemdLifecycle(t *testing.T) {
 			}
 			if state == "blocked" {
 				t.Fatalf("campaign blocked: %s", current)
-			}
-			if time.Since(lastWorkerStart) >= 5*time.Second {
-				lastWorkerStart = time.Now()
-				if output, err := exec.CommandContext(ctx, "systemctl", "start", "p2pstream-updater.service").CombinedOutput(); err != nil {
-					if want != "failed" {
-						t.Fatalf("real worker failed: %v\n%s", err, output)
-					}
-					// A single injected lost response should be recovered by the next
-					// invocation. Persistent errors still fail the bounded phase below.
-					t.Logf("rollback worker retry after failed invocation: %v", err)
-				}
 			}
 			app.reconcileAgentUpdateMaintenance(ctx, time.Now().UTC())
 			time.Sleep(250 * time.Millisecond)
@@ -363,13 +356,34 @@ func TestManagedUpdatesSystemdLifecycle(t *testing.T) {
 	if err := database.QueryRow(`SELECT updater_version FROM agent_updater_identities WHERE agent_id=?`, agent.ID).Scan(&enrolledUpdaterVersion); err != nil || enrolledUpdaterVersion != "v1.1.0" {
 		t.Fatalf("repair did not promote enrolled updater version: %q, %v", enrolledUpdaterVersion, err)
 	}
-	systemdCommand(t, ctx, "systemctl", "stop", "p2pstream-updater.timer")
+	systemdAssertPollingScheduled(t, ctx)
 	waitForAgentHubConnection(t, app, agent.ID, true)
 	assertLive("v1.1.0")
 	third := startCampaign("v1.2.0")
 	waitCampaign(third, "succeeded")
 	assertLive("v1.2.0")
-	t.Log("PASS: real install/enrollment, two upgrades, signed cancellation rollback, legacy worker report/lost-response retry, crash throttle, pinned-updater repair, and exact-target retry")
+	t.Log("PASS: production timer drove real install/enrollment, two upgrades, signed cancellation rollback, legacy worker report/lost-response retry, crash throttle, pinned-updater repair, and exact-target retry")
+}
+
+func systemdAssertPollingScheduled(t *testing.T, ctx context.Context) {
+	t.Helper()
+	// is-active also succeeds for an exhausted timer with no next trigger.
+	status := systemdCommand(t, ctx, "systemctl", "show", "p2pstream-updater.timer", "--property=SubState,NextElapseUSecMonotonic")
+	values := make(map[string]string)
+	for _, line := range strings.Split(strings.TrimSpace(status), "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if ok {
+			values[key] = value
+		}
+	}
+	state, deadline := values["SubState"], values["NextElapseUSecMonotonic"]
+	if state == "running" {
+		// A fired oneshot can temporarily have no next deadline until it exits.
+		return
+	}
+	if state != "waiting" || deadline == "" || deadline == "infinity" || deadline == "0" {
+		t.Fatalf("updater timer has no next polling deadline after install/repair: state=%q, deadline=%q", state, deadline)
+	}
 }
 
 type systemdTestCatalog struct {

--- a/scripts/install-agent.sh
+++ b/scripts/install-agent.sh
@@ -663,6 +663,9 @@ Description=Periodically check for an assigned p2pstream agent update
 
 [Timer]
 OnBootSec=30s
+# Re-arm polling when an existing timer is restarted after repair. Its boot
+# trigger may already be consumed and its service timestamps may be reset.
+OnActiveSec=30s
 OnUnitActiveSec=30s
 RandomizedDelaySec=30s
 AccuracySec=5s

--- a/scripts/systemd/p2pstream-updater.timer
+++ b/scripts/systemd/p2pstream-updater.timer
@@ -3,6 +3,9 @@ Description=Periodically check for an assigned p2pstream agent update
 
 [Timer]
 OnBootSec=30s
+# Re-arm polling when an existing timer is restarted after repair. Its boot
+# trigger may already be consumed and its service timestamps may be reset.
+OnActiveSec=30s
 OnUnitActiveSec=30s
 RandomizedDelaySec=30s
 AccuracySec=5s

--- a/scripts/test-agent-lifecycle.sh
+++ b/scripts/test-agent-lifecycle.sh
@@ -337,6 +337,7 @@ test_existing_install_managed_updater_bootstrap_preserves_env() {
   assert_contains "${SYSTEMD_DIR}/p2pstream-updater-activate.service" "IPAddressDeny=any"
   assert_contains "${SYSTEMD_DIR}/p2pstream-updater-activate.service" "ExecStart=${AGENT_INSTALL_ROOT}/updater/p2pstream updater activate"
   assert_contains "${SYSTEMD_DIR}/p2pstream-updater.timer" "RandomizedDelaySec=30s"
+  assert_contains "${SYSTEMD_DIR}/p2pstream-updater.timer" "OnActiveSec=30s"
   assert_contains "$COMMAND_LOG" "updater bootstrap-host"
   assert_contains "$COMMAND_LOG" "updater enroll"
   assert_contains "$COMMAND_LOG" "updater finalize-enrollment"

--- a/scripts/test-managed-updates-systemd.sh
+++ b/scripts/test-managed-updates-systemd.sh
@@ -50,8 +50,9 @@ multipass transfer "${build_dir}/fixture.tar.gz" "${vm_name}:/tmp/p2pstream-revi
 multipass exec "$vm_name" -- sudo bash -c 'set -e; mkdir -p /opt/p2pstream-systemd-fixture; tar -xzf /tmp/p2pstream-review-fixture.tar.gz -C /opt/p2pstream-systemd-fixture; printf "disposable-p2pstream-update-test\n" >/run/p2pstream-systemd-test-vm'
 printf 'Running installer, real services, legacy reports and repeated rollout in %s...\n' "$vm_name"
 result=0
-multipass exec "$vm_name" -- sudo env P2PSTREAM_SYSTEMD_INTEGRATION=1 P2PSTREAM_SYSTEMD_FIXTURE_DIR=/opt/p2pstream-systemd-fixture /opt/p2pstream-systemd-fixture/server.test -test.run '^TestManagedUpdatesSystemdLifecycle$' -test.v -test.timeout 10m >"${output_dir}/test.log" 2>&1 || result=$?
+multipass exec "$vm_name" -- sudo env P2PSTREAM_SYSTEMD_INTEGRATION=1 P2PSTREAM_SYSTEMD_FIXTURE_DIR=/opt/p2pstream-systemd-fixture /opt/p2pstream-systemd-fixture/server.test -test.run '^TestManagedUpdatesSystemdLifecycle$' -test.v -test.timeout 25m >"${output_dir}/test.log" 2>&1 || result=$?
 multipass exec "$vm_name" -- sudo cat /opt/p2pstream-systemd-fixture/systemd-journal.log >"${output_dir}/systemd-journal.log" 2>/dev/null || true
+multipass exec "$vm_name" -- sudo cat /opt/p2pstream-systemd-fixture/systemd-status.log >"${output_dir}/systemd-status.log" 2>/dev/null || true
 cat "${output_dir}/test.log"
 printf 'Logs: %s\n' "$output_dir"
 exit "$result"


### PR DESCRIPTION
Repair could leave an enabled updater timer in `active (elapsed)` with no next trigger. Enrollment's direct signed check made the new updater appear registered, but the hardened worker never polled again. Add `OnActiveSec=30s` to both timer definitions so every timer restart schedules a fresh check.

The systemd VM test now lets production timers drive campaigns, including after repair, and rejects an exhausted timer. It also records timer/service status for failures. Operations documentation includes the diagnosis and an existing-host correction.

Validation: the original timer failure was reproduced in isolated probes and the full lifecycle VM. The corrected installer passed the full VM lifecycle in 502.81 seconds, including legacy rollback, lost-response retry, repair and a subsequent rollout. Installer lifecycle tests, shell syntax, server vet and harness compilation passed. All four live hosts reproduced the fault; their corrected timers resumed polling, and the existing canary completed successfully on staging.88.

After merging, a normal UI campaign for the remaining three agents completed 3/3 healthy on staging.88 (the remote management server's trusted target). It used the default one-agent waves and 120-second health dwell, with no manual worker/service starts or retries. All running binary digests matched the published artifact. The two agents starting from v0.1.52 retained identical agent configuration hashes across their upgrades.
